### PR TITLE
Clarify source build of Julia 0.6 needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ LLVM.jl is a registered package, and can be installed using the Julia package ma
 Pkg.add("LLVM")
 ```
 
-However, in most cases **you need a source-build of Julia**. Refer to [the
+However, in most cases **you need a source-build of Julia 0.6**. Refer to [the
 documentation][docs-stable-url] for more information on how to install or use this package.


### PR DESCRIPTION
Tl;dr: Specifies that a source build of Julia 0.6 is usually needed.

My real life story: When I ran into a build issue with LLVM.jl using a Julia 0.6 downloaded binary, I saw here I needed a source build of Julia. So I built the latest Julia (0.7...) from source, things still was broke. I realised only later I needed a source build of Julia 0.6, then things worked great.

General comment: Love your works here LLVM GPU magic people!