### PR TITLE
asmcall: specify return type as an expression.

### DIFF
--- a/src/interop/asmcall.jl
+++ b/src/interop/asmcall.jl
@@ -38,7 +38,7 @@ arguments as a tuple-type in `argtyp`.
 :(@asmcall)
 
 macro asmcall(asm::String, constraints::String, side_effects::Bool,
-              rettyp::Symbol=:(Nothing), argtyp::Expr=:(Tuple{}), args...)
+              rettyp::Union{Expr,Symbol}=:(Nothing), argtyp::Expr=:(Tuple{}), args...)
     asm_val = Val{Symbol(asm)}()
     constraints_val = Val{Symbol(constraints)}()
     return esc(:(LLVM.Interop._asmcall($asm_val, $constraints_val,
@@ -48,12 +48,12 @@ end
 
 # shorthand: no side_effects
 macro asmcall(asm::String, constraints::String,
-              rettyp::Symbol=:(Nothing), argtyp::Expr=:(Tuple{}), args...)
+              rettyp::Union{Expr,Symbol}=:(Nothing), argtyp::Expr=:(Tuple{}), args...)
     esc(:(LLVM.Interop.@asmcall $asm $constraints false $rettyp $argtyp $(args...)))
 end
 
 # shorthand: no side_effects or constraints
 macro asmcall(asm::String,
-              rettyp::Symbol=:(Nothing), argtyp::Expr=:(Tuple{}), args...)
+              rettyp::Union{Expr,Symbol}=:(Nothing), argtyp::Expr=:(Tuple{}), args...)
     esc(:(LLVM.Interop.@asmcall $asm "" $rettyp $argtyp $(args...)))
 end

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -83,6 +83,11 @@ c3() = @asmcall("nop", "", false, Nothing, Tuple{})
 d1(a) = @asmcall("bswap \$0", "=r,r", Int32, Tuple{Int32}, a)
 @test d1(Int32(1)) == Int32(16777216)
 
+# multiple output registers
+
+e1() = @asmcall("mov \$\$1, \$0; mov \$\$2, \$1;", "=r,=r", Tuple{Int32,Int64})
+@test e1() == (Int32(1), Int64(2))
+
 end
 
 


### PR DESCRIPTION
Allows to return a tuple.
cc @jiahao