### PR TITLE
Improve coverage of Metadata API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,12 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
       - name: Build libLLVMExtra
         if: ${{ matrix.libLLVMExtra == 'local' }}
         run: |
           julia --project=deps -e 'using Pkg; Pkg.instantiate()'
           julia --project=deps deps/build_local.jl
-      - uses: julia-actions/julia-buildpkg@v1
       # test
       - uses: julia-actions/julia-runtest@v1
       # process results

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -34,9 +34,9 @@ version = "1.3.0"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "146382df21a14a60348f8377e5eac0669794a47b"
+git-tree-sha1 = "ca0fc51947aab764bd8c6f9dd8a91ba3da8647c7"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.2+0"
+version = "0.0.3+0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-LLVMExtra_jll = "0.0.2"
+LLVMExtra_jll = "0.0.3"
 julia = "1.6"

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -58,6 +58,8 @@ void LLVMExtraAppendToCompilerUsed(LLVMModuleRef Mod,
                                    size_t Count);
 void LLVMExtraAddGenericAnalysisPasses(LLVMPassManagerRef PM);
 
+const char *LLVMExtraDIScopeGetName(LLVMMetadataRef File, unsigned *Len);
+
 // Bug fixes
 void LLVMExtraSetInitializer(LLVMValueRef GlobalVar, LLVMValueRef ConstantVal);
 void LLVMExtraSetPersonalityFn(LLVMValueRef Fn, LLVMValueRef PersonalityFn);

--- a/deps/LLVMExtra/lib/llvm-api.cpp
+++ b/deps/LLVMExtra/lib/llvm-api.cpp
@@ -254,6 +254,16 @@ void LLVMExtraAddGenericAnalysisPasses(LLVMPassManagerRef PM)
     unwrap(PM)->add(createTargetTransformInfoWrapperPass(TargetIRAnalysis()));
 }
 
+template <typename DIT> DIT *unwrapDI(LLVMMetadataRef Ref) {
+  return (DIT *)(Ref ? unwrap<MDNode>(Ref) : nullptr);
+}
+
+const char *LLVMExtraDIScopeGetName(LLVMMetadataRef File, unsigned *Len) {
+  auto Name = unwrapDI<DIScope>(File)->getName();
+  *Len = Name.size();
+  return Name.data();
+}
+
 // Bug fixes (TODO: upstream these)
 
 void LLVMExtraSetInitializer(LLVMValueRef GlobalVar, LLVMValueRef ConstantVal) {

--- a/examples/constrained.jl
+++ b/examples/constrained.jl
@@ -53,7 +53,8 @@ meta(::Type{FPExceptStrict}) = "fpexcept.strict"
         Builder(ctx) do builder
             entry = BasicBlock(llvm_f, "entry", ctx)
             position!(builder, entry)
-            val = call!(builder, intrinsic, [parameters(llvm_f)..., mround, mfpexcept])
+            val = call!(builder, intrinsic,
+                        [parameters(llvm_f)..., Value(mround, ctx), Value(mfpexcept, ctx)])
             ret!(builder, val)
         end
 

--- a/lib/11/libLLVM_h.jl
+++ b/lib/11/libLLVM_h.jl
@@ -4552,7 +4552,7 @@ end
     LLVMDWARFEmissionLineTablesOnly = 2
 end
 
-@cenum __JL_Ctag_204::UInt32 begin
+@cenum LLVMMetadataKind::UInt32 begin
     LLVMMDStringMetadataKind = 0
     LLVMConstantAsMetadataMetadataKind = 1
     LLVMLocalAsMetadataMetadataKind = 2
@@ -4586,8 +4586,6 @@ end
     LLVMDIMacroFileMetadataKind = 30
     LLVMDICommonBlockMetadataKind = 31
 end
-
-const LLVMMetadataKind = Cuint
 
 const LLVMDWARFTypeEncoding = Cuint
 

--- a/lib/12/libLLVM_h.jl
+++ b/lib/12/libLLVM_h.jl
@@ -4859,7 +4859,7 @@ end
     LLVMDWARFEmissionLineTablesOnly = 2
 end
 
-@cenum __JL_Ctag_250::UInt32 begin
+@cenum LLVMMetadataKind::UInt32 begin
     LLVMMDStringMetadataKind = 0
     LLVMConstantAsMetadataMetadataKind = 1
     LLVMLocalAsMetadataMetadataKind = 2
@@ -4895,8 +4895,6 @@ end
     LLVMDIStringTypeMetadataKind = 32
     LLVMDIGenericSubrangeMetadataKind = 33
 end
-
-const LLVMMetadataKind = Cuint
 
 const LLVMDWARFTypeEncoding = Cuint
 

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -128,10 +128,6 @@ function LLVMGetValueContext(V)
     ccall((:LLVMExtraGetValueContext, libLLVMExtra),LLVMContextRef,(LLVMValueRef,),V)
 end
 
-function LLVMGetSourceLocation(V, index, Name, Filename, Line, Column)
-    ccall((:LLVMExtraGetSourceLocation, libLLVMExtra),Cint,(LLVMValueRef,Cint,Ptr{Cstring},Ptr{Cstring},Ptr{Cuint},Ptr{Cuint}), V, index, Name, Filename, Line, Column)
-end
-
 function LLVMExtraAppendToUsed(Mod, Values, Count)
     ccall((:LLVMExtraAppendToUsed, libLLVMExtra),Cvoid,(LLVMModuleRef,Ptr{LLVMValueRef},Csize_t), Mod, Values, Count)
 end

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -147,6 +147,15 @@ end
     LLVMDebugEmissionKindDebugDirectivesOnly = 3,
 )
 
