### PR TITLE
Fix namespace warnings

### DIFF
--- a/src/core/basicblock.jl
+++ b/src/core/basicblock.jl
@@ -1,6 +1,8 @@
 export BasicBlock, unsafe_delete!,
-       parent, terminator, name,
+       terminator, name,
        move_before, move_after
+
+import Base:gc, run, select!, parent
 
 @checked struct BasicBlock <: Value
     ref::reftype(Value)

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -1,7 +1,9 @@
 export Instruction, unsafe_delete!,
        hasmetadata, metadata, metadata!,
-       parent, opcode,
+       opcode,
        predicate_int, predicate_real
+
+import Base.parent
 
 # forward definition of Instruction in src/core/value/constant.jl
 identify(::Type{Value}, ::Val{API.LLVMInstructionValueKind}) = Instruction

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -1,5 +1,7 @@
 export null, all_ones, UndefValue, PointerNull
 
+import Base.parent
+
 null(typ::LLVMType) = Value(API.LLVMConstNull(ref(typ)))
 
 all_ones(typ::LLVMType) = Value(API.LLVMConstAllOnes(ref(typ)))
@@ -112,7 +114,7 @@ InlineAsm(typ::FunctionType, asm::String, constraints::String,
 abstract type GlobalValue <: Constant end
 
 export GlobalValue,
-       parent, isdeclaration,
+       isdeclaration,
        linkage, linkage!,
        section, section!,
        visibility, visibility!,

--- a/test/namespace.jl
+++ b/test/namespace.jl
@@ -1,0 +1,6 @@
+@testset "target" begin
+    methods(gc)
+    methods(parent)
+    methods(run)
+    methods(select!)
+end


### PR DESCRIPTION
This PR will fix the following warnings in the REPL.

```
WARNING: both LLVM and Base export "gc"; uses of it in module Main must be qualified
WARNING: both LLVM and Base export "parent"; uses of it in module Main must be qualified
WARNING: both LLVM and Base export "run"; uses of it in module Main must be qualified
WARNING: both LLVM and Base export "select!"; uses of it in module Main must be qualified
```