### PR TITLE
[ORC] Implement a reasonable default resolver and throw errors on undefinded symbols

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -1154,7 +1154,7 @@ ORC JIT
 Support
 -------
 
-- [ ] LLVMLoadLibraryPermanently
-- [ ] LLVMParseCommandLineOptions
-- [ ] LLVMSearchForAddressOfSymbol
-- [ ] LLVMAddSymbol
+- [x] LLVMLoadLibraryPermanently
+- [x] LLVMParseCommandLineOptions
+- [x] LLVMSearchForAddressOfSymbol
+- [x] LLVMAddSymbol

--- a/src/orc.jl
+++ b/src/orc.jl
@@ -150,7 +150,7 @@ end
 
 function callback!(orc::OrcJIT, callback, ctx)
     r_address = Ref{API.LLVMOrcTargetAddress}()
-    LLVM.API.LLVMOrcLazyCompileCallback(orc, r_address, callback, ctx)
+    API.LLVMOrcCreateLazyCompileCallback(orc, r_address, callback, ctx)
     return OrcTargetAddress(r_address[])
 end
 

--- a/src/orc.jl
+++ b/src/orc.jl
@@ -42,12 +42,52 @@ struct OrcModule
 end
 Base.convert(::Type{API.LLVMOrcModuleHandle}, mod::OrcModule) = mod.handle
 
-function compile!(orc::OrcJIT, mod::Module, resolver = C_NULL, ctx = C_NULL; lazy=false)
+"""
+   resolver(name, ctx)
+
+Lookup the symbol `name`. Iff `ctx` is passed to this function it should be a
+pointer to the OrcJIT we are compiling for.
+"""
+function resolver(name, ctx)
+    name = unsafe_string(name)
+    ## Step 0: Should have already resolved it iff it was in the
+    ##         same module
+    ## Step 1: See if it's something known to the execution engine
+    ptr = C_NULL
+    if ctx != C_NULL
+        orc = OrcJIT(ctx)
+        ptr = pointer(address(orc, name))
+    end
+
+    ## Step 2: Search the program symbols
+    if ptr == C_NULL
+        #
+        # SearchForAddressOfSymbol expects an unmangled 'C' symbol name.
+        # Iff we are on Darwin, strip the leading '_' off.
+        @static if Sys.isapple()
+            if name[1] == '_'
+                name = name[2:end]
+            end
+        end
+        ptr = LLVM.find_symbol(name)
+    end
+
+    ## Step 4: Lookup in libatomic
+    # TODO: Do we need to do this?
+
+    if ptr == C_NULL
+        error("OrcJIT: Symbol `$name` lookup failed. Aborting!")
+    end
+
+    return UInt64(reinterpret(UInt, ptr))
+end
+
+function compile!(orc::OrcJIT, mod::Module, resolver = @cfunction(resolver, UInt64, (Cstring, Ptr{Cvoid})), resolver_ctx = orc; lazy=false)
     r_mod = Ref{API.LLVMOrcModuleHandle}()
     if lazy
-        API.LLVMOrcAddLazilyCompiledIR(orc, r_mod, mod, resolver, ctx)
+        API.LLVMOrcAddLazilyCompiledIR(orc, r_mod, mod, resolver, resolver_ctx)
     else
-        API.LLVMOrcAddEagerlyCompiledIR(orc, r_mod, mod, resolver, ctx)
+        API.LLVMOrcAddEagerlyCompiledIR(orc, r_mod, mod, resolver, resolver_ctx)
     end
     OrcModule(r_mod[])
 end
@@ -56,9 +96,9 @@ function Base.delete!(orc::OrcJIT, mod::OrcModule)
     LLVM.API.LLVMOrcRemoveModule(orc, mod)
 end
 
-function add!(orc::OrcJIT, obj::MemoryBuffer, resolver = C_NULL, ctx = C_NULL)
+function add!(orc::OrcJIT, obj::MemoryBuffer, resolver = @cfunction(resolver, UInt64, (Cstring, Ptr{Cvoid})), resolver_ctx = orc)
     r_mod = Ref{API.LLVMOrcModuleHandle}()