+function LLVMExtraDIScopeGetName(Scope, Len)
+    ccall((:LLVMExtraDIScopeGetName, libLLVMExtra), Cstring, (LLVMMetadataRef, Ptr{Cuint}), Scope, Len)
+end
+
+
+# bug fixes
+
+# TODO: upstream
+
 function LLVMExtraSetInitializer(GlobalVar, ConstantVal)
     ccall((:LLVMExtraSetInitializer, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, ConstantVal)
 end

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -85,7 +85,7 @@ Base.haskey(md::InstructionMetadataDict, kind::MD) =
 
 function Base.getindex(md::InstructionMetadataDict, kind::MD)
     objref = API.LLVMGetMetadata(md.inst, kind)
-    objref == C_NULL && throw(KeyError(name))
+    objref == C_NULL && throw(KeyError(kind))
     return Metadata(MetadataAsValue(objref))
   end
 

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -86,11 +86,11 @@ Base.haskey(md::InstructionMetadataDict, kind::MD) =
 function Base.getindex(md::InstructionMetadataDict, kind::MD)
     objref = API.LLVMGetMetadata(md.inst, kind)
     objref == C_NULL && throw(KeyError(name))
-    return MetadataAsValue(objref)
+    return Metadata(MetadataAsValue(objref))
   end
 
-Base.setindex!(md::InstructionMetadataDict, node::MetadataAsValue, kind::MD) =
-    API.LLVMSetMetadata(md.inst, kind, node)
+Base.setindex!(md::InstructionMetadataDict, node::Metadata, kind::MD) =
+    API.LLVMSetMetadata(md.inst, kind, Value(node, context(md.inst)))
 
 Base.delete!(md::InstructionMetadataDict, kind::MD) =
     API.LLVMSetMetadata(md.inst, kind, C_NULL)

--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -37,7 +37,24 @@ identify(::Type{Value}, ::Val{API.LLVMMetadataAsValueValueKind}) = MetadataAsVal
 Value(md::Metadata, ctx::Context=GlobalContext()) =
     MetadataAsValue(API.LLVMMetadataAsValue(ctx, md))
 
-Metadata(val::MetadataAsValue) = Metadata(API.LLVMValueAsMetadata(val))
+
+## value as metadata
+
+abstract type ValueAsMetadata <: Metadata end
+
+@checked struct ConstantAsMetadata <: ValueAsMetadata
+    ref::API.LLVMMetadataRef
+end
+identify(::Type{Metadata}, ::Val{API.LLVMConstantAsMetadataMetadataKind}) = ConstantAsMetadata
+
+@checked struct LocalAsMetadata <: ValueAsMetadata
+    ref::API.LLVMMetadataRef
+end
+identify(::Type{Metadata}, ::Val{API.LLVMLocalAsMetadataMetadataKind}) = LocalAsMetadata
+
+# NOTE: this can be used to both pack e.g. constants as metadata, and to extract the
+#       metadata from an MetadataAsValue, so we don't type-assert narrowly here
+Metadata(val::Value) = Metadata(API.LLVMValueAsMetadata(val))
 
 
 ## values

--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -1,54 +1,88 @@
-export MDString, MDNode, operands, Metadata
+export Metadata
+
+# subtypes are expected to have a 'ref::API.LLVMMetadataRef' field
+abstract type Metadata end
+
+Base.unsafe_convert(::Type{API.LLVMMetadataRef}, md::Metadata) = md.ref
+
+identify(::Type{Metadata}, ref::API.LLVMMetadataRef) =
+    identify(Metadata, Val{API.LLVMGetMetadataKind(ref)}())
+identify(::Type{Metadata}, ::Val{K}) where {K} = error("Unknown metadata kind $K")
+
+@inline function refcheck(::Type{T}, ref::API.LLVMMetadataRef) where T<:Metadata
+    ref==C_NULL && throw(UndefRefError())
+    T′ = identify(Metadata, ref)
+    if T != T′
+        error("invalid conversion of $T′ metadata reference to $T")
+    end
+end
+
+# Construct a concretely typed metadata object from an abstract metadata ref
+function Metadata(ref::API.LLVMMetadataRef)
+    ref == C_NULL && throw(UndefRefError())
+    T = identify(Metadata, ref)
+    return T(ref)
+end
+
+
+## metadata as value
+
+# this is for interfacing with (older) APIs that accept a Value*, not a Metadata*
 
 @checked struct MetadataAsValue <: Value
     ref::API.LLVMValueRef
 end
 identify(::Type{Value}, ::Val{API.LLVMMetadataAsValueValueKind}) = MetadataAsValue
 
-# NOTE: the C API doesn't allow us to differentiate between MD kinds,
-#       all are wrapped by the opaque MetadataAsValue...
+Value(md::Metadata, ctx::Context=GlobalContext()) =
+    MetadataAsValue(API.LLVMMetadataAsValue(ctx, md))
 
-const MDString = MetadataAsValue
+Metadata(val::MetadataAsValue) = Metadata(API.LLVMValueAsMetadata(val))
 
-MDString(val::String) = MDString(API.LLVMMDString(val, length(val)))
 
-MDString(val::String, ctx::Context) =
-    MDString(API.LLVMMDStringInContext(ctx, val, length(val)))
+## values
+
+export MDString
+
+@checked struct MDString <: Metadata
+    ref::API.LLVMMetadataRef
+end
+identify(::Type{Metadata}, ::Val{API.LLVMMDStringMetadataKind}) = MDString
+
+MDString(val::String, ctx::Context=GlobalContext()) =
+    MDString(API.LLVMMDStringInContext2(ctx, val, length(val)))
 
 function Base.string(md::MDString)
     len = Ref{Cuint}()
-    ptr = API.LLVMGetMDString(md, len)
+    ptr = API.LLVMGetMDString(Value(md), len)
     ptr == C_NULL && throw(ArgumentError("invalid metadata, not a MDString?"))
     return unsafe_string(convert(Ptr{Int8}, ptr), len[])
 end
 
 
-const MDNode = MetadataAsValue
+## nodes
 
-MDNode(vals::Vector{<:Value}) =
-    MDNode(API.LLVMMDNode(vals, length(vals)))
+export MDNode, operands
 
-MDNode(vals::Vector{<:Value}, ctx::Context) =
-    MDNode(API.LLVMMDNodeInContext(ctx, vals, length(vals)))
+abstract type MDNode <: Metadata end
 
 function operands(md::MDNode)
-    nops = API.LLVMGetMDNodeNumOperands(md)
+    nops = API.LLVMGetMDNodeNumOperands(Value(md))
     ops = Vector{API.LLVMValueRef}(undef, nops)
-    API.LLVMGetMDNodeOperands(md, ops)
-    return Value[Value(op) for op in ops]
+    API.LLVMGetMDNodeOperands(Value(md), ops)
+    return Metadata[Metadata(Value(op)) for op in ops]
 end
 
 
-@checked struct Metadata
+## tuples
+
+export MDTuple
+
+@checked struct MDTuple <: MDNode
     ref::API.LLVMMetadataRef
 end
+identify(::Type{Metadata}, ::Val{API.LLVMMDTupleMetadataKind}) = MDTuple
 
-Base.unsafe_convert(::Type{API.LLVMMetadataRef}, md::Metadata) = md.ref
-
-function Metadata(val::Value)
-    return Metadata(API.LLVMValueAsMetadata(val))
-end
-
-function Value(md::Metadata, ctx::Context)
-    return MetadataAsValue(API.LLVMMetadataAsValue(ctx, md))
-end
+# MDTuples are commonly referred to as MDNodes, so keep that name
+MDNode(mds::Vector{<:Metadata}, ctx::Context=GlobalContext()) =
+    MDTuple(API.LLVMMDNodeInContext2(ctx, mds, length(mds)))

--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -34,6 +34,7 @@ end
 end
 identify(::Type{Value}, ::Val{API.LLVMMetadataAsValueValueKind}) = MetadataAsValue
 
+# NOTE: we can't do this automatically, as we can't query the context of metadata...
 Value(md::Metadata, ctx::Context=GlobalContext()) =
     MetadataAsValue(API.LLVMMetadataAsValue(ctx, md))
 

--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -104,3 +104,15 @@ identify(::Type{Metadata}, ::Val{API.LLVMMDTupleMetadataKind}) = MDTuple
 # MDTuples are commonly referred to as MDNodes, so keep that name
 MDNode(mds::Vector{<:Metadata}, ctx::Context=GlobalContext()) =
     MDTuple(API.LLVMMDNodeInContext2(ctx, mds, length(mds)))
+
+# for some reason, MDTuples are rendered ugly (`<0x5454150> = !{i64 1, i64 1}`)
+# so override that here
+function Base.show(io::IO, mime::MIME"text/plain", tuple::MDTuple)
+    print(io, "!{")
+    for (i, op) in enumerate(operands(tuple))
+        i > 1 && print(io, ", ")
+        print(io, Value(op))
+    end
+    print(io, "}")
+    return io
+end

--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -57,6 +57,8 @@ identify(::Type{Metadata}, ::Val{API.LLVMLocalAsMetadataMetadataKind}) = LocalAs
 #       metadata from an MetadataAsValue, so we don't type-assert narrowly here
 Metadata(val::Value) = Metadata(API.LLVMValueAsMetadata(val))
 
+Base.convert(::Type{Metadata}, val::Value) = Metadata(val)
+
 
 ## values
 
@@ -88,7 +90,7 @@ function operands(md::MDNode)
     nops = API.LLVMGetMDNodeNumOperands(Value(md))
     ops = Vector{API.LLVMValueRef}(undef, nops)
     API.LLVMGetMDNodeOperands(Value(md), ops)
-    return Metadata[Metadata(Value(op)) for op in ops]
+    return Metadata[Value(op) for op in ops]
 end
 
 
@@ -104,6 +106,8 @@ identify(::Type{Metadata}, ::Val{API.LLVMMDTupleMetadataKind}) = MDTuple
 # MDTuples are commonly referred to as MDNodes, so keep that name
 MDNode(mds::Vector{<:Metadata}, ctx::Context=GlobalContext()) =
     MDTuple(API.LLVMMDNodeInContext2(ctx, mds, length(mds)))
+MDNode(vals::Vector, ctx::Context=GlobalContext()) =
+    MDNode(convert(Vector{Metadata}, vals), ctx)
 
 # for some reason, MDTuples are rendered ugly (`<0x5454150> = !{i64 1, i64 1}`)
 # so override that here

--- a/src/debuginfo.jl
+++ b/src/debuginfo.jl
@@ -1,3 +1,163 @@
+## location information
+
+export DILocation
+
+@checked struct DILocation <: MDNode
+    ref::API.LLVMMetadataRef
+end
+identify(::Type{Metadata}, ::Val{API.LLVMDILocationMetadataKind}) = DILocation
+
+function Base.getproperty(location::DILocation, property::Symbol)
+    if property == :line
+        Int(API.LLVMDILocationGetLine(location))
+    elseif property == :column
+        Int(API.LLVMDILocationGetColumn(location))
+    elseif property === :scope
+        ref = API.LLVMDILocationGetScope(location)
+        ref == C_NULL ? nothing : Metadata(ref)::DIScope
+    elseif property === :inlined_at
+        ref = API.LLVMDILocationGetInlinedAt(location)
+        ref == C_NULL ? nothing : Metadata(ref)::DIScope
+    else
+        getfield(location, property)
+    end
+end
+
+
+## nodes
+
+export DINode
+
+abstract type DINode <: MDNode end
+
+
+## variables
+
+export DIVariable
+
+abstract type DIVariable <: DINode end
+
+for var in (:Local, :Global)
+    var_name = Symbol("DI$(var)Variable")
+    var_kind = Symbol("LLVM$(var_name)MetadataKind")
+    @eval begin
+        @checked struct $var_name <: DIVariable
+            ref::API.LLVMMetadataRef
+        end
+        identify(::Type{Metadata}, ::Val{API.$var_kind}) = $var_name
+    end
+end
+
+function Base.getproperty(var::DIVariable, property::Symbol)
+    if property == :file
+        ref = API.LLVMDIVariableGetFile(var)
+        ref == C_NULL ? nothing : Metadata(ref)::DIFile
+    elseif property === :scope
+        ref = API.LLVMDIVariableGetScope(var)
+        ref == C_NULL ? nothing : Metadata(ref)::DIScope
+    elseif property == :line
+        Int(API.LLVMDIVariableGetLine(var))
+    else
+        getfield(var, property)
+    end
+end
+
+
+## scopes
+
+export DIScope, DILocalScope
+
+abstract type DIScope <: DINode end
+
+abstract type DILocalScope <: DIScope end
+
+
+## file
+
+export DIFile
+
+@checked struct DIFile <: DIScope
+    ref::API.LLVMMetadataRef
+end
+identify(::Type{Metadata}, ::Val{API.LLVMDIFileMetadataKind}) = DIFile
+
+function Base.getproperty(file::DIFile, property::Symbol)
+    if property == :directory
+        len = Ref{Cuint}()
+        data = API.LLVMDIFileGetDirectory(file, len)
+        unsafe_string(convert(Ptr{Int8}, data), len[])
+    elseif property == :filename
+        len = Ref{Cuint}()
+        data = API.LLVMDIFileGetFilename(file, len)
+        unsafe_string(convert(Ptr{Int8}, data), len[])
+    elseif property == :source
+        len = Ref{Cuint}()
+        data = API.LLVMDIFileGetSource(file, len)
+        unsafe_string(convert(Ptr{Int8}, data), len[])
+    else
+        getfield(file, property)
+    end
+end
+
+
+## type
+
+export DIType
+
+abstract type DIType <: DIScope end
+
+for typ in (:Basic, :Derived, :Composite, :Subroutine)
+    typ_name = Symbol("DI$(typ)Type")
+    typ_kind = Symbol("LLVM$(typ_name)MetadataKind")
+    @eval begin
+        @checked struct $typ_name <: DIType
+            ref::API.LLVMMetadataRef
+        end
+        identify(::Type{Metadata}, ::Val{API.$typ_kind}) = $typ_name
+    end
+end
+
+function Base.getproperty(typ::DIType, property::Symbol)
+    if property == :name
+        len = Ref{Csize_t}()
+        data = API.LLVMDITypeGetName(typ, len)
+        unsafe_string(convert(Ptr{Int8}, data), len[])
+    elseif property == :size
+        API.LLVMDITypeGetSizeInBits(typ)
+    elseif property == :offset
+        API.LLVMDITypeGetOffsetInBits(typ)
+    elseif property == :alignment
+        API.LLVMDITypeGetAlignInBits(typ)
+    elseif property == :line
+        API.LLVMDITypeGetLine(typ)
+    elseif property == :flags
+        API.LLVMDITypeGetFlags(typ)
+    else
+        getfield(typ, property)
+    end
+end
+
+
+## subprogram
+
+export DISubProgram
+
+@checked struct DISubProgram <: DIScope
+    ref::API.LLVMMetadataRef
+end
+identify(::Type{Metadata}, ::Val{API.LLVMDISubprogramMetadataKind}) = DISubProgram
+
+function Base.getproperty(subprogram::DISubProgram, property::Symbol)
+    if property == :line
+        API.LLVMDITypeGetLine(subprogram)
+    else
+        getfield(subprogram, property)
+    end
+end
+
+
+## other
+
 export DEBUG_METADATA_VERSION, strip_debuginfo!
 
 DEBUG_METADATA_VERSION() = API.LLVMDebugMetadataVersion()
@@ -6,6 +166,6 @@ strip_debuginfo!(mod::Module) = API.LLVMStripModuleDebugInfo(mod)
 
 function get_subprogram(func::Function)
     ref = API.LLVMGetSubprogram(func)
-    ref==C_NULL ? nothing : Metadata(ref)
+    ref==C_NULL ? nothing : Metadata(ref)::DISubProgram
 end
-set_subprogram!(func::Function, sp::Metadata) = API.LLVMSetSubprogram(func, sp)
+set_subprogram!(func::Function, sp::DISubProgram) = API.LLVMSetSubprogram(func, sp)

--- a/src/dibuilder.jl
+++ b/src/dibuilder.jl
@@ -1,0 +1,5 @@
+function DILocation(ctx, line, col, scope=nothing, inlined_at=nothing)
+    DILocation(API.LLVMDIBuilderCreateDebugLocation(ctx, line, col,
+                                                    something(scope, C_NULL),
+                                                    something(inlined_at, C_NULL)))
+end

--- a/src/dibuilder.jl
+++ b/src/dibuilder.jl
@@ -1,7 +1,0 @@
-export DILocation
-
-function DILocation(ctx, line, col, scope=nothing, inlined_at=nothing)
-    Metadata(API.LLVMDIBuilderCreateDebugLocation(ctx, line, col,
-                                                  something(scope, C_NULL),
-                                                  something(inlined_at, C_NULL)))
-end

--- a/src/dibuilder.jl
+++ b/src/dibuilder.jl
@@ -1,4 +1,6 @@
 function DILocation(ctx, line, col, scope=nothing, inlined_at=nothing)
+    # XXX: are null scopes valid? they crash LLVM:
+    #      DILocation(Context(), 1, 2).scope
     DILocation(API.LLVMDIBuilderCreateDebugLocation(ctx, line, col,
                                                     something(scope, C_NULL),
                                                     something(inlined_at, C_NULL)))

--- a/src/interop/utils.jl
+++ b/src/interop/utils.jl
@@ -5,12 +5,12 @@ function tbaa_make_child(name::String, ctx::LLVM.Context=Context(); constant::Bo
     tbaa_struct_type =
         MDNode(Metadata[MDString("custom_tbaa_$name", ctx),
                         tbaa_root,
-                        Metadata(ConstantInt(0, ctx))], ctx)
+                        ConstantInt(0, ctx)], ctx)
     tbaa_access_tag =
         MDNode(Metadata[tbaa_struct_type,
                         tbaa_struct_type,
-                        Metadata(ConstantInt(0, ctx)),
-                        Metadata(ConstantInt(constant ? 1 : 0, ctx))], ctx)
+                        ConstantInt(0, ctx),
+                        ConstantInt(constant ? 1 : 0, ctx)], ctx)
 
     return tbaa_access_tag
 end

