### PR TITLE
Fix build on Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons_shortcuts:
 #       so construct it manually
 matrix:
   include:
-    # LLVM 3.9
+    # LLVM 3.9 on Linux
     - os: linux
       env: LLVM_VERSION=3.9
       julia: 0.5
@@ -42,7 +42,7 @@ matrix:
       - sudo apt-get update -q
       - sudo apt-get remove llvm -y
       - sudo apt-get install llvm-3.9 -y
-    # LLVM 3.9 with LLVM.jl in DEBUG mode
+    # LLVM 3.9 on Linux, DEBUG mode
     - os: linux
       env:
         - LLVM_VERSION=3.9
@@ -67,7 +67,7 @@ matrix:
       - sudo apt-get update -q
       - sudo apt-get remove llvm -y
       - sudo apt-get install llvm-3.9 -y
-    # LLVM 4.0
+    # LLVM 4.0 on Linux
     - os: linux
       env: LLVM_VERSION=4.0
       julia: 0.5
@@ -88,7 +88,7 @@ matrix:
       - sudo apt-get update -q
       - sudo apt-get remove llvm -y
       - sudo apt-get install llvm-4.0 -y
-    # LLVM 4.0 with LLVM.jl in DEBUG mode
+    # LLVM 4.0 on Linux, DEBUG mode
     - os: linux
       env:
         - LLVM_VERSION=4.0
@@ -113,6 +113,40 @@ matrix:
       - sudo apt-get update -q
       - sudo apt-get remove llvm -y
       - sudo apt-get install llvm-4.0 -y
+    # # LLVM 3.9 on macOS
+    # - os: osx
+    #   env: LLVM_VERSION=3.9
+    #   julia: 0.5
+    #   before_install:
+    #   - wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz
+    #   - tar -xvf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz
+    #   - export PATH=$PATH:$PWD/clang+llvm-3.9.0-x86_64-apple-darwin/bin/
+    # - os: osx
+    #   env: LLVM_VERSION=3.9
+    #   julia: nightly
+    #   before_install:
+    #   - wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz
+    #   - tar -xvf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz
+    #   - export PATH=$PATH:$PWD/clang+llvm-3.9.0-x86_64-apple-darwin/bin/
+    # # LLVM 3.9 on macOS, DEBUG mode
+    # - os: osx
+    #   env:
+    #     - LLVM_VERSION=3.9
+    #     - DEBUG=1
+    #   julia: 0.5
+    #   before_install:
+    #   - wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz
+    #   - tar -xvf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz
+    #   - export PATH=$PATH:$PWD/clang+llvm-3.9.0-x86_64-apple-darwin/bin/
+    # - os: osx
+    #   env:
+    #     - LLVM_VERSION=3.9
+    #     - DEBUG=1
+    #   julia: nightly
+    #   before_install:
+    #   - wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz
+    #   - tar -xvf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz
+    #   - export PATH=$PATH:$PWD/clang+llvm-3.9.0-x86_64-apple-darwin/bin/
 
 after_success:
  - julia -e 'cd(Pkg.dir("LLVM")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -167,6 +167,11 @@ end
 wrapped_libdir = joinpath(@__DIR__, "..", "lib", verstr(wrapper_version))
 @assert isdir(wrapped_libdir)
 
+# sanity check: open the library
+# NOTE: can't do this because LLVM 3.9 can link against libLTO (see Makefile workaround)
+# debug("Opening library")
+# Libdl.dlopen(llvm_library)
+
 
 #
 # Finishing up
@@ -191,6 +196,10 @@ cd(joinpath(@__DIR__, "llvm-extra")) do
         run(`make -j$(Sys.CPU_CORES+1)`)
     end
 end
+
+# sanity check: open the library
+debug("Opening wrapper library")
+Libdl.dlopen(libllvm_extra)
 
 llvm_library_mtime = stat(llvm_library).mtime
 
