### PR TITLE
Compatibility with LLVM 12.

### DIFF
--- a/test/transform.jl
+++ b/test/transform.jl
@@ -65,7 +65,9 @@ ModulePassManager() do pm
     scalar_repl_aggregates_ssa!(pm)
     simplify_lib_calls!(pm)
     tail_call_elimination!(pm)
-    constant_propagation!(pm)
+    if LLVM.version() < v"12"
+        constant_propagation!(pm)
+    end
     demote_memory_to_register!(pm)
     verifier!(pm)
     correlated_value_propagation!(pm)
@@ -87,7 +89,9 @@ ModulePassManager() do pm
     always_inliner!(pm)
     global_dce!(pm)
     global_optimizer!(pm)
-    ipconstant_propagation!(pm)
+    if LLVM.version() < v"12"
+        ipconstant_propagation!(pm)
+    end
     prune_eh!(pm)
     ipsccp!(pm)
     strip_dead_prototypes!(pm)


### PR DESCRIPTION
Tested on https://github.com/JuliaLang/julia/pull/40774.

https://releases.llvm.org/12.0.0/docs/ReleaseNotes.html:
> The ConstantPropagation pass was removed. Users should use the InstSimplify pass instead.