### PR TITLE
update transform.jl : add 'using Unicode'

### DIFF
--- a/src/transform.jl
+++ b/src/transform.jl
@@ -5,6 +5,7 @@ export PassManagerBuilder, dispose,
        unit_at_a_time!, unroll_loops!, simplify_libcalls!, inliner!,
        populate!
 
+using Unicode
 @checked struct PassManagerBuilder
     ref::API.LLVMPassManagerBuilderRef
 end


### PR DESCRIPTION
precompile would raise LoadError (Julia 0.7.0-DEV.2925 Commit e615c80c16* 2017-12-13 21:49 UTC) without using Unicode. since Base.isupper has been moved to the standard library  package Unicode.