-    API.LLVMOrcAddObjectFile(orc, r_mod, obj, resolver, ctx)
+    API.LLVMOrcAddObjectFile(orc, r_mod, obj, resolver, resolver_ctx)
     return OrcModule(r_mod[])
 end
 

--- a/src/orc.jl
+++ b/src/orc.jl
@@ -11,6 +11,9 @@ export JITTargetMachine
 end
 
 Base.unsafe_convert(::Type{API.LLVMOrcJITStackRef}, orc::OrcJIT) = orc.ref
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, orc::OrcJIT) = Base.unsafe_convert(Ptr{Cvoid}, orc.ref)
+
+OrcJIT(ref::Ptr{Cvoid}) = OrcJIT(Base.unsafe_convert(API.LLVMOrcJITStackRef, ref))
 
 """
     OrcJIT(::TargetMachine)

--- a/src/orc.jl
+++ b/src/orc.jl
@@ -31,6 +31,15 @@ function dispose(orc::OrcJIT)
     API.LLVMOrcDisposeInstance(orc)
 end
 
+function OrcJIT(f::Core.Function, tm::TargetMachine)
+    orc = OrcJIT(tm)
+    try
+        f(orc)
+    finally
+        dispose(orc)
+    end
+end
+
 function errormsg(orc::OrcJIT)
     # The error message is owned by `orc`, and will
     # be disposed along-side the OrcJIT. 

--- a/src/support.jl
+++ b/src/support.jl
@@ -4,3 +4,26 @@ function clopts(opts...)
     args = ["", opts...]
     API.LLVMParseCommandLineOptions(length(args), args, C_NULL)
 end
+
+"""
+    add_symbol(name, ptr)
+
+Permanently add the symbol `name` with the value `ptr`. These symbols are searched
+before any libraries.
+"""
+add_symbol(name, ptr) = LLVM.API.LLVMAddSymbol(name, ptr)
+
+"""
+    load_library_permantly(path)
+
+This function permanently loads the dynamic library at the given path.
+It is safe to call this function multiple times for the same library.
+"""
+load_library_permantly(path) = LLVM.API.LLVMLoadLibraryPermanently(path)
+
+"""
+    find_symbol(name)
+
+Search the global symbols for `name` and return the pointer to it.
+"""
+find_symbol(name) = LLVM.API.LLVMSearchForAddressOfSymbol(name)

--- a/test/orc.jl
+++ b/test/orc.jl
@@ -1,274 +1,275 @@
 @testset "orc" begin
 
 @testset "Undefined Symbol" begin
-    ctx = Context()
     tm  = JITTargetMachine()
-    orc = OrcJIT(tm)
+    OrcJIT(tm) do orc
+       Context() do ctx
+            mod = LLVM.Module("jit", ctx)
+            T_Int32 = LLVM.Int32Type(ctx)
+            ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
+            fn = LLVM.Function(mod, "mysum", ft)
+            linkage!(fn, LLVM.API.LLVMExternalLinkage)
 
-    mod = LLVM.Module("jit", ctx)
-    T_Int32 = LLVM.Int32Type(ctx)
-    ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-    fn = LLVM.Function(mod, "mysum", ft)
-    linkage!(fn, LLVM.API.LLVMExternalLinkage)
+            fname = mangle(orc, "wrapper")
+            wrapper = LLVM.Function(mod, fname, ft)
+            # generate IR
+            Builder(ctx) do builder
+                entry = BasicBlock(wrapper, "entry", ctx)
+                position!(builder, entry)
 
-    fname = mangle(orc, "wrapper")
-    wrapper = LLVM.Function(mod, fname, ft)
-    # generate IR
-    Builder(ctx) do builder
-        entry = BasicBlock(wrapper, "entry", ctx)
-        position!(builder, entry)
+                tmp = call!(builder, fn, [parameters(wrapper)...])
+                ret!(builder, tmp)
+            end
 
-        tmp = call!(builder, fn, [parameters(wrapper)...])
-        ret!(builder, tmp)
+            triple!(mod, triple(tm))
+            ModulePassManager() do pm
+                add_library_info!(pm, triple(mod))
+                add_transform_info!(pm, tm)
+                run!(pm, mod)
+            end
+            verify(mod)
+
+            orc_mod = compile!(orc, mod)
+            @test_throws ErrorException address(orc, fname) == C_NULL
+
+            delete!(orc, orc_mod)
+        end
     end
-
-    triple!(mod, triple(tm))
-    ModulePassManager() do pm
-        add_library_info!(pm, triple(mod))
-        add_transform_info!(pm, tm)
-        run!(pm, mod)
-    end
-    verify(mod)
-
-    orc_mod = compile!(orc, mod)
-    @test_throws ErrorException address(orc, fname)
-
-    delete!(orc, orc_mod)
-    dispose(orc)
 end
 
 @testset "Custom Resolver" begin
-    ctx = Context()
     tm  = JITTargetMachine()
-    orc = OrcJIT(tm)
+    OrcJIT(tm) do orc
+       Context() do ctx
+            known_functions = Dict{String, OrcTargetAddress}()
+            fnames = Dict{String, Int}()
+            function lookup(name, ctx)
+                name = unsafe_string(name)
+                try
+                    if !haskey(fnames, name)
+                        fnames[name] = 0
+                    end
+                    fnames[name] += 1
 
-    known_functions = Dict{String, OrcTargetAddress}()
-    fnames = Dict{String, Int}()
-    function lookup(name, ctx)
-        name = unsafe_string(name)
-        try 
-            if !haskey(fnames, name)
-                fnames[name] = 0
+                    return known_functions[name].ptr
+                catch ex
+                    @error "Exception during lookup" name exception=(ex, catch_backtrace())
+                    error("OrcJIT: Could not find symbol")
+                end
             end
-            fnames[name] += 1
 
-            return known_functions[name].ptr
-        catch ex
-            @error "Exception during lookup" name exception=(ex, catch_backtrace())
-            error("OrcJIT: Could not find symbol")
+            mod = LLVM.Module("jit", ctx)
+            T_Int32 = LLVM.Int32Type(ctx)
+            ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
+            fn = LLVM.Function(mod, "mysum", ft)
+            linkage!(fn, LLVM.API.LLVMExternalLinkage)
+
+            fname = mangle(orc, "wrapper")
+            wrapper = LLVM.Function(mod, fname, ft)
+            # generate IR
+            Builder(ctx) do builder
+                entry = BasicBlock(wrapper, "entry", ctx)
+                position!(builder, entry)
+
+                tmp = call!(builder, fn, [parameters(wrapper)...])
+                ret!(builder, tmp)
+            end
+
+            triple!(mod, triple(tm))
+            ModulePassManager() do pm
+                add_library_info!(pm, triple(mod))
+                add_transform_info!(pm, tm)
+                run!(pm, mod)
+            end
+            verify(mod)
+
+            mysum_name = mangle(orc, "mysum")
+            known_functions[mysum_name] = OrcTargetAddress(@cfunction(+, Int32, (Int32, Int32)))
+
+            f_lookup = @cfunction($lookup, UInt64, (Cstring, Ptr{Cvoid}))
+            GC.@preserve f_lookup begin
+                orc_mod = compile!(orc, mod, f_lookup, C_NULL, lazy=true) # will capture f_lookup
+
+                addr = address(orc, fname)
+                @test errormsg(orc) == ""
+                addr2 = addressin(orc, orc_mod, fname)
+
+                @test addr == addr2
+                @test addr.ptr != 0
+                @test !haskey(fnames, mysum_name)
+
+                r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2) # uses f_lookup
+                @test r == 3
+            end
+
+            @test haskey(fnames, mysum_name)
+            @test fnames[mysum_name] == 1
+
+            empty!(fnames)
+            delete!(orc, orc_mod)
         end
     end
-
-    mod = LLVM.Module("jit", ctx)
-    T_Int32 = LLVM.Int32Type(ctx)
-    ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-    fn = LLVM.Function(mod, "mysum", ft)
-    linkage!(fn, LLVM.API.LLVMExternalLinkage)
-
-    fname = mangle(orc, "wrapper")
-    wrapper = LLVM.Function(mod, fname, ft)
-    # generate IR
-    Builder(ctx) do builder
-        entry = BasicBlock(wrapper, "entry", ctx)
-        position!(builder, entry)
-
-        tmp = call!(builder, fn, [parameters(wrapper)...])
-        ret!(builder, tmp)
-    end
-
-    triple!(mod, triple(tm))
-    ModulePassManager() do pm
-        add_library_info!(pm, triple(mod))
-        add_transform_info!(pm, tm)
-        run!(pm, mod)
-    end
-    verify(mod)
-
-    mysum_name = mangle(orc, "mysum")
-    known_functions[mysum_name] = OrcTargetAddress(@cfunction(+, Int32, (Int32, Int32)))
-
-    f_lookup = @cfunction($lookup, UInt64, (Cstring, Ptr{Cvoid}))
-    GC.@preserve f_lookup begin
-        orc_mod = compile!(orc, mod, f_lookup, C_NULL, lazy=true) # will capture f_lookup
-
-        addr = address(orc, fname)
-        @test errormsg(orc) == ""
-        addr2 = addressin(orc, orc_mod, fname)
-
-        @test addr == addr2
-        @test addr.ptr != 0
-        @test !haskey(fnames, mysum_name)
-
-        r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2) # uses f_lookup
-        @test r == 3
-    end
-    
-    @test haskey(fnames, mysum_name)
-    @test fnames[mysum_name] == 1
-
-    empty!(fnames)
-    delete!(orc, orc_mod)
-    dispose(orc)
 end
 
 @testset "Default Resolver + Stub" begin
-    ctx = Context()
     tm  = JITTargetMachine()
-    orc = OrcJIT(tm)
+    OrcJIT(tm) do orc
+            Context() do ctx
+            mod = LLVM.Module("jit", ctx)
+            T_Int32 = LLVM.Int32Type(ctx)
+            ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
+            fn = LLVM.Function(mod, "mysum", ft)
+            linkage!(fn, LLVM.API.LLVMExternalLinkage)
 
-    mod = LLVM.Module("jit", ctx)
-    T_Int32 = LLVM.Int32Type(ctx)
-    ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-    fn = LLVM.Function(mod, "mysum", ft)
-    linkage!(fn, LLVM.API.LLVMExternalLinkage)
+            fname = mangle(orc, "wrapper")
+            wrapper = LLVM.Function(mod, fname, ft)
+            # generate IR
+            Builder(ctx) do builder
+                entry = BasicBlock(wrapper, "entry", ctx)
+                position!(builder, entry)
 
-    fname = mangle(orc, "wrapper")
-    wrapper = LLVM.Function(mod, fname, ft)
-    # generate IR
-    Builder(ctx) do builder
-        entry = BasicBlock(wrapper, "entry", ctx)
-        position!(builder, entry)
+                tmp = call!(builder, fn, [parameters(wrapper)...])
+                ret!(builder, tmp)
+            end
 
-        tmp = call!(builder, fn, [parameters(wrapper)...])
-        ret!(builder, tmp)
+            triple!(mod, triple(tm))
+            ModulePassManager() do pm
+                add_library_info!(pm, triple(mod))
+                add_transform_info!(pm, tm)
+                run!(pm, mod)
+            end
+            verify(mod)
+
+            create_stub!(orc, mangle(orc, "mysum"), OrcTargetAddress(@cfunction(+, Int32, (Int32, Int32))))
+
+            orc_mod = compile!(orc, mod)
+
+            addr = address(orc, fname)
+            @test errormsg(orc) == ""
+
+            r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2)
+            @test r == 3
+
+            delete!(orc, orc_mod)
+        end
     end
-
-    triple!(mod, triple(tm))
-    ModulePassManager() do pm
-        add_library_info!(pm, triple(mod))
-        add_transform_info!(pm, tm)
-        run!(pm, mod)
-    end
-    verify(mod)
-
-    create_stub!(orc, mangle(orc, "mysum"), OrcTargetAddress(@cfunction(+, Int32, (Int32, Int32))))
-
-    orc_mod = compile!(orc, mod)
-
-    addr = address(orc, fname)
-    @test errormsg(orc) == ""
-
-    r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2)
-    @test r == 3
-
-    delete!(orc, orc_mod)
-    dispose(orc)
 end
 
 @testset "Default Resolver + Global Symbol" begin
-    ctx = Context()
     tm  = JITTargetMachine()
-    orc = OrcJIT(tm)
+    OrcJIT(tm) do orc
+        Context() do ctx
+            mod = LLVM.Module("jit", ctx)
+            T_Int32 = LLVM.Int32Type(ctx)
+            ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
+            mysum = mangle(orc, "mysum")
+            fn = LLVM.Function(mod, mysum, ft)
+            linkage!(fn, LLVM.API.LLVMExternalLinkage)
 
-    mod = LLVM.Module("jit", ctx)
-    T_Int32 = LLVM.Int32Type(ctx)
-    ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-    mysum = mangle(orc, "mysum")
-    fn = LLVM.Function(mod, mysum, ft)
-    linkage!(fn, LLVM.API.LLVMExternalLinkage)
+            fname = mangle(orc, "wrapper")
+            wrapper = LLVM.Function(mod, fname, ft)
+            # generate IR
+            Builder(ctx) do builder
+                entry = BasicBlock(wrapper, "entry", ctx)
+                position!(builder, entry)
 
-    fname = mangle(orc, "wrapper")
-    wrapper = LLVM.Function(mod, fname, ft)
-    # generate IR
-    Builder(ctx) do builder
-        entry = BasicBlock(wrapper, "entry", ctx)
-        position!(builder, entry)
+                tmp = call!(builder, fn, [parameters(wrapper)...])
+                ret!(builder, tmp)
+            end
 
-        tmp = call!(builder, fn, [parameters(wrapper)...])
-        ret!(builder, tmp)
+            triple!(mod, triple(tm))
+            ModulePassManager() do pm
+                add_library_info!(pm, triple(mod))
+                add_transform_info!(pm, tm)
+                run!(pm, mod)
+            end
+            verify(mod)
+
+            # Should do pretty much the same as `@ccallable`
+            LLVM.add_symbol(mysum, @cfunction(+, Int32, (Int32, Int32)))
+            ptr = LLVM.find_symbol(mysum)
+            @test ptr !== C_NULL
+            @test ccall(ptr, Int32, (Int32, Int32), 1, 2) == 3
+
+            orc_mod = compile!(orc, mod, lazy=true)
+
+            addr = address(orc, fname)
+            @test errormsg(orc) == ""
+
+            r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2)
+            @test r == 3
+
+            delete!(orc, orc_mod)
+        end
     end
-
-    triple!(mod, triple(tm))
-    ModulePassManager() do pm
-        add_library_info!(pm, triple(mod))
-        add_transform_info!(pm, tm)
-        run!(pm, mod)
-    end
-    verify(mod)
-
-    # Should do pretty much the same as `@ccallable`
-    LLVM.add_symbol(mysum, @cfunction(+, Int32, (Int32, Int32)))
-    ptr = LLVM.find_symbol(mysum)
-    @test ptr !== C_NULL
-    @test ccall(ptr, Int32, (Int32, Int32), 1, 2) == 3
-
-    orc_mod = compile!(orc, mod, lazy=true)
-
-    addr = address(orc, fname)
-    @test errormsg(orc) == ""
-
-    r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2)
-    @test r == 3
-
-    delete!(orc, orc_mod)
-    dispose(orc)
 end
 
 @testset "Loading ObjectFile" begin
-    ctx = Context()
-    tm = JITTargetMachine()
-    orc = OrcJIT(tm) 
-    sym = mangle(orc, "SomeFunction")
+    tm  = JITTargetMachine()
+    OrcJIT(tm) do orc
+        Context() do ctx
+            sym = mangle(orc, "SomeFunction")
 
-    mod = LLVM.Module("jit", ctx)
-    ft = LLVM.FunctionType(LLVM.VoidType(ctx))
-    fn = LLVM.Function(mod, sym, ft)
+            mod = LLVM.Module("jit", ctx)
+            ft = LLVM.FunctionType(LLVM.VoidType(ctx))
+            fn = LLVM.Function(mod, sym, ft)
 
-    Builder(ctx) do builder
-        entry = BasicBlock(fn, "entry")
-        position!(builder, entry)
-        ret!(builder)
+            Builder(ctx) do builder
+                entry = BasicBlock(fn, "entry")
+                position!(builder, entry)
+                ret!(builder)
+            end
+            verify(mod)
+
+            obj = emit(tm, mod, LLVM.API.LLVMObjectFile)
+
+            orc_m = add!(orc, MemoryBuffer(obj))
+            addr = address(orc, sym)
+
+            @test addr.ptr != 0
+            delete!(orc, orc_m)
+        end
     end
-    verify(mod)
-
-    obj = emit(tm, mod, LLVM.API.LLVMObjectFile)
-
-    orc_m = add!(orc, MemoryBuffer(obj))
-    addr = address(orc, sym)
-
-    @test addr.ptr != 0
-    delete!(orc, orc_m)
 end
 
 @testset "Stubs" begin
-    ctx = Context()
-    tm = JITTargetMachine()
-    orc = OrcJIT(tm)
+    tm  = JITTargetMachine()
+    OrcJIT(tm) do orc
+        Context() do ctx
+            toggle = Ref{Bool}(false)
+            on()  = (toggle[] = true; nothing)
+            off() = (toggle[] = false; nothing)
 
-    toggle = Ref{Bool}(false)
-    on()  = (toggle[] = true; nothing)
-    off() = (toggle[] = false; nothing)
+            # Note that `CFunction` objects can be GC'd (???)
+            # and we capture them below.
+            func_on = @cfunction($on, Cvoid, ())
+            GC.@preserve func_on begin
+                ptr = Base.unsafe_convert(Ptr{Cvoid}, func_on)
 
-    # Note that `CFunction` objects can be GC'd (???)
-    # and we capture them below.
-    func_on = @cfunction($on, Cvoid, ())
-    GC.@preserve func_on begin
-        ptr = Base.unsafe_convert(Ptr{Cvoid}, func_on)
+                create_stub!(orc, "mystub", OrcTargetAddress(ptr))
+                addr = address(orc, "mystub")
 
-        create_stub!(orc, "mystub", OrcTargetAddress(ptr))
-        addr = address(orc, "mystub")
-    
-        @test addr.ptr != 0
-        @test toggle[] == false
-    
-        ccall(pointer(addr), Cvoid, ())
-        @test toggle[] == true
+                @test addr.ptr != 0
+                @test toggle[] == false
+
+                ccall(pointer(addr), Cvoid, ())
+                @test toggle[] == true
+            end
+
+            func_off = @cfunction($off, Cvoid, ())
+            GC.@preserve func_off begin
+                ptr = Base.unsafe_convert(Ptr{Cvoid}, func_off)
+
+                set_stub!(orc, "mystub", OrcTargetAddress(ptr))
+
+                @test addr == address(orc, "mystub")
+                @test toggle[] == true
+
+                ccall(pointer(addr), Cvoid, ())
+                @test toggle[] == false
+            end
+        end
     end
-
-    func_off = @cfunction($off, Cvoid, ())
-    GC.@preserve func_off begin
-        ptr = Base.unsafe_convert(Ptr{Cvoid}, func_off)
-
-        set_stub!(orc, "mystub", OrcTargetAddress(ptr))
-
-        @test addr == address(orc, "mystub")
-        @test toggle[] == true
-    
-        ccall(pointer(addr), Cvoid, ())
-        @test toggle[] == false
-    end
-
-    dispose(orc)
 end
 
 # TODO:


### PR DESCRIPTION
After spending quite a bit of time debugging the wrong part of the compiler I realized that
I was jumping on a non-executable page..., which was apparently due to the fact that I had
an unresolved symbol and OrcJIT decided not to tell me.


