### PR TITLE
Wrap intrinsics API.

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -11,3 +11,5 @@ import Base: haskey, getindex, get
 @deprecate haskey(::TargetIterator, name::String) Target(;name=name) !== nothing
 @deprecate getindex(iter::TargetIterator, name::String) Target(;name=name)
 @deprecate get(::TargetIterator, name::String, default) try Target(;name=name) catch; default end
+
+@deprecate intrinsic_id(f::Function) isintrinsic(f) ? Intrinsic(f) : 0

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,7 +1,7 @@
 # utilities
 
-function unsafe_message(ptr)
-    str = unsafe_string(ptr)
+function unsafe_message(ptr, args...)
+    str = unsafe_string(ptr, args...)
     API.LLVMDisposeMessage(ptr)
     str
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -705,23 +705,27 @@ LLVM.Module("SomeModule", ctx) do mod
     @test isintrinsic(intr_fn)
 
     intr = Intrinsic(intr_fn)
-    @test isoverloaded(intr)
+    show(devnull, intr)
+
+    if LLVM.version() >= v"8"
+        @test isoverloaded(intr)
+
+        @test name(intr) == "llvm.sin"
+        @test name(intr, [LLVM.DoubleType(ctx)]) == "llvm.sin.f64"
+
+        ft = FunctionType(intr, [LLVM.DoubleType(ctx)])
+        @test ft isa FunctionType
+        @test return_type(ft) == LLVM.DoubleType(ctx)
+
+        fn = LLVM.Function(mod, intr, [LLVM.DoubleType(ctx)])
+        @test fn isa LLVM.Function
+        @test eltype(llvmtype(fn)) == ft
+        @test isintrinsic(fn)
+    end
 
     if LLVM.version() >= v"9"
         @test intr == Intrinsic("llvm.sin")
     end
-
-    @test name(intr) == "llvm.sin"
-    @test name(intr, [LLVM.DoubleType(ctx)]) == "llvm.sin.f64"
-
-    ft = FunctionType(intr, [LLVM.DoubleType(ctx)])
-    @test ft isa FunctionType
-    @test return_type(ft) == LLVM.DoubleType(ctx)
-
-    fn = LLVM.Function(mod, intr, [LLVM.DoubleType(ctx)])
-    @test fn isa LLVM.Function
-    @test eltype(llvmtype(fn)) == ft
-    @test isintrinsic(fn)
 end
 end
 


### PR DESCRIPTION
Fixed https://github.com/maleadt/LLVM.jl/issues/112

```julia
julia> using LLVM

julia> intr = Intrinsic("llvm.sin")
Intrinsic(211): "llvm.sin" (overloaded)

julia> name(intr)
"llvm.sin"

julia> isoverloaded(intr)
true

julia> name(intr, [LLVM.DoubleType()])
"llvm.sin.f64"

julia> FunctionType(intr, [LLVM.DoubleType()])
double (double)

julia> typeof(ans)
FunctionType

julia> mod = LLVM.Module("")


julia> LLVM.Function(mod, intr, [LLVM.DoubleType()])

; Function Attrs: nounwind readnone speculatable
declare double @llvm.sin.f64(double) #0


julia> typeof(ans)
LLVM.Function

julia> f = first(functions(mod))

; Function Attrs: nounwind readnone speculatable
declare double @llvm.sin.f64(double) #0


julia> isintrinsic(f)
true

julia> Intrinsic(f)
Intrinsic(211): "llvm.sin" (overloaded)
```

TODO: better version-guard functionality that's only there on LLVM 8 or 9