### PR TITLE
Use jl_get_libllvm to locate libLLVM.

### DIFF
--- a/src/LLVM.jl
+++ b/src/LLVM.jl
@@ -60,21 +60,29 @@ function __init__()
     # we only support working with the copy of LLVM that Julia uses, because we have
     # additional library calls compiled in the Julia binary which cannot be used with
     # another copy of LLVM. loading multiple copies of LLVM typically breaks anyhow.
-    libllvm_paths = filter(Libdl.dllist()) do lib
-        occursin(r"LLVM\b", basename(lib))
+    libllvm[] = if VERSION >= v"1.6.0-DEV.1356"
+        path = Base.libllvm()
+        if path === nothing
+            error("""Cannot find the LLVM library loaded by Julia.
+                     Please use a version of Julia that has been built with USE_LLVM_SHLIB=1 (like the official binaries).
+                     If you are, please file an issue and attach the output of `Libdl.dllist()`.""")
+        end
+        String(path)
+    else
+        libllvm_paths = filter(Libdl.dllist()) do lib
+            occursin(r"LLVM\b", basename(lib))
+        end
+        if isempty(libllvm_paths)
+            error("""Cannot find the LLVM library loaded by Julia.
+                     Please use a version of Julia that has been built with USE_LLVM_SHLIB=1 (like the official binaries).
+                     If you are, please file an issue and attach the output of `Libdl.dllist()`.""")
+        end
+        if length(libllvm_paths) > 1
+            error("""Multiple LLVM libraries loaded by Julia.
+                     Please file an issue and attach the output of `Libdl.dllist()`.""")
+        end
+        first(libllvm_paths)
     end
-    if isempty(libllvm_paths)
-        error("""
-            Cannot find the LLVM library loaded by Julia.
-            Please use a version of Julia that has been built with USE_LLVM_SHLIB=1 (like the official binaries).
-            If you are, please file an issue and attach the output of `Libdl.dllist()`.""")
-    end
-    if length(libllvm_paths) > 1
-        error("""
-            Multiple LLVM libraries loaded by Julia.
-            Please file an issue and attach the output of `Libdl.dllist()`.""")
-    end
-    libllvm[] = first(libllvm_paths)
 
     @debug "Using LLVM $(version()) at $(Libdl.dlpath(libllvm[]))"
     if version() !== runtime_version()


### PR DESCRIPTION
Fixes https://github.com/maleadt/LLVM.jl/issues/209 using https://github.com/JuliaLang/julia/pull/38172.