### PR TITLE
Implement Base.string instead of convert(::String).

### DIFF
--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -15,7 +15,7 @@ MDString(val::String) = MDString(API.LLVMMDString(val, length(val)))
 MDString(val::String, ctx::Context) =
     MDString(API.LLVMMDStringInContext(ctx, val, length(val)))
 
-function Base.convert(::Type{String}, md::MDString)
+function Base.string(md::MDString)
     len = Ref{Cuint}()
     ptr = API.LLVMGetMDString(md, len)
     ptr == C_NULL && throw(ArgumentError("invalid metadata, not a MDString?"))

--- a/src/core/module.jl
+++ b/src/core/module.jl
@@ -39,7 +39,7 @@ function Module(f::Core.Function, args...)
 end
 
 function Base.show(io::IO, mod::Module)
-    output = convert(String, mod)
+    output = string(mod)
     print(io, output)
 end
 

--- a/src/datalayout.jl
+++ b/src/datalayout.jl
@@ -25,11 +25,11 @@ end
 
 dispose(data::DataLayout) = API.LLVMDisposeTargetData(data)
 
-Base.convert(::Type{String}, data::DataLayout) =
+Base.string(data::DataLayout) =
     unsafe_message(API.LLVMCopyStringRepOfTargetData(data))
 
 function Base.show(io::IO, data::DataLayout)
-    @printf(io, "DataLayout(%s)", convert(String, data))
+    @printf(io, "DataLayout(%s)", string(data))
 end
 
 byteorder(data::DataLayout) = API.LLVMByteOrder(data)

--- a/src/interop/base.jl
+++ b/src/interop/base.jl
@@ -64,7 +64,7 @@ function call_function(llvmf::LLVM.Function, rettyp::Type=Nothing, argtyp::Type=
                        args::Expr=:())
     if VERSION >= v"1.6.0-DEV.674"
         mod = LLVM.parent(llvmf)
-        ir = convert(String, mod)
+        ir = string(mod)
         fn = LLVM.name(llvmf)
         @assert !isempty(fn)
         quote

--- a/src/ir.jl
+++ b/src/ir.jl
@@ -19,4 +19,4 @@ end
 
 ## writer
 
-Base.convert(::Type{String}, mod::Module) = unsafe_message(API.LLVMPrintModuleToString(mod))
+Base.string(mod::Module) = unsafe_message(API.LLVMPrintModuleToString(mod))

--- a/test/core.jl
+++ b/test/core.jl
@@ -488,7 +488,7 @@ end
 
 Context() do ctx
     str = MDString("foo", ctx)
-    @test convert(String, str) == "foo"
+    @test string(str) == "foo"
 end
 
 @test MDNode([MDString("foo")]) == MDNode([MDString("foo", global_ctx)], global_ctx)
@@ -540,7 +540,7 @@ LLVM.Module("SomeModule", ctx) do mod
 
     dummyLayout = "e-p:64:64:64"
     datalayout!(mod, dummyLayout)
-    @test convert(String, datalayout(mod)) == dummyLayout
+    @test string(datalayout(mod)) == dummyLayout
 
     if LLVM.version() >= v"8.0"
         md = Metadata(ConstantInt(42, ctx))

--- a/test/datalayout.jl
+++ b/test/datalayout.jl
@@ -2,7 +2,7 @@
 
 Context() do ctx
 DataLayout("E-p:32:32-f128:128:128") do data
-    @test convert(String, data) == "E-p:32:32-f128:128:128"
+    @test string(data) == "E-p:32:32-f128:128:128"
 
     @test occursin("E-p:32:32-f128:128:128", sprint(io->show(io,data)))
 
@@ -21,7 +21,7 @@ DataLayout("E-p:32:32-f128:128:128") do data
         @test preferred_alignment(data, gv) == 4
 
         datalayout!(mod, data)
-        @test convert(String, datalayout(mod)) == convert(String, data)
+        @test string(datalayout(mod)) == string(data)
     end
 
     elem = [LLVM.Int32Type(ctx), LLVM.FloatType(ctx)]

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -17,9 +17,9 @@ LLVM.Module("SomeModule", ctx) do source_mod
     ret!(builder)
 
     verify(source_mod)
-    
 
-    ir = convert(String, source_mod)
+
+    ir = string(source_mod)
 
     let
         mod = parse(LLVM.Module, ir)


### PR DESCRIPTION
This seems like a better (more common) way to do this. Also brings down invalidations from ~400 to 0 :-)