--- a/src/interop/utils.jl
+++ b/src/interop/utils.jl
@@ -3,14 +3,14 @@ export tbaa_make_child, tbaa_addrspace
 function tbaa_make_child(name::String, ctx::LLVM.Context=Context(); constant::Bool=false)
     tbaa_root = MDNode([MDString("custom_tbaa", ctx)], ctx)
     tbaa_struct_type =
-        MDNode([MDString("custom_tbaa_$name", ctx),
-                tbaa_root,
-                LLVM.ConstantInt(0, ctx)], ctx)
+        MDNode(Metadata[MDString("custom_tbaa_$name", ctx),
+                        tbaa_root,
+                        Metadata(ConstantInt(0, ctx))], ctx)
     tbaa_access_tag =
-        MDNode([tbaa_struct_type,
-                tbaa_struct_type,
-                LLVM.ConstantInt(0, ctx),
-                LLVM.ConstantInt(constant ? 1 : 0, ctx)], ctx)
+        MDNode(Metadata[tbaa_struct_type,
+                        tbaa_struct_type,
+                        Metadata(ConstantInt(0, ctx)),
+                        Metadata(ConstantInt(constant ? 1 : 0, ctx))], ctx)
 
     return tbaa_access_tag
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -655,7 +655,7 @@ Context() do ctx
     loc = DILocation(ctx, 2, 3)
     @test loc.line == 2
     @test loc.column == 3
