### PR TITLE
Use XUnit.jl for parallel testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.1'
-          - '1.2'
           - '1.3'
           - '1.4'
           - '1.5'

--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,3 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 CEnum = "0.2, 0.3, 0.4"
 julia = "1.0"
-
-[extras]
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test", "InteractiveUtils"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,13 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-julia = "1.0"
+julia = "1.3"
+
+[extras]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+XUnit = "3e3c03f2-1a94-11e9-2981-050a4ca824ab"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["XUnit", "InteractiveUtils", "Pkg", "Test"]

--- a/test/Kaleidoscope.jl
+++ b/test/Kaleidoscope.jl
@@ -2,7 +2,7 @@
 
 include(joinpath(@__DIR__, "..", "examples", "Kaleidoscope", "Kaleidoscope.jl"))
 
-@testset "recursion" begin
+@testcase "recursion" begin
     program = """
         def fib(x) {
             if x < 3 then
@@ -24,7 +24,7 @@ include(joinpath(@__DIR__, "..", "examples", "Kaleidoscope", "Kaleidoscope.jl"))
     end
 end
 
-@testset "loops" begin
+@testcase "loops" begin
     program = """
     def fib(x) {
         var a = 1, b = 1
@@ -52,7 +52,7 @@ end
     end
 end
 
-@testset "global vars" begin
+@testcase "global vars" begin
     program = """
     var x = 5
     var y = 3

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,0 @@
-[deps]
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-XUnit = "3e3c03f2-1a94-11e9-2981-050a4ca824ab"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+XUnit = "3e3c03f2-1a94-11e9-2981-050a4ca824ab"

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -1,4 +1,4 @@
-@testset "analysis" begin
+@testcase "analysis" begin
 
 Context() do ctx
 Builder(ctx) do builder

--- a/test/bitcode.jl
+++ b/test/bitcode.jl
@@ -1,4 +1,4 @@
-@testset "bitcode" begin
+@testcase "bitcode" begin
 
 let
     invalid_bitcode = "invalid"

--- a/test/buffer.jl
+++ b/test/buffer.jl
@@ -1,4 +1,4 @@
-@testset "buffer" begin
+@testcase "buffer" begin
 
 data = rand(UInt8, 8)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -13,10 +13,8 @@ end
 
 @testset "core" begin
 
-@testset "context" begin
+@testcase "context" begin
 
-global global_ctx
-global_ctx = GlobalContext()
 local_ctx = Context()
 
 let
@@ -30,7 +28,7 @@ Context() do ctx end
 end
 
 
-@testset "type" begin
+@testcase "type" begin
 
 Context() do ctx
     typ = LLVM.Int1Type(ctx)
@@ -54,7 +52,7 @@ end
 # integer
 let
     typ = LLVM.Int1Type()
-    @test context(typ) == global_ctx
+    @test context(typ) == GlobalContext()
 
     show(devnull, typ)
 
@@ -124,11 +122,11 @@ end
 # structure
 let
     st = LLVM.StructType([LLVM.VoidType()])
-    @test context(st) == global_ctx
+    @test context(st) == GlobalContext()
     @test !isempty(st)
 
     st2 = LLVM.StructType("foo")
-    @test context(st2) == global_ctx
+    @test context(st2) == GlobalContext()
     @test isempty(st2)
 end
 Context() do ctx
@@ -170,7 +168,7 @@ end
 # other
 let
     typ = LLVM.VoidType()
-    @test context(typ) == global_ctx
+    @test context(typ) == GlobalContext()
 end
 Context() do ctx
     typ = LLVM.VoidType(ctx)
@@ -178,7 +176,7 @@ Context() do ctx
 end
 let
     typ = LLVM.LabelType()
-    @test context(typ) == global_ctx
+    @test context(typ) == GlobalContext()
 end
 Context() do ctx
     typ = LLVM.LabelType(ctx)
@@ -212,7 +210,7 @@ end
 end
 
 
-@testset "value" begin
+@testcase "value" begin
 
 Context() do ctx
 Builder(ctx) do builder
@@ -324,7 +322,7 @@ end
 # constants
 
 Context() do ctx
-    @testset "constants" begin
+    @testcase "constants" begin
 
     typ = LLVM.Int32Type(ctx)
     ptrtyp = LLVM.PointerType(typ)
@@ -351,7 +349,7 @@ end
 
 # scalar
 Context() do ctx
-    @testset "integer constants" begin
+    @testcase "integer constants" begin
 
     # manual construction of small values
     let
@@ -391,7 +389,7 @@ Context() do ctx
     end
 
 
-    @testset "floating point constants" begin
+    @testcase "floating point constants" begin
 
     let
         typ = LLVM.HalfType(ctx)
@@ -416,7 +414,7 @@ Context() do ctx
     end
 
 
-    @testset "array constants" begin
+    @testcase "array constants" begin
 
     # from Julia values
     let
@@ -455,7 +453,7 @@ Context() do ctx
 
     end
 
-    @testset "struct constants" begin
+    @testcase "struct constants" begin
 
     # from Julia values
     let
@@ -514,7 +512,7 @@ end
 
 # constant expressions
 Context() do ctx
-    @testset "constant expressions" begin
+    @testcase "constant expressions" begin
 
     # inline assembly
     let
@@ -634,16 +632,16 @@ end
 end
 
 
-@testset "metadata" begin
+@testcase "metadata" begin
 
-@test MDString("foo") == MDString("foo", global_ctx)
+@test MDString("foo") == MDString("foo", GlobalContext())
 
 Context() do ctx
     str = MDString("foo", ctx)
     @test string(str) == "foo"
 end
 
-@test MDNode([MDString("foo")]) == MDNode([MDString("foo", global_ctx)], global_ctx)
+@test MDNode([MDString("foo")]) == MDNode([MDString("foo", GlobalContext())], GlobalContext())
 
 Context() do ctx
     str = MDString("foo", ctx)
@@ -656,11 +654,11 @@ end
 end
 
 
-@testset "module" begin
+@testcase "module" begin
 
 let
     mod = LLVM.Module("SomeModule")
-    @test context(mod) == global_ctx
+    @test context(mod) == GlobalContext()
 
     @test name(mod) == "SomeModule"
     name!(mod, "SomeOtherName")
@@ -790,7 +788,7 @@ end
 end
 
 
-@testset "function" begin
+@testcase "function" begin
 
 Context() do ctx
 LLVM.Module("SomeModule", ctx) do mod
@@ -996,7 +994,7 @@ end
 end
 
 
-@testset "basic blocks" begin
+@testcase "basic blocks" begin
 
 Builder() do builder
 LLVM.Module("SomeModule") do mod
@@ -1067,7 +1065,7 @@ end
 end
 
 
-@testset "instructions" begin
+@testcase "instructions" begin
 
 Context() do ctx
 Builder(ctx) do builder

--- a/test/datalayout.jl
+++ b/test/datalayout.jl
@@ -1,4 +1,4 @@
-@testset "datalayout" begin
+@testcase "datalayout" begin
 
 Context() do ctx
 DataLayout("E-p:32:32-f128:128:128") do data

--- a/test/debuginfo.jl
+++ b/test/debuginfo.jl
@@ -1,4 +1,4 @@
-@testset "debuginfo" begin
+@testcase "debuginfo" begin
 
 DEBUG_METADATA_VERSION()
 

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,4 +1,4 @@
-@testset "examples" begin
+@testcase "examples" begin
 
 function find_sources(path::String, sources=String[])
     if isdir(path)
@@ -18,13 +18,15 @@ filter!(file -> !occursin("Kaleidoscope", file), examples)
 
 cd(examples_dir) do
     examples = relpath.(examples, Ref(examples_dir))
-    @testset for example in examples
-        cmd = Base.julia_cmd()
-        if Base.JLOptions().project != C_NULL
-            cmd = `$cmd --project=$(unsafe_string(Base.JLOptions().project))`
-        end
+    for example in examples
+        @testcase "$example" begin
+            cmd = Base.julia_cmd()
+            if Base.JLOptions().project != C_NULL
+                cmd = `$cmd --project=$(unsafe_string(Base.JLOptions().project))`
+            end
 
-        @test success(pipeline(`$cmd $example`, stderr=stderr))
+            @test success(pipeline(`$cmd $example`, stderr=stderr))
+        end
     end
 end
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -1,6 +1,6 @@
 @testset "execution" begin
 
-@testset "generic values" begin
+@testcase "generic values" begin
 
 let
     val = GenericValue(LLVM.Int32Type(), -1)
@@ -40,7 +40,7 @@ end
 end
 
 
-@testset "execution engine" begin
+@testcase "execution engine" begin
 
 Context() do ctx
     mod = LLVM.Module("SomeModule", ctx)

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -140,7 +140,10 @@ end
 end
 end
 
-VERSION >= v"1.5-" && @testset "pointer" begin
+VERSION >= v"1.6-" && @testset "pointer" begin
+# NOTE: LLVMPtr is available in Julia 1.5 already, but a couple of bugs remain
+#       which are triggered by these tests (e.g. JuliaLang/julia#38958).
+
 
 using Core: LLVMPtr
 
@@ -241,7 +244,6 @@ struct Singleton end
                               Singleton}))
     @test !occursin("\bstore\b", ir)
 end
-
 end
 
 end

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1,4 +1,4 @@
-@testset "ir" begin
+@testcase "ir" begin
 
 let
     invalid_ir = "invalid"

--- a/test/irbuilder.jl
+++ b/test/irbuilder.jl
@@ -1,4 +1,4 @@
-@testset "irbuilder" begin
+@testcase "irbuilder" begin
 
 let
     builder = Builder()

--- a/test/linker.jl
+++ b/test/linker.jl
@@ -1,4 +1,4 @@
-@testset "linker" begin
+@testcase "linker" begin
 
 Context() do ctx
 Builder(ctx) do builder

--- a/test/moduleprovider.jl
+++ b/test/moduleprovider.jl
@@ -1,4 +1,4 @@
-@testset "moduleprovider" begin
+@testcase "moduleprovider" begin
 
 Context() do ctx
 let

--- a/test/orc.jl
+++ b/test/orc.jl
@@ -1,215 +1,289 @@
 @testset "orc" begin
 
-@testset "Undefined Symbol" begin
-    tm  = JITTargetMachine()
-    OrcJIT(tm) do orc
-       Context() do ctx
-            mod = LLVM.Module("jit", ctx)
-            T_Int32 = LLVM.Int32Type(ctx)
-            ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-            fn = LLVM.Function(mod, "mysum", ft)
-            linkage!(fn, LLVM.API.LLVMExternalLinkage)
+@testcase "Undefined Symbol" begin
+tm  = JITTargetMachine()
+OrcJIT(tm) do orc
+Context() do ctx
+    mod = LLVM.Module("jit", ctx)
+    T_Int32 = LLVM.Int32Type(ctx)
+    ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
+    fn = LLVM.Function(mod, "mysum_", ft)
+    linkage!(fn, LLVM.API.LLVMExternalLinkage)
 
-            fname = mangle(orc, "wrapper")
-            wrapper = LLVM.Function(mod, fname, ft)
-            # generate IR
-            Builder(ctx) do builder
-                entry = BasicBlock(wrapper, "entry", ctx)
-                position!(builder, entry)
+    fname = mangle(orc, "wrapper_")
+    wrapper = LLVM.Function(mod, fname, ft)
+    # generate IR
+    Builder(ctx) do builder
+        entry = BasicBlock(wrapper, "entry", ctx)
+        position!(builder, entry)
 
-                tmp = call!(builder, fn, [parameters(wrapper)...])
-                ret!(builder, tmp)
-            end
-
-            triple!(mod, triple(tm))
-            ModulePassManager() do pm
-                add_library_info!(pm, triple(mod))
-                add_transform_info!(pm, tm)
-                run!(pm, mod)
-            end
-            verify(mod)
-
-            orc_mod = compile!(orc, mod)
-            @test_throws ErrorException address(orc, fname) == C_NULL
-
-            delete!(orc, orc_mod)
-        end
+        tmp = call!(builder, fn, [parameters(wrapper)...])
+        ret!(builder, tmp)
     end
+
+    triple!(mod, triple(tm))
+    ModulePassManager() do pm
+        add_library_info!(pm, triple(mod))
+        add_transform_info!(pm, tm)
+        run!(pm, mod)
+    end
+    verify(mod)
+
+    orc_mod = compile!(orc, mod)
+    @test_throws ErrorException address(orc, fname)
+
+    delete!(orc, orc_mod)
+end
+end
 end
 
-@testset "Custom Resolver" begin
-    tm  = JITTargetMachine()
-    OrcJIT(tm) do orc
-       Context() do ctx
-            known_functions = Dict{String, OrcTargetAddress}()
-            fnames = Dict{String, Int}()
-            function lookup(name, ctx)
-                name = unsafe_string(name)
-                try
-                    if !haskey(fnames, name)
-                        fnames[name] = 0
-                    end
-                    fnames[name] += 1
-
-                    return known_functions[name].ptr
-                catch ex
-                    @error "Exception during lookup" name exception=(ex, catch_backtrace())
-                    error("OrcJIT: Could not find symbol")
-                end
+@testcase "Custom Resolver" begin
+tm  = JITTargetMachine()
+OrcJIT(tm) do orc
+Context() do ctx
+    known_functions = Dict{String, OrcTargetAddress}()
+    fnames = Dict{String, Int}()
+    function lookup(name, ctx)
+        name = unsafe_string(name)
+        try
+            if !haskey(fnames, name)
+                fnames[name] = 0
             end
+            fnames[name] += 1
 
-            mod = LLVM.Module("jit", ctx)
-            T_Int32 = LLVM.Int32Type(ctx)
-            ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-            fn = LLVM.Function(mod, "mysum", ft)
-            linkage!(fn, LLVM.API.LLVMExternalLinkage)
-
-            fname = mangle(orc, "wrapper")
-            wrapper = LLVM.Function(mod, fname, ft)
-            # generate IR
-            Builder(ctx) do builder
-                entry = BasicBlock(wrapper, "entry", ctx)
-                position!(builder, entry)
-
-                tmp = call!(builder, fn, [parameters(wrapper)...])
-                ret!(builder, tmp)
-            end
-
-            triple!(mod, triple(tm))
-            ModulePassManager() do pm
-                add_library_info!(pm, triple(mod))
-                add_transform_info!(pm, tm)
-                run!(pm, mod)
-            end
-            verify(mod)
-
-            mysum_name = mangle(orc, "mysum")
-            known_functions[mysum_name] = OrcTargetAddress(@cfunction(+, Int32, (Int32, Int32)))
-
-            f_lookup = @cfunction($lookup, UInt64, (Cstring, Ptr{Cvoid}))
-            GC.@preserve f_lookup begin
-                orc_mod = compile!(orc, mod, f_lookup, C_NULL, lazy=true) # will capture f_lookup
-
-                addr = address(orc, fname)
-                @test errormsg(orc) == ""
-                addr2 = addressin(orc, orc_mod, fname)
-
-                @test addr == addr2
-                @test addr.ptr != 0
-                @test !haskey(fnames, mysum_name)
-
-                r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2) # uses f_lookup
-                @test r == 3
-            end
-
-            @test haskey(fnames, mysum_name)
-            @test fnames[mysum_name] == 1
-
-            empty!(fnames)
-            delete!(orc, orc_mod)
+            return known_functions[name].ptr
+        catch ex
+            @error "Exception during lookup" name exception=(ex, catch_backtrace())
+            error("OrcJIT: Could not find symbol")
         end
     end
+
+    mod = LLVM.Module("jit", ctx)
+    T_Int32 = LLVM.Int32Type(ctx)
+    ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
+    fn = LLVM.Function(mod, "mysum", ft)
+    linkage!(fn, LLVM.API.LLVMExternalLinkage)
+
+    fname = mangle(orc, "wrapper")
+    wrapper = LLVM.Function(mod, fname, ft)
+    # generate IR
+    Builder(ctx) do builder
+        entry = BasicBlock(wrapper, "entry", ctx)
+        position!(builder, entry)
+
+        tmp = call!(builder, fn, [parameters(wrapper)...])
+        ret!(builder, tmp)
+    end
+
+    triple!(mod, triple(tm))
+    ModulePassManager() do pm
+        add_library_info!(pm, triple(mod))
+        add_transform_info!(pm, tm)
+        run!(pm, mod)
+    end
+    verify(mod)
+
+    mysum_name = mangle(orc, "mysum")
+    known_functions[mysum_name] = OrcTargetAddress(@cfunction(+, Int32, (Int32, Int32)))
+
+    f_lookup = @cfunction($lookup, UInt64, (Cstring, Ptr{Cvoid}))
+    GC.@preserve f_lookup begin
+        orc_mod = compile!(orc, mod, f_lookup, C_NULL, lazy=true) # will capture f_lookup
+
+        addr = address(orc, fname)
+        @test errormsg(orc) == ""
+        addr2 = addressin(orc, orc_mod, fname)
+
+        @test addr == addr2
+        @test addr.ptr != 0
+        @test !haskey(fnames, mysum_name)
+
+        r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2) # uses f_lookup
+        @test r == 3
+    end
+
+    @test haskey(fnames, mysum_name)
+    @test fnames[mysum_name] == 1
+
+    empty!(fnames)
+    delete!(orc, orc_mod)
+end
+end
 end
 
-@testset "Default Resolver + Stub" begin
-    tm  = JITTargetMachine()
-    OrcJIT(tm) do orc
-            Context() do ctx
-            mod = LLVM.Module("jit", ctx)
-            T_Int32 = LLVM.Int32Type(ctx)
-            ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-            fn = LLVM.Function(mod, "mysum", ft)
-            linkage!(fn, LLVM.API.LLVMExternalLinkage)
+@testcase "Default Resolver + Stub" begin
+tm  = JITTargetMachine()
+OrcJIT(tm) do orc
+Context() do ctx
+    mod = LLVM.Module("jit", ctx)
+    T_Int32 = LLVM.Int32Type(ctx)
+    ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
+    fn = LLVM.Function(mod, "mysum", ft)
+    linkage!(fn, LLVM.API.LLVMExternalLinkage)
 
-            fname = mangle(orc, "wrapper")
-            wrapper = LLVM.Function(mod, fname, ft)
-            # generate IR
-            Builder(ctx) do builder
-                entry = BasicBlock(wrapper, "entry", ctx)
-                position!(builder, entry)
+    fname = mangle(orc, "wrapper")
+    wrapper = LLVM.Function(mod, fname, ft)
+    # generate IR
+    Builder(ctx) do builder
+        entry = BasicBlock(wrapper, "entry", ctx)
+        position!(builder, entry)
 
-                tmp = call!(builder, fn, [parameters(wrapper)...])
-                ret!(builder, tmp)
-            end
+        tmp = call!(builder, fn, [parameters(wrapper)...])
+        ret!(builder, tmp)
+    end
 
-            triple!(mod, triple(tm))
-            ModulePassManager() do pm
-                add_library_info!(pm, triple(mod))
-                add_transform_info!(pm, tm)
-                run!(pm, mod)
-            end
-            verify(mod)
+    triple!(mod, triple(tm))
+    ModulePassManager() do pm
+        add_library_info!(pm, triple(mod))
+        add_transform_info!(pm, tm)
+        run!(pm, mod)
+    end
+    verify(mod)
 
-            create_stub!(orc, mangle(orc, "mysum"), OrcTargetAddress(@cfunction(+, Int32, (Int32, Int32))))
+    create_stub!(orc, mangle(orc, "mysum"), OrcTargetAddress(@cfunction(+, Int32, (Int32, Int32))))
 
-            orc_mod = compile!(orc, mod)
+    orc_mod = compile!(orc, mod)
 
-            addr = address(orc, fname)
-            @test errormsg(orc) == ""
+    addr = address(orc, fname)
+    @test errormsg(orc) == ""
 
-            r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2)
-            @test r == 3
+    r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2)
+    @test r == 3
 
-            delete!(orc, orc_mod)
-        end
+    delete!(orc, orc_mod)
+end
+end
+end
+
+@testcase "Default Resolver + Global Symbol" begin
+tm  = JITTargetMachine()
+OrcJIT(tm) do orc
+Context() do ctx
+    mod = LLVM.Module("jit", ctx)
+    T_Int32 = LLVM.Int32Type(ctx)
+    ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
+    mysum = mangle(orc, "mysum")
+    fn = LLVM.Function(mod, mysum, ft)
+    linkage!(fn, LLVM.API.LLVMExternalLinkage)
+
+    fname = mangle(orc, "wrapper")
+    wrapper = LLVM.Function(mod, fname, ft)
+    # generate IR
+    Builder(ctx) do builder
+        entry = BasicBlock(wrapper, "entry", ctx)
+        position!(builder, entry)
+
+        tmp = call!(builder, fn, [parameters(wrapper)...])
+        ret!(builder, tmp)
+    end
+
+    triple!(mod, triple(tm))
+    ModulePassManager() do pm
+        add_library_info!(pm, triple(mod))
+        add_transform_info!(pm, tm)
+        run!(pm, mod)
+    end
+    verify(mod)
+
+    # Should do pretty much the same as `@ccallable`
+    LLVM.add_symbol(mysum, @cfunction(+, Int32, (Int32, Int32)))
+    ptr = LLVM.find_symbol(mysum)
+    @test ptr !== C_NULL
+    @test ccall(ptr, Int32, (Int32, Int32), 1, 2) == 3
+
+    orc_mod = compile!(orc, mod, lazy=true)
+
+    addr = address(orc, fname)
+    @test errormsg(orc) == ""
+
+    r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2)
+    @test r == 3
+
+    delete!(orc, orc_mod)
+end
+end
+end
+
+@testcase "Loading ObjectFile" begin
+tm  = JITTargetMachine()
+OrcJIT(tm) do orc
+Context() do ctx
+    sym = mangle(orc, "SomeFunction")
+
+    mod = LLVM.Module("jit", ctx)
+    ft = LLVM.FunctionType(LLVM.VoidType(ctx))
+    fn = LLVM.Function(mod, sym, ft)
+
+    Builder(ctx) do builder
+        entry = BasicBlock(fn, "entry")
+        position!(builder, entry)
+        ret!(builder)
+    end
+    verify(mod)
+
+    obj = emit(tm, mod, LLVM.API.LLVMObjectFile)
+
+    orc_m = add!(orc, MemoryBuffer(obj))
+    addr = address(orc, sym)
+
+    @test addr.ptr != 0
+    delete!(orc, orc_m)
+end
+end
+end
+
+@testcase "Stubs" begin
+tm  = JITTargetMachine()
+OrcJIT(tm) do orc
+Context() do ctx
+    toggle = Ref{Bool}(false)
+    on()  = (toggle[] = true; nothing)
+    off() = (toggle[] = false; nothing)
+
+    # Note that `CFunction` objects can be GC'd (???)
+    # and we capture them below.
+    func_on = @cfunction($on, Cvoid, ())
+    GC.@preserve func_on begin
+        ptr = Base.unsafe_convert(Ptr{Cvoid}, func_on)
+
+        create_stub!(orc, "mystub", OrcTargetAddress(ptr))
+        addr = address(orc, "mystub")
+
+        @test addr.ptr != 0
+        @test toggle[] == false
+
+        ccall(pointer(addr), Cvoid, ())
+        @test toggle[] == true
+    end
+
+    func_off = @cfunction($off, Cvoid, ())
+    GC.@preserve func_off begin
+        ptr = Base.unsafe_convert(Ptr{Cvoid}, func_off)
+
+        set_stub!(orc, "mystub", OrcTargetAddress(ptr))
+
+        @test addr == address(orc, "mystub")
+        @test toggle[] == true
+
+        ccall(pointer(addr), Cvoid, ())
+        @test toggle[] == false
     end
 end
-
-@testset "Default Resolver + Global Symbol" begin
-    tm  = JITTargetMachine()
-    OrcJIT(tm) do orc
-        Context() do ctx
-            mod = LLVM.Module("jit", ctx)
-            T_Int32 = LLVM.Int32Type(ctx)
-            ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-            mysum = mangle(orc, "mysum")
-            fn = LLVM.Function(mod, mysum, ft)
-            linkage!(fn, LLVM.API.LLVMExternalLinkage)
-
-            fname = mangle(orc, "wrapper")
-            wrapper = LLVM.Function(mod, fname, ft)
-            # generate IR
-            Builder(ctx) do builder
-                entry = BasicBlock(wrapper, "entry", ctx)
-                position!(builder, entry)
-
-                tmp = call!(builder, fn, [parameters(wrapper)...])
-                ret!(builder, tmp)
-            end
-
-            triple!(mod, triple(tm))
-            ModulePassManager() do pm
-                add_library_info!(pm, triple(mod))
-                add_transform_info!(pm, tm)
-                run!(pm, mod)
-            end
-            verify(mod)
-
-            # Should do pretty much the same as `@ccallable`
-            LLVM.add_symbol(mysum, @cfunction(+, Int32, (Int32, Int32)))
-            ptr = LLVM.find_symbol(mysum)
-            @test ptr !== C_NULL
-            @test ccall(ptr, Int32, (Int32, Int32), 1, 2) == 3
-
-            orc_mod = compile!(orc, mod, lazy=true)
-
-            addr = address(orc, fname)
-            @test errormsg(orc) == ""
-
-            r = ccall(pointer(addr), Int32, (Int32, Int32), 1, 2)
-            @test r == 3
-
-            delete!(orc, orc_mod)
-        end
-    end
+end
 end
 
-@testset "Loading ObjectFile" begin
-    tm  = JITTargetMachine()
-    OrcJIT(tm) do orc
-        Context() do ctx
-            sym = mangle(orc, "SomeFunction")
+@testcase "callback!" begin
+tm  = JITTargetMachine()
+OrcJIT(tm) do orc
+    triggered = Ref{Bool}(false)
 
+    # Setup the lazy callback for creating a module
+    function callback(orc_ref::LLVM.API.LLVMOrcJITStackRef, callback_ctx::Ptr{Cvoid})
+        orc = OrcJIT(orc_ref)
+        sym = mangle(orc, "SomeFunction")
+
+        # 1. IRGen & Optimize the module
+        orc_mod = Context() do ctx
             mod = LLVM.Module("jit", ctx)
             ft = LLVM.FunctionType(LLVM.VoidType(ctx))
             fn = LLVM.Function(mod, sym, ft)
@@ -221,113 +295,39 @@ end
             end
             verify(mod)
 
-            obj = emit(tm, mod, LLVM.API.LLVMObjectFile)
+            triple!(mod, triple(tm))
+            ModulePassManager() do pm
+                add_library_info!(pm, triple(mod))
+                add_transform_info!(pm, tm)
+                run!(pm, mod)
+            end
+            verify(mod)
 
-            orc_m = add!(orc, MemoryBuffer(obj))
-            addr = address(orc, sym)
-
-            @test addr.ptr != 0
-            delete!(orc, orc_m)
+            # 2. Add the IR module to the JIT
+            return compile!(orc, mod)
         end
+
+        # 3. Obtain address of compiled module
+        addr = addressin(orc, orc_mod, sym)
+
+        # 4. Update the stub pointer to point to the recently compiled module
+        set_stub!(orc, "lazystub", addr)
+
+        # 5. Return the address of tie implementation, since we are going to call it now
+        triggered[] = true
+        return addr.ptr
     end
+    c_callback = @cfunction($callback, UInt64, (LLVM.API.LLVMOrcJITStackRef, Ptr{Cvoid}))
+
+    GC.@preserve c_callback begin
+        initial_addr = callback!(orc, c_callback, C_NULL)
+        create_stub!(orc, "lazystub", initial_addr)
+        addr = address(orc, "lazystub")
+
+        ccall(pointer(addr), Cvoid, ()) # Triggers compilation
+    end
+    @test triggered[]
 end
-
-@testset "Stubs" begin
-    tm  = JITTargetMachine()
-    OrcJIT(tm) do orc
-        Context() do ctx
-            toggle = Ref{Bool}(false)
-            on()  = (toggle[] = true; nothing)
-            off() = (toggle[] = false; nothing)
-
-            # Note that `CFunction` objects can be GC'd (???)
-            # and we capture them below.
-            func_on = @cfunction($on, Cvoid, ())
-            GC.@preserve func_on begin
-                ptr = Base.unsafe_convert(Ptr{Cvoid}, func_on)
-
-                create_stub!(orc, "mystub", OrcTargetAddress(ptr))
-                addr = address(orc, "mystub")
-
-                @test addr.ptr != 0
-                @test toggle[] == false
-
-                ccall(pointer(addr), Cvoid, ())
-                @test toggle[] == true
-            end
-
-            func_off = @cfunction($off, Cvoid, ())
-            GC.@preserve func_off begin
-                ptr = Base.unsafe_convert(Ptr{Cvoid}, func_off)
-
-                set_stub!(orc, "mystub", OrcTargetAddress(ptr))
-
-                @test addr == address(orc, "mystub")
-                @test toggle[] == true
-
-                ccall(pointer(addr), Cvoid, ())
-                @test toggle[] == false
-            end
-        end
-    end
-end
-
-@testset "callback!" begin
-    tm  = JITTargetMachine()
-    OrcJIT(tm) do orc
-        triggered = Ref{Bool}(false)
-
-        # Setup the lazy callback for creating a module
-        function callback(orc_ref::LLVM.API.LLVMOrcJITStackRef, callback_ctx::Ptr{Cvoid})
-            orc = OrcJIT(orc_ref)
-            sym = mangle(orc, "SomeFunction")
-
-            # 1. IRGen & Optimize the module
-            orc_mod = Context() do ctx
-                mod = LLVM.Module("jit", ctx)
-                ft = LLVM.FunctionType(LLVM.VoidType(ctx))
-                fn = LLVM.Function(mod, sym, ft)
-
-                Builder(ctx) do builder
-                    entry = BasicBlock(fn, "entry")
-                    position!(builder, entry)
-                    ret!(builder)
-                end
-                verify(mod)
-
-                triple!(mod, triple(tm))
-                ModulePassManager() do pm
-                    add_library_info!(pm, triple(mod))
-                    add_transform_info!(pm, tm)
-                    run!(pm, mod)
-                end
-                verify(mod)
-
-                # 2. Add the IR module to the JIT
-                return compile!(orc, mod)
-            end
-
-            # 3. Obtain address of compiled module
-            addr = addressin(orc, orc_mod, sym)
-
-            # 4. Update the stub pointer to point to the recently compiled module
-            set_stub!(orc, "lazystub", addr)
-
-            # 5. Return the address of tie implementation, since we are going to call it now
-            triggered[] = true
-            return addr.ptr
-        end
-        c_callback = @cfunction($callback, UInt64, (LLVM.API.LLVMOrcJITStackRef, Ptr{Cvoid}))
-
-        GC.@preserve c_callback begin
-            initial_addr = callback!(orc, c_callback, C_NULL)
-            create_stub!(orc, "lazystub", initial_addr)
-            addr = address(orc, "lazystub")
-
-            ccall(pointer(addr), Cvoid, ()) # Triggers compilation
-        end
-        @test triggered[]
-    end
 end
 
 end

--- a/test/orc.jl
+++ b/test/orc.jl
@@ -7,10 +7,10 @@ Context() do ctx
     mod = LLVM.Module("jit", ctx)
     T_Int32 = LLVM.Int32Type(ctx)
     ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-    fn = LLVM.Function(mod, "mysum_", ft)
+    fn = LLVM.Function(mod, "mysum", ft)
     linkage!(fn, LLVM.API.LLVMExternalLinkage)
 
-    fname = mangle(orc, "wrapper_")
+    fname = mangle(orc, "wrapper")
     wrapper = LLVM.Function(mod, fname, ft)
     # generate IR
     Builder(ctx) do builder
@@ -162,7 +162,7 @@ Context() do ctx
     mod = LLVM.Module("jit", ctx)
     T_Int32 = LLVM.Int32Type(ctx)
     ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
-    mysum = mangle(orc, "mysum")
+    mysum = mangle(orc, String(gensym("mysum")))
     fn = LLVM.Function(mod, mysum, ft)
     linkage!(fn, LLVM.API.LLVMExternalLinkage)
 
@@ -186,6 +186,7 @@ Context() do ctx
     verify(mod)
 
     # Should do pretty much the same as `@ccallable`
+    # XXX: this has global effects; hence the gensym
     LLVM.add_symbol(mysum, @cfunction(+, Int32, (Int32, Int32)))
     ptr = LLVM.find_symbol(mysum)
     @test ptr !== C_NULL

--- a/test/pass.jl
+++ b/test/pass.jl
@@ -1,4 +1,4 @@
-@testset "pass" begin
+@testcase "passes" begin
 
 Context() do ctx
 Builder(ctx) do builder

--- a/test/passmanager.jl
+++ b/test/passmanager.jl
@@ -1,10 +1,6 @@
 @testset "passmanager" begin
 
-let
-    mpm = ModulePassManager()
-    dispose(mpm)
-end
-
+@testcase "module pass manager" begin
 Context() do ctx
 LLVM.Module("SomeModule", ctx) do mod
 ModulePassManager() do mpm
@@ -12,7 +8,9 @@ ModulePassManager() do mpm
 end
 end
 end
+end
 
+@testcase "function pass manager" begin
 Context() do ctx
 LLVM.Module("SomeModule", ctx) do mod
 FunctionPassManager(mod) do fpm
@@ -22,6 +20,7 @@ FunctionPassManager(mod) do fpm
     @test !initialize!(fpm)
     @test !run!(fpm, fn)
     @test !finalize!(fpm)
+end
 end
 end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using LLVM
 
 using Pkg
-Pkg.add(name="XUnit", rev="master")
+Pkg.add(PackageSpec(name="XUnit", rev="9b756fcda72d813dbf017f8400d7c55251ef7d1b"))
 
 using XUnit
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,15 @@
 using LLVM
 
-using Test
+using Pkg
+Pkg.add(name="XUnit", rev="master")
 
-@testset "LLVM" begin
+using XUnit
+
+@testset runner=ParallelTestRunner() "LLVM" begin
 
 include("util.jl")
 
-@testset "types" begin
+@testcase "types" begin
     @test convert(Bool, LLVM.True) == true
     @test convert(Bool, LLVM.False) == false
 
@@ -16,7 +19,7 @@ include("util.jl")
     @test convert(LLVM.Bool, false) == LLVM.False
 end
 
-@testset "pass registry" begin
+@testcase "pass registry" begin
     passreg = GlobalPassRegistry()
 
     version()
@@ -57,7 +60,7 @@ include("target.jl")
 include("targetmachine.jl")
 include("datalayout.jl")
 include("debuginfo.jl")
-if LLVM.has_orc_v1() 
+if LLVM.has_orc_v1()
     include("orc.jl")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using LLVM
 
-using Pkg
-Pkg.add(PackageSpec(name="XUnit", rev="9b756fcda72d813dbf017f8400d7c55251ef7d1b"))
+if VERSION >= v"1.6-"
+    using Pkg
+    Pkg.add(PackageSpec(name="XUnit", rev="9b756fcda72d813dbf017f8400d7c55251ef7d1b"))
+end
 
 using XUnit
 

--- a/test/support.jl
+++ b/test/support.jl
@@ -1,6 +1,6 @@
 @testset "support" begin
 
-@testset "command-line options" begin
+@testcase "command-line options" begin
 
 code = """
     using LLVM

--- a/test/target.jl
+++ b/test/target.jl
@@ -1,4 +1,4 @@
-@testset "target" begin
+@testcase "target" begin
     @test_throws ArgumentError Target(triple="invalid")
     @test_throws ArgumentError Target(name="invalid")
 

--- a/test/targetmachine.jl
+++ b/test/targetmachine.jl
@@ -1,4 +1,4 @@
-@testset "targetmachine" begin
+@testcase "targetmachine" begin
 
 host_triple = triple()
 host_t = Target(triple=host_triple)

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -1,4 +1,4 @@
-@testset "transform" begin
+@testcase "transform" begin
 
 let
     pmb = PassManagerBuilder()


### PR DESCRIPTION
Doesn't really matter for LLVM.jl, its tests don't take long, but it's a good experiment. WIP for now since the latest XUnit.jl release doesn't support Julia 1.6.

It's also a good test for the statelessness aspect of the package. @vchuravy I noticed that the ORC tests failed when using `mysum` and `wrapper` for all tests, now executed in parallel. Is there some global caching going on despite local contexts? Renaming the undefined symbol test to `mysum_` and `wrapper_` fixed the `@test_throws`.