### PR TITLE
Constructors for ConstantStruct and multidimensional ConstantArrays

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -432,10 +432,10 @@ Core
 - [ ] LLVMConstString
 - [ ] LLVMIsConstantString
 - [ ] LLVMGetAsString
-- [ ] LLVMConstStructInContext
-- [ ] LLVMConstStruct
-- [ ] LLVMConstArray
-- [ ] LLVMConstNamedStruct
+- [x] LLVMConstStructInContext
+- [x] LLVMConstStruct
+- [x] LLVMConstArray
+- [x] LLVMConstNamedStruct
 - [ ] LLVMGetElementAsConstant
 - [ ] LLVMConstVector
 

--- a/src/core/module.jl
+++ b/src/core/module.jl
@@ -77,25 +77,12 @@ set_used!(mod::Module, values::GlobalVariable...) = nothing
 set_compiler_used!(mod::Module, values::GlobalVariable...) = nothing
 end
 
+
 ## type iteration
 
 export types
 
-struct ModuleTypeDict <: AbstractDict{String,LLVMType}
-    mod::Module
-end
-
-types(mod::Module) = ModuleTypeDict(mod)
-
-function Base.haskey(iter::ModuleTypeDict, name::String)
-    return API.LLVMGetTypeByName(iter.mod, name) != C_NULL
-end
-
-function Base.getindex(iter::ModuleTypeDict, name::String)
-    objref = API.LLVMGetTypeByName(iter.mod, name)
-    objref == C_NULL && throw(KeyError(name))
-    return LLVMType(objref)
-end
+@deprecate types(mod::Module) types(context(mod))
 
 
 ## metadata iteration

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -238,10 +238,15 @@ function ConstantStruct(value::T, ctx::Context=GlobalContext(); name=String(name
 
     if anonymous
         ConstantStruct(constants, ctx; packed=packed)
+    elseif haskey(types(ctx), name)
+        typ = types(ctx)[name]
+        if collect(elements(typ)) != llvmtype.(constants)
+            throw(ArgumentError("Cannot create struct $name {$(join(llvmtype.(constants), ", "))} as it is already defined in this context as {$(join(elements(typ), ", "))}."))
+        end
+        ConstantStruct(typ, constants)
     else
-        # check if this name already exists in the context
-        haskey(types(ctx), name) && throw(ArgumentError("Type name '$name' is already used in this context. Use a different context, name, or request an anonymous struct."))
         typ = StructType(name, ctx)
+        elements!(typ, llvmtype.(constants))
         ConstantStruct(typ, constants)
     end
 end

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -128,7 +128,8 @@ function ConstantArray(typ::LLVMType, data::AbstractArray{T,N}) where {T<:Consta
         return ConstantArray(API.LLVMConstArray(typ, Array(data), length(data)))
     end
 
-    ca_vec = map(x->ConstantArray(typ, x), eachslice(data, dims=1))
+    # FIXME: once we drop support for julia 1.0, we can use `eachslice(data, dims=1)` instead of this monstrosity
+    ca_vec = map(x->ConstantArray(typ, x), (view(data, i, ntuple(d->(:), N-1)...) for i in axes(data, 1)))
     ca_typ = llvmtype(first(ca_vec))
 
     return ConstantArray(API.LLVMConstArray(ca_typ, ca_vec, length(ca_vec)))

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -128,8 +128,11 @@ function ConstantArray(typ::LLVMType, data::AbstractArray{T,N}) where {T<:Consta
         return ConstantArray(API.LLVMConstArray(typ, Array(data), length(data)))
     end
 
-    # FIXME: once we drop support for julia 1.0, we can use `eachslice(data, dims=1)` instead of this monstrosity
-    ca_vec = map(x->ConstantArray(typ, x), (view(data, i, ntuple(d->(:), N-1)...) for i in axes(data, 1)))
+    if VERSION >= v"1.1"
+        ca_vec = map(x->ConstantArray(typ, x), eachslice(data, dims=1))
+    else
+        ca_vec = map(x->ConstantArray(typ, x), (view(data, i, ntuple(d->(:), N-1)...) for i in axes(data, 1)))
+    end
     ca_typ = llvmtype(first(ca_vec))
 
     return ConstantArray(API.LLVMConstArray(ca_typ, ca_vec, length(ca_vec)))

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -206,7 +206,7 @@ ConstantStruct(typ::StructType, values::Vector{<:Constant}) =
     ConstantStruct(API.LLVMConstNamedStruct(typ, values, length(values)))
 
 # create a ConstantStruct from a Julia object
-function ConstantStruct(value::T, ctx::Context=GlobalContext();
+function ConstantStruct(value::T, ctx::Context=GlobalContext(); name=String(nameof(T)),
                         anonymous::Core.Bool=false, packed::Core.Bool=false) where {T}
     isbitstype(T) || throw(ArgumentError("Can only create a ConstantStruct from an isbits struct"))
     constants = Vector{Constant}()
@@ -228,7 +228,9 @@ function ConstantStruct(value::T, ctx::Context=GlobalContext();
     if anonymous
         ConstantStruct(constants, ctx; packed=packed)
     else
-        typ = StructType(String(nameof(T)), ctx)
+        # check if this name already exists in the context
+        haskey(types(ctx), name) && throw(ArgumentError("Type name '$name' is already used in this context. Use a different context, name, or request an anonymous struct."))
+        typ = StructType(name, ctx)
         ConstantStruct(typ, constants)
     end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -371,6 +371,14 @@ Context() do ctx
         constval = ConstantInt(UInt32(1), ctx)
         @test convert(UInt, constval) == 1
     end
+    let
+        constval = ConstantInt(false, ctx)
+        @test llvmtype(constval) == LLVM.Int1Type(ctx)
+        @test !convert(Bool, constval)
+
+        constval = ConstantInt(true, ctx)
+        @test convert(Bool, constval)
+    end
 
     # issue #81
     for T in [Int32, UInt32, Int64, UInt64]

--- a/test/core.jl
+++ b/test/core.jl
@@ -4,6 +4,10 @@ struct TestStruct
     z::Float16
 end
 
+struct AnotherTestStruct
+    x::Int
+end
+
 struct TestSingleton
 end
 
@@ -478,7 +482,11 @@ Context() do ctx
         ]
         @test collect(operands(constant_struct)) == expected_operands
 
-        @test_throws ArgumentError ConstantStruct(test_struct, ctx)
+        # re-creating the same type shouldn't fail
+        ConstantStruct(TestStruct(true, 42, 0), ctx)
+        # unless it's a conflicting type
+        @test_throws ArgumentError ConstantStruct(AnotherTestStruct(1), ctx; name="TestStruct")
+
     end
     let
         test_struct = TestSingleton()

--- a/test/core.jl
+++ b/test/core.jl
@@ -186,6 +186,22 @@ Context() do ctx
     @test context(typ) == ctx
 end
 
+# type iteration
+Context() do ctx
+    st = LLVM.StructType("SomeType", ctx)
+
+    let ts = types(ctx)
+        @test keytype(ts) == String
+        @test valtype(ts) == LLVMType
+
+        @test haskey(ts, "SomeType")
+        @test ts["SomeType"] == st
+
+        @test !haskey(ts, "SomeOtherType")
+        @test_throws KeyError ts["SomeOtherType"]
+    end
+end
+
 end
 
 
@@ -450,6 +466,8 @@ Context() do ctx
             ConstantFP(LLVM.HalfType(ctx), -2.5)
         ]
         @test collect(operands(constant_struct)) == expected_operands
+
+        @test_throws ArgumentError ConstantStruct(test_struct, ctx; anonymous=false)
     end
 
     end
@@ -648,26 +666,6 @@ LLVM.Module("SomeModule", ctx) do mod
 
         @test mod_flags["foobar"] == md
         @test_throws KeyError mod_flags["foobaz"]
-    end
-end
-end
-
-# type iteration
-Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
-    st = LLVM.StructType("SomeType", ctx)
-    ft = LLVM.FunctionType(st, [st])
-    fn = LLVM.Function(mod, "SomeFunction", ft)
-
-    let ts = types(mod)
-        @test keytype(ts) == String
-        @test valtype(ts) == LLVMType
-
-        @test haskey(ts, "SomeType")
-        @test ts["SomeType"] == st
-
-        @test !haskey(ts, "SomeOtherType")
-        @test_throws KeyError ts["SomeOtherType"]
     end
 end
 end


### PR DESCRIPTION
This PR adds some convenient constructors for `ConstantStruct` and allows for multidimensional `ConstantArray`'s.

Nested structs are currently not supported via the `ConstantStruct(value, packed::Core.Bool=false)`, `ConstantStruct(value, ctx::Context, packed::Core.Bool=false)` and `ConstantStruct(value, typ::LLVMType)` constructors. After some testing and looking at the generated LLVM IR of some C code using nested structs, it appears like nested structs need to be named. This is an issue because we can't know the LLVM name of a nested struct type via a Julia value. Of course we could define our own LLVM struct types for nested structs, but this leads to other issues, like making sure the names do not clash, and duplicated definitions of the same struct (e.g. when calling `ConstStruct` multiple times with the same struct value). Nested structs can still be created via the "lower-level" constructors if necessary.

As for multidimensional arrays: it doesn't seem to be possible to read from them via `LLVMGetElementAsConstant`, so this is not supported.