-    @test loc.scope === nothing
+    #@test loc.scope === nothing    # trips up an assertion
     @test loc.inlined_at === nothing
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -653,10 +653,10 @@ end
 
 Context() do ctx
     loc = DILocation(ctx, 2, 3)
-    @test loc.line == 2
-    @test loc.column == 3
-    #@test loc.scope === nothing    # trips up an assertion
-    @test loc.inlined_at === nothing
+    @test LLVM.line(loc) == 2
+    @test LLVM.column(loc) == 3
+    #@test LLVM.scope(loc) === nothing    # trips up an assertion
+    @test LLVM.inlined_at(loc) === nothing
 end
 
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -791,11 +791,11 @@ LLVM.Module("SomeModule", ctx) do mod
         @test valtype(mds) == NamedMDNode
 
         @test !haskey(mds, "SomeMDNode")
-        @test !(node in collect(operands(mds["SomeMDNode"])))
-        @test haskey(mds, "SomeMDNode")
+        @test !(node in operands(mds["SomeMDNode"]))
+        @test haskey(mds, "SomeMDNode") # getindex is mutating
 
-        push!(operands(mds["SomeMDNode"]), node)
-        @test node in collect(operands(mds["SomeMDNode"]))
+        push!(mds["SomeMDNode"], node)
+        @test node in operands(mds["SomeMDNode"])
     end
 end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -720,16 +720,14 @@ LLVM.Module("SomeModule", ctx) do mod
 
     let mds = metadata(mod)
         @test keytype(mds) == String
