### PR TITLE
fix arg type and API call for LLVMAddIncoming

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
+julia 0.6
 Compat 0.17.0

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -203,7 +203,9 @@ Base.getindex(iter::PhiIncomingSet, i) =
 function Base.append!(iter::PhiIncomingSet, args::Vector{Tuple{V, BasicBlock}} where V <: Value)
     vals, blocks = zip(args...)
     API.LLVMAddIncoming(ref(iter.phi), collect(ref.(vals)),
-                        collect(ref.(blocks)), UInt32(length(args)))
+                        collect(ref.(blocks)), Cuint(length(args)))
 end
+
+Base.push!(iter::PhiIncomingSet, args::Tuple{<:Value, BasicBlock}) = append!(iter, [args])
 
 Base.length(iter::PhiIncomingSet) = API.LLVMCountIncoming(ref(iter.phi))

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -135,7 +135,7 @@ callconv!(inst::Instruction, cc) =
 istailcall(inst::Instruction) = convert(Core.Bool, API.LLVMIsTailCall(ref(inst)))
 tailcall!(inst::Instruction, bool) = API.LLVMSetTailCall(ref(inst), convert(Bool, bool))
 
-called_value(inst::Instruction) = Value(API.LLVMGetCalledValue(ref( inst)))
+called_value(inst::Instruction) = Value(API.LLVMGetCalledValue(ref(inst)))
 
 
 ## terminators
@@ -200,10 +200,10 @@ Base.getindex(iter::PhiIncomingSet, i) =
     tuple(Value(API.LLVMGetIncomingValue(ref(iter.phi), Cuint(i-1))),
                 BasicBlock(API.LLVMGetIncomingBlock(ref(iter.phi), Cuint(i-1))))
 
-function Base.append!(iter::PhiIncomingSet, args::Vector{Tuple{Value, BasicBlock}})
+function Base.append!(iter::PhiIncomingSet, args::Vector{Tuple{V, BasicBlock}} where V <: Value)
     vals, blocks = zip(args...)
-    API.LLVMAddIncoming(ref(iter.phi), ref.(vals),
-                        ref.(blocks), length(args))
+    API.LLVMAddIncoming(ref(iter.phi), collect(ref.(vals)),
+                        collect(ref.(blocks)), UInt32(length(args)))
 end
 
 Base.length(iter::PhiIncomingSet) = API.LLVMCountIncoming(ref(iter.phi))


### PR DESCRIPTION
For `args` we don't want `Value` in an `invariant` (?) position because if we end up with a Vector that has more specific types than `Value` e.g. `Instruction`, this function couldn't be called.
Also, the results of `zip(args...)` is two tuples but we need arrays to get the `Ptr`, therefore collect the result. In addition, the length should be given as a `UInt32`.

Added a test as well which should cover these lines (it seems they were not previously tested). Found this when working on Kaleidoscope.jl when the if statements are introduced.