### PR TITLE
Use LLVMExtra_jll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.1'
-          - '1.2'
-          - '1.3'
-          - '1.4'
-          - '1.5'
           - '1.6'
           - 'nightly'
         os:

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,14 +1,133 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
 [[CEnum]]
 git-tree-sha1 = "215a9aa4a1f23fbd05b92769fdd62559488d70e9"
 uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 version = "0.4.1"
 
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.3.0"
+
+[[LLVMExtra_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "14a66c356635a678830ab38e8fc32f00a11c0a95"
+uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
+version = "0.0.1+0"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.2"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,18 @@
 name = "LLVM"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "3.9.0"
+version = "3.10.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+LLVMExtra_jll = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-julia = "1.0"
+LLVMExtra_jll = "0.0.1"
+julia = "1.6"
 
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -111,9 +111,10 @@ end
 function LLVMAddLoadStoreVectorizerPass(PM)
     @runtime_ccall (:LLVMExtraAddLoadStoreVectorizerPass, libLLVMExtra) Cvoid (LLVMPassManagerRef,) PM
 end
-
+if LLVM.version() < v"12"
 function LLVMAddInstSimplifyPass(PM)
     @runtime_ccall (:LLVMExtraAddInstructionSimplifyPass, libLLVMExtra) Cvoid (LLVMPassManagerRef,) PM
+end
 end
 
 function LLVMGetValueContext(V)

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -1,45 +1,45 @@
-# Julia wrapper for source: julia/src/llvm-api.cpp
+# Julia wrapper for source: LLVMExtra_jll
 
 # initialization functions
 
 function LLVMInitializeAllTargetInfos()
-    ccall(:LLVMExtraInitializeAllTargetInfos,Cvoid,())
+    @runtime_ccall (:LLVMExtraInitializeAllTargetInfos, libLLVMExtra) Cvoid ()
 end
 
 function LLVMInitializeAllTargets()
-    ccall(:LLVMExtraInitializeAllTargets,Cvoid,())
+    @runtime_ccall (:LLVMExtraInitializeAllTargets, libLLVMExtra) Cvoid ()
 end
 
 function LLVMInitializeAllTargetMCs()
-    ccall(:LLVMExtraInitializeAllTargetMCs,Cvoid,())
+    @runtime_ccall (:LLVMExtraInitializeAllTargetMCs, libLLVMExtra) Cvoid ()
 end
 
 function LLVMInitializeAllAsmPrinters()
-    ccall(:LLVMExtraInitializeAllAsmPrinters,Cvoid,())
+    @runtime_ccall (:LLVMExtraInitializeAllAsmPrinters, libLLVMExtra) Cvoid ()
 end
 
 function LLVMInitializeAllAsmParsers()
-    ccall(:LLVMExtraInitializeAllAsmParsers,Cvoid,())
+    @runtime_ccall (:LLVMExtraInitializeAllAsmParsers, libLLVMExtra) Cvoid ()
 end
 
 function LLVMInitializeAllDisassemblers()
-    ccall(:LLVMExtraInitializeAllDisassemblers,Cvoid,())
+    @runtime_ccall (:LLVMExtraInitializeAllDisassemblers, libLLVMExtra) Cvoid ()
 end
 
 function LLVMInitializeNativeTarget()
-    ccall(:LLVMExtraInitializeNativeTarget,LLVMBool,())
+    @runtime_ccall (:LLVMExtraInitializeNativeTarget, libLLVMExtra) LLVMBool ()
 end
 
 function LLVMInitializeNativeAsmPrinter()
-    ccall(:LLVMExtraInitializeNativeAsmPrinter,LLVMBool,())
+    @runtime_ccall (:LLVMExtraInitializeNativeAsmPrinter, libLLVMExtra) LLVMBool ()
 end
 
 function LLVMInitializeNativeAsmParser()
-    ccall(:LLVMExtraInitializeNativeAsmParser,LLVMBool,())
+    @runtime_ccall (:LLVMExtraInitializeNativeAsmParser, libLLVMExtra) LLVMBool ()
 end
 
 function LLVMInitializeNativeDisassembler()
-    ccall(:LLVMExtraInitializeNativeDisassembler,LLVMBool,())
+    @runtime_ccall (:LLVMExtraInitializeNativeDisassembler, libLLVMExtra) LLVMBool ()
 end
 
 # infrastructure for writing LLVM passes in Julia
@@ -50,193 +50,87 @@ end
 const LLVMPassRef = Ptr{LLVMOpaquePass}
 
 function LLVMAddPass(PM, P)
-    ccall(:LLVMExtraAddPass,Cvoid,
-        (LLVMPassManagerRef, LLVMPassRef),
-        PM, P)
+    @runtime_ccall (:LLVMExtraAddPass, libLLVMExtra) Cvoid (LLVMPassManagerRef, LLVMPassRef) PM P
 end
 
 function LLVMCreateModulePass(Name, Callback)
-    ccall(:LLVMExtraCreateModulePass,LLVMPassRef,
-        (Cstring, Any),
-        Name, Callback)
+    @runtime_ccall (:LLVMExtraCreateModulePass, libLLVMExtra) LLVMPassRef (Cstring, Any) Name Callback
 end
 
 function LLVMCreateFunctionPass(Name, Callback)
-    ccall(:LLVMExtraCreateFunctionPass,LLVMPassRef,
-        (Cstring, Any),
-        Name, Callback)
+    @runtime_ccall (:LLVMExtraCreateFunctionPass, libLLVMExtra) LLVMPassRef (Cstring, Any) Name Callback
 end
 
 function LLVMCreateBasicBlockPass(Name, Callback)
-    ccall(:LLVMExtraCreateBasicBlockPass,LLVMPassRef,
-        (Cstring, Any),
-        Name, Callback)
+    @runtime_ccall (:LLVMExtraCreateBasicBlockPass, libLLVMExtra) LLVMPassRef (Cstring, Any) Name Callback
 end
 
 function LLVMCreateModulePass2(Name, Callback, Data)
-    ccall(:LLVMExtraCreateModulePass2,LLVMPassRef,
-        (Cstring, Ptr{Cvoid}, Ptr{Cvoid}),
-        Name, Callback, Data)
+    @runtime_ccall (:LLVMExtraCreateModulePass2, libLLVMExtra) LLVMPassRef (Cstring, Ptr{Cvoid}, Ptr{Cvoid}) Name Callback Data
 end
 
 function LLVMCreateFunctionPass2(Name, Callback, Data)
-    ccall(:LLVMExtraCreateFunctionPass2,LLVMPassRef,
-        (Cstring, Ptr{Cvoid}, Ptr{Cvoid}),
-        Name, Callback, Data)
+    @runtime_ccall (:LLVMExtraCreateFunctionPass2, libLLVMExtra) LLVMPassRef (Cstring, Ptr{Cvoid}, Ptr{Cvoid}) Name Callback Data
 end
 
 
 # various missing functions
 
 function LLVMAddInternalizePassWithExportList(PM, ExportList, Length)
-    ccall(:LLVMExtraAddInternalizePassWithExportList,Cvoid,(LLVMPassManagerRef,Ptr{Cstring},Csize_t), PM, ExportList, Length)
+    @runtime_ccall (:LLVMExtraAddInternalizePassWithExportList, libLLVMExtra) Cvoid (LLVMPassManagerRef,Ptr{Cstring},Csize_t) PM ExportList Length
 end
 
 function LLVMAddTargetLibraryInfoByTriple(Triple, PM)
-    ccall(:LLVMExtraAddTargetLibraryInfoByTiple,Cvoid,(Cstring, LLVMPassManagerRef), Triple, PM)
+    @runtime_ccall (:LLVMExtraAddTargetLibraryInfoByTiple, libLLVMExtra) Cvoid (Cstring, LLVMPassManagerRef) Triple PM
 end
 
-if VERSION < v"1.2.0-DEV.531"
 function LLVMAddNVVMReflectPass(PM, smversion)
-    ccall(:LLVMExtraAddMVVMReflectPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-else
-
-if version() < v"8.0"
-    function LLVMAddNVVMReflectPass(PM, smversion)
-        ccall(:LLVMExtraAddNVVMReflectPass,Cvoid,(LLVMPassManagerRef,), PM)
-    end
-else
-    function LLVMAddNVVMReflectPass(PM, smversion)
-        ccall(:LLVMExtraAddNVVMReflectFunctionPass,Cvoid,(LLVMPassManagerRef, Cuint), PM, smversion)
-    end
-end
-
-function LLVMAddAllocOptPass(PM)
-    ccall(:LLVMExtraAddAllocOptPass,Cvoid,(LLVMPassManagerRef,), PM)
+     @runtime_ccall (:LLVMExtraAddNVVMReflectFunctionPass, libLLVMExtra) Cvoid (LLVMPassManagerRef, Cuint) PM smversion
 end
 
 function LLVMAddBarrierNoopPass(PM)
-    ccall(:LLVMExtraAddBarrierNoopPass,Cvoid,(LLVMPassManagerRef,), PM)
+    @runtime_ccall (:LLVMExtraAddBarrierNoopPass, libLLVMExtra) Cvoid (LLVMPassManagerRef,) PM
 end
 
-function LLVMAddGCInvariantVerifierPass(PM, Strong)
-    ccall(:LLVMExtraAddGCInvariantVerifierPass,Cvoid,(LLVMPassManagerRef,LLVMBool), PM, Strong)
-end
-
-function LLVMAddLowerExcHandlersPass(PM)
-    ccall(:LLVMExtraAddLowerExcHandlersPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-
-function LLVMAddCombineMulAddPass(PM)
-    ccall(:LLVMExtraAddCombineMulAddPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-
-function LLVMAddMultiVersioningPass(PM)
-    ccall(:LLVMExtraAddMultiVersioningPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-
-function LLVMAddPropagateJuliaAddrspaces(PM)
-    ccall(:LLVMExtraAddPropagateJuliaAddrspaces,Cvoid,(LLVMPassManagerRef,), PM)
-end
-
-function LLVMAddLowerPTLSPass(PM, imaging_mode)
-    ccall(:LLVMExtraAddLowerPTLSPass,Cvoid,(LLVMPassManagerRef,LLVMBool), PM, imaging_mode)
-end
-
-function LLVMAddLowerSimdLoopPass(PM)
-    ccall(:LLVMExtraAddLowerSimdLoopPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-
-function LLVMAddLateLowerGCFramePass(PM)
-    ccall(:LLVMExtraAddLateLowerGCFramePass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-
-end
-
-if VERSION >= v"1.3.0-DEV.95"
-function LLVMAddFinalLowerGCPass(PM)
-    ccall(:LLVMExtraAddFinalLowerGCPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-end
-
-if VERSION >= v"1.5.0-DEV.802"
-function LLVMAddRemoveJuliaAddrspacesPass(PM)
-    ccall(:LLVMExtraAddRemoveJuliaAddrspacesPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-end
-
-if VERSION >= v"1.6.0-DEV.1215"
-function LLVMAddDemoteFloat16Pass(PM)
-    ccall(:LLVMExtraAddDemoteFloat16Pass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-end
-
-if VERSION >= v"1.6.0-DEV.1476"
-function LLVMAddRemoveNIPass(PM)
-    ccall(:LLVMExtraAddRemoveNIPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-end
-
-if VERSION >= v"1.6.0-DEV.1477"
-function LLVMAddJuliaLICMPass(PM)
-    ccall(:LLVMExtraJuliaLICMPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
-end
-
-if VERSION >= v"1.6.0-DEV.1503"
 function LLVMAddDivRemPairsPass(PM)
-    ccall(:LLVMExtraAddDivRemPairsPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
+    @runtime_ccall (:LLVMExtraAddDivRemPairsPass, libLLVMExtra) Cvoid (LLVMPassManagerRef,) PM
 end
 
-if VERSION >= v"1.6.0-DEV.1503"
 function LLVMAddLoopDistributePass(PM)
-    ccall(:LLVMExtraAddLoopDistributePass,Cvoid,(LLVMPassManagerRef,), PM)
-end
+    @runtime_ccall (:LLVMExtraAddLoopDistributePass, libLLVMExtra) Cvoid (LLVMPassManagerRef,) PM
 end
 
-if VERSION >= v"1.6.0-DEV.1503"
 function LLVMAddLoopFusePass(PM)
-    ccall(:LLVMExtraAddLoopFusePass,Cvoid,(LLVMPassManagerRef,), PM)
-end
+    @runtime_ccall (:LLVMExtraAddLoopFusePass, libLLVMExtra) Cvoid (LLVMPassManagerRef,) PM
 end
 
-if VERSION >= v"1.6.0-DEV.1503"
 function LLVMAddLoopLoadEliminationPass(PM)
-    ccall(:LLVMExtraLoopLoadEliminationPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
+    @runtime_ccall (:LLVMExtraLoopLoadEliminationPass, libLLVMExtra) Cvoid (LLVMPassManagerRef,) PM
 end
 
-if VERSION >= v"1.6.0-DEV.1503"
 function LLVMAddLoadStoreVectorizerPass(PM)
-    ccall(:LLVMExtraAddLoadStoreVectorizerPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
+    @runtime_ccall (:LLVMExtraAddLoadStoreVectorizerPass, libLLVMExtra) Cvoid (LLVMPassManagerRef,) PM
 end
 
-if VERSION >= v"1.6.0-DEV.1503"
 function LLVMAddInstSimplifyPass(PM)
-    ccall(:LLVMExtraAddInstructionSimplifyPass,Cvoid,(LLVMPassManagerRef,), PM)
-end
+    @runtime_ccall (:LLVMExtraAddInstructionSimplifyPass, libLLVMExtra) Cvoid (LLVMPassManagerRef,) PM
 end
 
 function LLVMGetValueContext(V)
-    ccall(:LLVMExtraGetValueContext,LLVMContextRef,(LLVMValueRef,),V)
+    @runtime_ccall (:LLVMExtraGetValueContext, libLLVMExtra) LLVMContextRef (LLVMValueRef,) V
 end
 
-if VERSION >= v"0.7.0-alpha.37"
 function LLVMGetSourceLocation(V, index, Name, Filename, Line, Column)
-    ccall(:LLVMExtraGetSourceLocation,Cint,(LLVMValueRef,Cint,Ptr{Cstring},Ptr{Cstring},Ptr{Cuint},Ptr{Cuint}), V, index, Name, Filename, Line, Column)
-end
+    @runtime_ccall (:LLVMExtraGetSourceLocation, libLLVMExtra) Cint (LLVMValueRef,Cint,Ptr{Cstring},Ptr{Cstring},Ptr{Cuint},Ptr{Cuint}) V index Name Filename Line Column
 end
 
 if VERSION >= v"1.5" && !(v"1.6-" <= VERSION < v"1.6.0-DEV.90")
 function LLVMExtraAppendToUsed(Mod, Values, Count)
-    ccall(:LLVMExtraAppendToUsed,Cvoid,(LLVMModuleRef,Ptr{LLVMValueRef},Csize_t), Mod, Values, Count)
+    @runtime_ccall (:LLVMExtraAppendToUsed, libLLVMExtra) Cvoid (LLVMModuleRef,Ptr{LLVMValueRef},Csize_t) Mod Values Count
 end
 
 function LLVMExtraAppendToCompilerUsed(Mod, Values, Count)
-    ccall(:LLVMExtraAppendToCompilerUsed,Cvoid,(LLVMModuleRef,Ptr{LLVMValueRef},Csize_t), Mod, Values, Count)
+    @runtime_ccall (:LLVMExtraAppendToCompilerUsed, libLLVMExtra) Cvoid (LLVMModuleRef,Ptr{LLVMValueRef},Csize_t) Mod Values Count
 end
 
 function LLVMExtraAddGenericAnalysisPasses(PM)
@@ -244,11 +138,9 @@ function LLVMExtraAddGenericAnalysisPasses(PM)
 end
 end
 
-if version() >= v"8.0"
-    @cenum(LLVMDebugEmissionKind,
-        LLVMDebugEmissionKindNoDebug = 0,
-        LLVMDebugEmissionKindFullDebug = 1,
-        LLVMDebugEmissionKindLineTablesOnly = 2,
-        LLVMDebugEmissionKindDebugDirectivesOnly = 3,
-    )
-end
+@cenum(LLVMDebugEmissionKind,
+    LLVMDebugEmissionKindNoDebug = 0,
+    LLVMDebugEmissionKindFullDebug = 1,
+    LLVMDebugEmissionKindLineTablesOnly = 2,
+    LLVMDebugEmissionKindDebugDirectivesOnly = 3,
+)

--- a/lib/libLLVM_julia.jl
+++ b/lib/libLLVM_julia.jl
@@ -1,0 +1,57 @@
+# Julia wrapper for source: julia/src/llvm-api.cpp
+
+function LLVMAddAllocOptPass(PM)
+    ccall(:LLVMExtraAddAllocOptPass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddGCInvariantVerifierPass(PM, Strong)
+    ccall(:LLVMExtraAddGCInvariantVerifierPass,Cvoid,(LLVMPassManagerRef,LLVMBool), PM, Strong)
+end
+
+function LLVMAddLowerExcHandlersPass(PM)
+    ccall(:LLVMExtraAddLowerExcHandlersPass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddCombineMulAddPass(PM)
+    ccall(:LLVMExtraAddCombineMulAddPass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddMultiVersioningPass(PM)
+    ccall(:LLVMExtraAddMultiVersioningPass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddPropagateJuliaAddrspaces(PM)
+    ccall(:LLVMExtraAddPropagateJuliaAddrspaces,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddLowerPTLSPass(PM, imaging_mode)
+    ccall(:LLVMExtraAddLowerPTLSPass,Cvoid,(LLVMPassManagerRef,LLVMBool), PM, imaging_mode)
+end
+
+function LLVMAddLowerSimdLoopPass(PM)
+    ccall(:LLVMExtraAddLowerSimdLoopPass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddLateLowerGCFramePass(PM)
+    ccall(:LLVMExtraAddLateLowerGCFramePass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddFinalLowerGCPass(PM)
+    ccall(:LLVMExtraAddFinalLowerGCPass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddRemoveJuliaAddrspacesPass(PM)
+    ccall(:LLVMExtraAddRemoveJuliaAddrspacesPass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddDemoteFloat16Pass(PM)
+    ccall(:LLVMExtraAddDemoteFloat16Pass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddRemoveNIPass(PM)
+    ccall(:LLVMExtraAddRemoveNIPass,Cvoid,(LLVMPassManagerRef,), PM)
+end
+
+function LLVMAddJuliaLICMPass(PM)
+    ccall(:LLVMExtraJuliaLICMPass,Cvoid,(LLVMPassManagerRef,), PM)
+end

--- a/src/LLVM.jl
+++ b/src/LLVM.jl
@@ -30,8 +30,11 @@ if !isdir(libdir)
     You might need a newer version of LLVM.jl for this version of Julia.""")
 end
 
+import LLVMExtra_jll: libLLVMExtra
+
 include(joinpath(libdir, llvm_version, "libLLVM_h.jl"))
 include(joinpath(libdir, "libLLVM_extra.jl"))
+include(joinpath(libdir, "libLLVM_julia.jl"))
 end # module API
 
 # LLVM API wrappers

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -119,8 +119,18 @@ scalar_repl_aggregates_ssa!(pm::PassManager) =
 define_transforms([:DCE], version() >= v"10.0")
 
 define_transforms([
-    :DivRemPairs, :LoopDistribute, :LoopFuse, :LoopLoadElimination, :InstSimplify
+    :DivRemPairs, :LoopDistribute, :LoopFuse, :LoopLoadElimination
 ], VERSION >= v"1.6.0-DEV.1503")
+
+define_transforms([:InstSimplify], version() < v"12" && VERSION >= v"1.6.0-DEV.1503")
+define_transforms([:InstructionSimplify], version() >= v"12")
+
+if version() <= v"12"
+    instruction_simplify!(pm) = inst_simplify!(pm)
+else
+    @deprecate inst_simplify!(pm) instruction_simplify!(pm)
+end
+
 
 ## vectorization transformations
 

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -41,7 +41,7 @@ ModulePassManager() do pm
     div_rem_pairs!(pm)
     ind_var_simplify!(pm)
     instruction_combining!(pm)
-    inst_simplify!(pm)
+    instruction_simplify!(pm)
     jump_threading!(pm)
     licm!(pm)
     loop_deletion!(pm)


### PR DESCRIPTION
@maleadt I think we can't maintain support for Julia before 1.6 with this.
LLVMExtra_jll declares a minimum compat of 1.6