-        @test valtype(mds) == Vector{LLVM.Metadata}
+        @test valtype(mds) == NamedMDNode
 
-        push!(mds, "SomeMDNode", node)
-
+        @test !haskey(mds, "SomeMDNode")
+        @test !(node in collect(operands(mds["SomeMDNode"])))
         @test haskey(mds, "SomeMDNode")
-        mdvals = mds["SomeMDNode"]
-        @test mdvals[1] == node
 
-        @test !haskey(mds, "SomeOtherMDNode")
-        @test_throws KeyError mds["SomeOtherMDNode"]
+        push!(operands(mds["SomeMDNode"]), node)
+        @test node in collect(operands(mds["SomeMDNode"]))
     end
 end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -651,6 +651,14 @@ Context() do ctx
     @test ops[1] == str
 end
 
+Context() do ctx
+    loc = DILocation(ctx, 2, 3)
+    @test loc.line == 2
+    @test loc.column == 3
+    @test loc.scope === nothing
+    @test loc.inlined_at === nothing
+end
+
 end
 
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -651,12 +651,80 @@ Context() do ctx
     @test ops[1] == str
 end
 
+@testset "debuginfo" begin
+
 Context() do ctx
-    loc = DILocation(ctx, 2, 3)
-    @test LLVM.line(loc) == 2
-    @test LLVM.column(loc) == 3
-    #@test LLVM.scope(loc) === nothing    # trips up an assertion
-    @test LLVM.inlined_at(loc) === nothing
+mod = parse(LLVM.Module, raw"""
+       define double @test(i64 signext %0, double %1) !dbg !5 {
+       top:
+         %2 = sitofp i64 %0 to double, !dbg !7
+         %3 = fadd double %2, %1, !dbg !18
+         ret double %3, !dbg !17
+       }
+
+       !llvm.module.flags = !{!0, !1}
+       !llvm.dbg.cu = !{!2}
+
+       !0 = !{i32 2, !"Dwarf Version", i32 4}
+       !1 = !{i32 1, !"Debug Info Version", i32 3}
+       !2 = distinct !DICompileUnit(language: DW_LANG_Julia, file: !3, producer: "julia", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, nameTableKind: GNU)
+       !3 = !DIFile(filename: "promotion.jl", directory: ".")
+       !4 = !{}
+       !5 = distinct !DISubprogram(name: "+", linkageName: "julia_+_2055", scope: null, file: !3, line: 321, type: !6, scopeLine: 321, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !4)
+       !6 = !DISubroutineType(types: !4)
+       !7 = !DILocation(line: 94, scope: !8, inlinedAt: !10)
+       !8 = distinct !DISubprogram(name: "Float64;", linkageName: "Float64", scope: !9, file: !9, type: !6, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !4)
+       !9 = !DIFile(filename: "float.jl", directory: ".")
+       !10 = !DILocation(line: 7, scope: !11, inlinedAt: !13)
+       !11 = distinct !DISubprogram(name: "convert;", linkageName: "convert", scope: !12, file: !12, type: !6, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !4)
+       !12 = !DIFile(filename: "number.jl", directory: ".")
+       !13 = !DILocation(line: 269, scope: !14, inlinedAt: !15)
+       !14 = distinct !DISubprogram(name: "_promote;", linkageName: "_promote", scope: !3, file: !3, type: !6, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !4)
+       !15 = !DILocation(line: 292, scope: !16, inlinedAt: !17)
+       !16 = distinct !DISubprogram(name: "promote;", linkageName: "promote", scope: !3, file: !3, type: !6, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !4)
+       !17 = !DILocation(line: 321, scope: !5)
+       !18 = !DILocation(line: 326, scope: !19, inlinedAt: !17)
+       !19 = distinct !DISubprogram(name: "+;", linkageName: "+", scope: !9, file: !9, type: !6, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !4)""", ctx)
+
+    fun = functions(mod)["test"]
+    bb = first(collect(blocks(fun)))
+    inst = first(collect(instructions(bb)))
+
+    @test haskey(metadata(inst), LLVM.MD_dbg)
+    loc = metadata(inst)[LLVM.MD_dbg]
+
+    @test loc isa DILocation
+    @test LLVM.line(loc) == 94
+    @test LLVM.column(loc) == 0
+
+    scope = LLVM.scope(loc)
+    @test scope isa DISubProgram
+    @test LLVM.line(scope) == 0
+    @test LLVM.name(scope) == "Float64;"
+
+    file = LLVM.file(scope)
+    @test file isa DIFile
+    @test LLVM.filename(file) == "float.jl"
+    @test LLVM.directory(file) == "."
+    @test LLVM.source(file) == ""
+
+    loc = LLVM.inlined_at(loc)
+    @test loc isa DILocation
+    @test LLVM.line(loc) == 7
+
+    loc = LLVM.inlined_at(loc)
+    @test loc isa DILocation
+
+    loc = LLVM.inlined_at(loc)
+    @test loc isa DILocation
+
+    loc = LLVM.inlined_at(loc)
+    @test loc isa DILocation
+
+    loc = LLVM.inlined_at(loc)
+    @test loc === nothing
+end
+
 end
 
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -720,7 +720,7 @@ LLVM.Module("SomeModule", ctx) do mod
 
     let mds = metadata(mod)
         @test keytype(mds) == String
-        @test valtype(mds) == Vector{LLVM.MetadataAsValue}
+        @test valtype(mds) == Vector{LLVM.Metadata}
 
         push!(mds, "SomeMDNode", node)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1153,10 +1153,6 @@ LLVM.Module("SomeModule", ctx) do mod
         @test isempty(md)
         @test !haskey(md, LLVM.MD_dbg)
     end
-    let val = ConstantInt(42, ctx)
-        md = Metadata(val)
-        @test first(operands(LLVM.Value(md, ctx))) == val
-    end
 
     @test retinst in instructions(bb3)
     delete!(bb3, retinst)


### PR DESCRIPTION
Because **somebody** removed the `LLVMGetSourceLocation` API we had hacked in Julia, I decided to properly flesh out our coverage of the (read only) parts of the Metadata API.

Breaking changes:
- metadata is now represented as `Metadata` nodes in LLVM, and not directly as `MetadataAsValue` wrappers. That means metadata isn't a value anymore, so you'll need to add `Value(...)` calls where you actually need a value instead of raw metadata.
- named module metadata iteration has been reworked to more closely match the LLVM APIs. Essentially, you need to fetch the metadata using `metadata(mod)[...]`, and then `push!(...)` to append metadata nodes.