@@ -218,6 +227,3 @@ open(joinpath(@__DIR__, "ext.jl"), "w") do fh
         include("$libllvm_wrapper")
         include("$libllvm_extra_wrapper")""")
 end
-
-# final sanity check: open the library
-Libdl.dlopen(llvm_library)

--- a/deps/llvm-extra/Makefile
+++ b/deps/llvm-extra/Makefile
@@ -1,8 +1,16 @@
 # NOTE: this Makefile is only to be invoked from build.jl
 #       if running manually, make sure you provide all required environment variables
 
-TARGET  = libLLVM_extra.so
-SOURCES = $(shell find -name '*.cpp')
+UNAME = $(shell uname)
+
+ifeq ($(UNAME), Darwin)
+	SLIB = dylib
+else
+	SLIB = so
+endif
+
+TARGET  = libLLVM_extra.$(SLIB)
+SOURCES = $(shell find . -name '*.cpp')
 OBJECTS = $(SOURCES:.cpp=.o)
 
 
@@ -40,7 +48,8 @@ CPPFLAGS += $(addprefix -DTARGET_, $(LLVM_TARGETS))
 # NOTE: this is best-effort, as the target compiler might just not support the new ABI
 OBJDUMP := $(shell command -v objdump 2> /dev/null)
 ifdef OBJDUMP
-CXX11_SYMBOLS=$(shell objdump -tT "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
+# CXX11_SYMBOLS=$(shell objdump -tT "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
+CXX11_SYMBOLS=$(shell otool -tV "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
 ifeq ($(CXX11_SYMBOLS),)
 CPPFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
 else
@@ -64,11 +73,18 @@ LDLIBS += $(shell $(JULIA) $(JULIA_CONFIG) --ldlibs)
 # Build
 #
 
-LDFLAGS += -Wl,-z,defs
+ifeq ($(UNAME), Darwin)
+	#LDFLAGS += -Wl
+else
+	LDFLAGS += -Wl,-z,defs
+endif
 
 # shared-library building
 CXXFLAGS += -fPIC
 %.so:
+	$(LINK.cc) -shared $^ $(LDFLAGS) $(LDLIBS) -o $@
+
+%.dylib:
 	$(LINK.cc) -shared $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 .PHONY: all

--- a/deps/llvm-extra/Makefile
+++ b/deps/llvm-extra/Makefile
@@ -27,6 +27,20 @@ LDFLAGS += "-Wl,-rpath,$(dir $(LLVM_LIBRARY))"
 ifeq ($(UNAME), Darwin)
   # macOS dylibs are versioned already
   LDLIBS += -lLLVM
+
+  # some LLVM libraries erroneously link against libLTO (D25865), provided by Julia too.
+  # however, for some reason loading libLLVM only picks up / prioritizes the Julia RPATH,
+  # loading the wrong version of libLTO. workaround: load the correct libLTO ourselves now.
+  # NOTE: I haven't seen this arise on Linux, but might very well happen there too.
+  OTOOL := $(shell command -v otool 2> /dev/null)
+  ifdef OTOOL
+    LIBLTO=$(shell $(OTOOL) -L "$(LLVM_LIBRARY)" | grep "libLTO")
+    ifneq ($(LIBLTO),)
+      LDLIBS += -lLTO
+    endif
+  else
+    $(error otool not available)
+  endif
 else
   # specify the versioned library name to make sure we pick up the correct one
   LDLIBS += -l:$(notdir $(LLVM_LIBRARY))
@@ -53,10 +67,10 @@ CPPFLAGS += $(addprefix -DTARGET_, $(LLVM_TARGETS))
 NM := $(shell command -v nm 2> /dev/null)
 ifdef NM
   ifeq ($(UNAME),Linux)
-    CXX11_SYMBOLS=$(shell nm -D "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
+    CXX11_SYMBOLS=$(shell $(NM) -D "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
   endif
   ifeq ($(UNAME),Darwin)
-    CXX11_SYMBOLS=$(shell nm -g "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
+    CXX11_SYMBOLS=$(shell $(NM) -g "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
   endif
   ifeq ($(CXX11_SYMBOLS),)
     CPPFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
@@ -64,7 +78,7 @@ ifdef NM
     CPPFLAGS += -D_GLIBCXX_USE_CXX11_ABI=1
   endif
 else
-  $(warning "nm not available, cannot detect C++11 ABI")
+  $(warning nm not available, cannot detect C++11 ABI)
 endif
 
 

--- a/deps/llvm-extra/Makefile
+++ b/deps/llvm-extra/Makefile
@@ -1,12 +1,12 @@
 # NOTE: this Makefile is only to be invoked from build.jl
 #       if running manually, make sure you provide all required environment variables
 
-UNAME = $(shell uname)
+UNAME = $(shell uname -s)
 
 ifeq ($(UNAME), Darwin)
-	SLIB = dylib
+  SLIB := dylib
 else
-	SLIB = so
+  SLIB := so
 endif
 
 TARGET  = libLLVM_extra.$(SLIB)
@@ -23,10 +23,14 @@ CXXFLAGS = $(shell $(LLVM_CONFIG) --cxxflags)
 LDFLAGS = $(shell $(LLVM_CONFIG) --ldflags)
 LDLIBS = $(shell $(LLVM_CONFIG) --system-libs)
 
-# specify a specific rpath and library name to mare sure we pick up the correct library
-# NOTE: this doesn't use llvm-config, but uses the LLVM_LIBRARY variable passed by build.jl
-LDLIBS += -l:$(notdir $(LLVM_LIBRARY))
 LDFLAGS += "-Wl,-rpath,$(dir $(LLVM_LIBRARY))"
+ifeq ($(UNAME), Darwin)
+  # macOS dylibs are versioned already
+  LDLIBS += -lLLVM
+else
+  # specify the versioned library name to make sure we pick up the correct one
+  LDLIBS += -l:$(notdir $(LLVM_LIBRARY))
+endif
 
 # sanitize the cflags llvm-config provides us with
 # (removing C++ specific ones, or flags supported by only Clang or GCC)
@@ -46,17 +50,21 @@ CPPFLAGS += $(addprefix -DTARGET_, $(LLVM_TARGETS))
 
 # try to detect LLVM's C++ ABI, and configure GLIBC accordingly
 # NOTE: this is best-effort, as the target compiler might just not support the new ABI
-OBJDUMP := $(shell command -v objdump 2> /dev/null)
-ifdef OBJDUMP
-# CXX11_SYMBOLS=$(shell objdump -tT "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
-CXX11_SYMBOLS=$(shell otool -tV "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
-ifeq ($(CXX11_SYMBOLS),)
-CPPFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
+NM := $(shell command -v nm 2> /dev/null)
+ifdef NM
+  ifeq ($(UNAME),Linux)
+    CXX11_SYMBOLS=$(shell nm -D "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
+  endif
+  ifeq ($(UNAME),Darwin)
+    CXX11_SYMBOLS=$(shell nm -g "$(LLVM_LIBRARY)" | grep -E "(_cxx11|B5cxx11)")
+  endif
+  ifeq ($(CXX11_SYMBOLS),)
+    CPPFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
+  else
+    CPPFLAGS += -D_GLIBCXX_USE_CXX11_ABI=1
+  endif
 else
-CPPFLAGS += -D_GLIBCXX_USE_CXX11_ABI=1
-endif
-else
-$(warning "objdump not available, cannot detect C++11 ABI")
+  $(warning "nm not available, cannot detect C++11 ABI")
 endif
 
 
@@ -73,18 +81,13 @@ LDLIBS += $(shell $(JULIA) $(JULIA_CONFIG) --ldlibs)
 # Build
 #
 
-ifeq ($(UNAME), Darwin)
-	#LDFLAGS += -Wl
-else
-	LDFLAGS += -Wl,-z,defs
+ifneq ($(UNAME), Darwin)
+  LDFLAGS += -Wl,-z,defs
 endif
 
 # shared-library building
 CXXFLAGS += -fPIC
-%.so:
-	$(LINK.cc) -shared $^ $(LDFLAGS) $(LDLIBS) -o $@
-
-%.dylib:
+%.$(SLIB):
 	$(LINK.cc) -shared $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 .PHONY: all


### PR DESCRIPTION
This fixes some issues but I'm still not there. With this I get
```
c++ -I/Users/andreasnoack/juliagpu/usr/include -fPIC -fvisibility-inlines-hidden -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wnon-virtual-dtor -Werror=date-time -std=c++11 -O3 -DNDEBUG -fno-exceptions -fno-rtti -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fno-rtti -DJULIA_ENABLE_THREADING=1 -fPIC -DJULIA_INIT_DIR=\"/Users/andreasnoack/juliagpu/usr/lib\" -I/Users/andreasnoack/juliagpu/usr/include/julia -fPIC -I/Users/andreasnoack/juliagpu/usr/include   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_NVPTX -DTARGET_X86 -D_GLIBCXX_USE_CXX11_ABI=0 -L/Users/andreasnoack/juliagpu/usr/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names "-Wl,-rpath,/Users/andreasnoack/juliagpu/usr/lib/" -L/Users/andreasnoack/juliagpu/usr/lib  -shared IR/Metadata.o IR/Pass.o Target/NVPTX.o Target.o Transforms/IPO.o -L/Users/andreasnoack/juliagpu/usr/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names "-Wl,-rpath,/Users/andreasnoack/juliagpu/usr/lib/" -L/Users/andreasnoack/juliagpu/usr/lib -lcurses -lz -lm -l:libLLVM.dylib -Wl,-rpath,/Users/andreasnoack/juliagpu/usr/lib -ljulia -o libLLVM_extra.dylib
ld: library not found for -l:libLLVM.dylib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [libLLVM_extra.dylib] Error 1
```