### PR TITLE
Make the context a compulsory keyword argument of most APIs.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -34,9 +34,9 @@ version = "1.3.0"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ca0fc51947aab764bd8c6f9dd8a91ba3da8647c7"
+git-tree-sha1 = "99200ba262364a8502e5a0cca0057cf7c60901d7"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.3+0"
+version = "0.0.4+0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-LLVMExtra_jll = "0.0.3"
+LLVMExtra_jll = "0.0.4"
 julia = "1.6"

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -58,7 +58,23 @@ void LLVMExtraAppendToCompilerUsed(LLVMModuleRef Mod,
                                    size_t Count);
 void LLVMExtraAddGenericAnalysisPasses(LLVMPassManagerRef PM);
 
+void LLVMExtraDumpMetadata(LLVMMetadataRef MD);
+
+char* LLVMExtraPrintMetadataToString(LLVMMetadataRef MD);
+
 const char *LLVMExtraDIScopeGetName(LLVMMetadataRef File, unsigned *Len);
+
+const char *LLVMExtraGetMDString2(LLVMMetadataRef MD, unsigned *Length);
+
+unsigned LLVMExtraGetMDNodeNumOperands2(LLVMMetadataRef MD);
+
+void LLVMExtraGetMDNodeOperands2(LLVMMetadataRef MD, LLVMMetadataRef *Dest);
+
+unsigned LLVMExtraGetNamedMetadataNumOperands2(LLVMNamedMDNodeRef NMD);
+
+void LLVMExtraGetNamedMetadataOperands2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef *Dest);
+
+void LLVMExtraAddNamedMetadataOperand2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef Val);
 
 // Bug fixes
 void LLVMExtraSetInitializer(LLVMValueRef GlobalVar, LLVMValueRef ConstantVal);

--- a/examples/Kaleidoscope/codegen.jl
+++ b/examples/Kaleidoscope/codegen.jl
@@ -9,7 +9,7 @@ mutable struct CodeGen
             ctx,
             LLVM.Builder(ctx),
             CurrentScope(),
-            LLVM.Module("KaleidoscopeModule", ctx),
+            LLVM.Module("KaleidoscopeModule"; ctx),
         )
 end
 
@@ -82,7 +82,7 @@ end
 
 function codegen(cg::CodeGen, expr::CallExprAST)
     if !haskey(LLVM.functions(cg.mod), expr.callee)
-        error("encountered undeclared function $(expr.callee)")        
+        error("encountered undeclared function $(expr.callee)")
     end
     func =  LLVM.functions(cg.mod)[expr.callee]
 
@@ -117,7 +117,7 @@ function codegen(cg::CodeGen, expr::FunctionAST)
     # create new function...
     the_function = codegen(cg, expr.proto)
 
-    entry = LLVM.BasicBlock(the_function, "entry", cg.ctx)
+    entry = LLVM.BasicBlock(the_function, "entry"; cg.ctx)
     LLVM.position!(cg.builder, entry)
 
     new_scope(cg) do
@@ -137,9 +137,9 @@ end
 
 function codegen(cg::CodeGen, expr::IfExprAST)
     func = LLVM.parent(LLVM.position(cg.builder))
-    then = LLVM.BasicBlock(func, "then", cg.ctx)
-    elsee = LLVM.BasicBlock(func, "else", cg.ctx)
-    merge = LLVM.BasicBlock(func, "ifcont", cg.ctx)
+    then = LLVM.BasicBlock(func, "then"; cg.ctx)
+    elsee = LLVM.BasicBlock(func, "else"; cg.ctx)
+    merge = LLVM.BasicBlock(func, "ifcont"; cg.ctx)
 
     local phi
     new_scope(cg) do
@@ -181,7 +181,7 @@ function codegen(cg::CodeGen, expr::ForExprAST)
         LLVM.store!(cg.builder, start, alloc)
 
         # Loop block
-        loopblock = LLVM.BasicBlock(func, "loop", cg.ctx)
+        loopblock = LLVM.BasicBlock(func, "loop"; cg.ctx)
         LLVM.br!(cg.builder, loopblock)
         LLVM.position!(cg.builder, loopblock)
 
@@ -198,7 +198,7 @@ function codegen(cg::CodeGen, expr::ForExprAST)
             LLVM.ConstantFP(LLVM.DoubleType(cg.ctx), 0.0))
 
         loopendblock = position(cg.builder)
-        afterblock = LLVM.BasicBlock(func, "afterloop", cg.ctx)
+        afterblock = LLVM.BasicBlock(func, "afterloop"; cg.ctx)
 
         LLVM.br!(cg.builder, endd, loopblock, afterblock)
         LLVM.position!(cg.builder, afterblock)

--- a/examples/Kaleidoscope/run.jl
+++ b/examples/Kaleidoscope/run.jl
@@ -1,4 +1,4 @@
-function generate_IR(str, ctx::LLVM.Context=LLVM.GlobalContext())
+function generate_IR(str; ctx::LLVM.Context)
     cg = CodeGen(ctx)
     ps = Parser(str)
     while true
@@ -35,7 +35,7 @@ function run(mod::LLVM.Module, entry::String)
         end
         f = LLVM.functions(engine)[entry]
         res = LLVM.run(engine, f)
-        res_jl = convert(Float64, res, LLVM.DoubleType())
+        res_jl = convert(Float64, res, LLVM.DoubleType(LLVM.context(mod)))
         LLVM.dispose(res)
     end
     return res_jl

--- a/examples/constrained.jl
+++ b/examples/constrained.jl
@@ -34,7 +34,7 @@ meta(::Type{FPExceptStrict}) = "fpexcept.strict"
     @assert N >= 0
 
     Context() do ctx
-        typ = convert(LLVMType, T, ctx)
+        typ = convert(LLVMType, T; ctx)
 
         # create a function
         paramtyps = [typ for i in 1:N]
@@ -42,8 +42,8 @@ meta(::Type{FPExceptStrict}) = "fpexcept.strict"
 
         # create the intrinsic
         mtyp = LLVM.MetadataType(ctx)
-        mround = MDString(meta(round), ctx)
-        mfpexcept = MDString(meta(fpexcept), ctx)
+        mround = MDString(meta(round); ctx)
+        mfpexcept = MDString(meta(fpexcept); ctx)
         mod = LLVM.parent(llvm_f)
         intrinsic_typ = LLVM.FunctionType(typ, [paramtyps..., mtyp, mtyp])
         intrinsic = LLVM.Function(mod, "llvm.experimental.constrained.$(func(F)).$(suffix(T))",
@@ -51,10 +51,10 @@ meta(::Type{FPExceptStrict}) = "fpexcept.strict"
 
         # generate IR
         Builder(ctx) do builder
-            entry = BasicBlock(llvm_f, "entry", ctx)
+            entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
             val = call!(builder, intrinsic,
-                        [parameters(llvm_f)..., Value(mround, ctx), Value(mfpexcept, ctx)])
+                        [parameters(llvm_f)..., Value(mround; ctx), Value(mfpexcept; ctx)])
             ret!(builder, val)
         end
 

--- a/examples/generated.jl
+++ b/examples/generated.jl
@@ -11,9 +11,9 @@ end
 @generated function Base.unsafe_load(p::CustomPtr{T}, i::Integer=1) where T
     Context() do ctx
         # get the element type
-        eltyp = convert(LLVMType, T, ctx)
+        eltyp = convert(LLVMType, T; ctx)
 
-        T_int = LLVM.IntType(sizeof(Int)*8, ctx)
+        T_int = LLVM.IntType(sizeof(Int)*8; ctx)
         T_ptr = LLVM.PointerType(eltyp)
 
         # create a function
@@ -22,7 +22,7 @@ end
 
         # generate IR
         Builder(ctx) do builder
-            entry = BasicBlock(llvmf, "entry", ctx)
+            entry = BasicBlock(llvmf, "entry"; ctx)
             position!(builder, entry)
 
             ptr = inttoptr!(builder, parameters(llvmf)[1], T_ptr)

--- a/examples/sum_integrated.jl
+++ b/examples/sum_integrated.jl
@@ -19,7 +19,7 @@ Context() do ctx
 
     # generate IR
     Builder(ctx) do builder
-        entry = BasicBlock(sum, "entry", ctx)
+        entry = BasicBlock(sum, "entry"; ctx)
         position!(builder, entry)
 
         tmp = add!(builder, parameters(sum)[1], parameters(sum)[2], "tmp")
@@ -27,7 +27,7 @@ Context() do ctx
     end
 
     # make Julia compile and execute the function
-    push!(function_attributes(sum), EnumAttribute("alwaysinline"))
+    push!(function_attributes(sum), EnumAttribute("alwaysinline"; ctx))
     @eval call_sum(x, y) = $(call_function(sum, Int32, Tuple{Int32, Int32}, :x, :y))
 end
 

--- a/examples/sum_orc.jl
+++ b/examples/sum_orc.jl
@@ -28,7 +28,7 @@ Context() do ctx
     ret_type = LLVM.Int32Type(ctx)
 
     name = mangle(orc, "sum_orc.jl")
-    mod = LLVM.Module("jit", ctx)
+    mod = LLVM.Module("jit"; ctx)
     triple!(mod, triple(tm))
 
     ft = LLVM.FunctionType(ret_type, param_types)
@@ -36,7 +36,7 @@ Context() do ctx
 
     # generate IR
     Builder(ctx) do builder
-        entry = BasicBlock(sum, "entry", ctx)
+        entry = BasicBlock(sum, "entry"; ctx)
         position!(builder, entry)
 
         tmp = add!(builder, parameters(sum)[1], parameters(sum)[2], "tmp")

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -147,8 +147,40 @@ end
     LLVMDebugEmissionKindDebugDirectivesOnly = 3,
 )
 
+function LLVMExtraDumpMetadata(MD)
+    ccall((:LLVMExtraDumpMetadata, libLLVMExtra), Cvoid, (LLVMMetadataRef,), MD)
+end
+
+function LLVMExtraPrintMetadataToString(MD)
+    ccall((:LLVMExtraPrintMetadataToString, libLLVMExtra), Cstring, (LLVMMetadataRef,), MD)
+end
+
 function LLVMExtraDIScopeGetName(Scope, Len)
     ccall((:LLVMExtraDIScopeGetName, libLLVMExtra), Cstring, (LLVMMetadataRef, Ptr{Cuint}), Scope, Len)
+end
+
+function LLVMExtraGetMDString2(MD, Len)
+    ccall((:LLVMExtraGetMDString2, libLLVMExtra), Cstring, (LLVMMetadataRef, Ptr{Cuint}), MD, Len)
+end
+
+function LLVMExtraGetMDNodeNumOperands2(MD)
+    ccall((:LLVMExtraGetMDNodeNumOperands2, libLLVMExtra), Cuint, (LLVMMetadataRef,), MD)
+end
+
+function LLVMExtraGetMDNodeOperands2(MD, Dest)
+    ccall((:LLVMExtraGetMDNodeOperands2, libLLVMExtra), Cvoid, (LLVMMetadataRef, Ptr{LLVMMetadataRef}), MD, Dest)
+end
+
+function LLVMExtraGetNamedMetadataNumOperands2(NMD)
+    ccall((:LLVMExtraGetNamedMetadataNumOperands2, libLLVMExtra), Cuint, (LLVMNamedMDNodeRef,), NMD)
+end
+
+function LLVMExtraGetNamedMetadataOperands2(NMD, Dest)
+    ccall((:LLVMExtraGetNamedMetadataOperands2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, Ptr{LLVMMetadataRef}), NMD, Dest)
+end
+
+function LLVMExtraAddNamedMetadataOperand2(NMD, Val)
+    ccall((:LLVMExtraAddNamedMetadataOperand2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, LLVMMetadataRef), NMD, Val)
 end
 
 

--- a/src/bitcode.jl
+++ b/src/bitcode.jl
@@ -1,14 +1,6 @@
 ## reader
-function Base.parse(::Type{Module}, membuf::MemoryBuffer)
-    out_ref = Ref{API.LLVMModuleRef}()
 
-    status = convert(Core.Bool, API.LLVMParseBitcode2(membuf, out_ref))
-    @assert !status # caught by diagnostics handler
-
-    Module(out_ref[])
-end
-
-function Base.parse(::Type{Module}, membuf::MemoryBuffer, ctx::Context)
+function Base.parse(::Type{Module}, membuf::MemoryBuffer; ctx::Context)
     out_ref = Ref{API.LLVMModuleRef}()
 
     status = convert(Core.Bool, API.LLVMParseBitcodeInContext2(ctx, membuf, out_ref))
@@ -17,10 +9,8 @@ function Base.parse(::Type{Module}, membuf::MemoryBuffer, ctx::Context)
     Module(out_ref[])
 end
 
-Base.parse(::Type{Module}, data::Vector) =
-    parse(Module, MemoryBuffer(data, "", false))
-Base.parse(::Type{Module}, data::Vector, ctx::Context) =
-    parse(Module, MemoryBuffer(data, "", false), ctx)
+Base.parse(::Type{Module}, data::Vector; ctx::Context) =
+    parse(Module, MemoryBuffer(data, "", false); ctx)
 
 
 ## writer

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -17,8 +17,8 @@ function MemoryBuffer(data::Vector{T}, name::String="", copy::Core.Bool=true) wh
     end
 end
 
-function MemoryBuffer(f::Core.Function, args...)
-    membuf = MemoryBuffer(args...)
+function MemoryBuffer(f::Core.Function, args...; kwargs...)
+    membuf = MemoryBuffer(args...; kwargs...)
     try
         f(membuf)
     finally
@@ -41,8 +41,8 @@ function MemoryBufferFile(path::String)
     MemoryBuffer(out_ref[])
 end
 
-function MemoryBufferFile(f::Core.Function, args...)
-    membuf = MemoryBufferFile(args...)
+function MemoryBufferFile(f::Core.Function, args...; kwargs...)
+    membuf = MemoryBufferFile(args...; kwargs...)
     try
         f(membuf)
     finally

--- a/src/core/attributes.jl
+++ b/src/core/attributes.jl
@@ -41,7 +41,7 @@ end
 # NOTE: the AttrKind enum is not exported in the C API,
 #       so we don't expose a way to construct EnumAttribute from its raw enum value
 #       (which also would conflict with the inner ref constructor)
-function EnumAttribute(kind::String, value::Integer=0, ctx::Context=GlobalContext())
+function EnumAttribute(kind::String, value::Integer=0; ctx::Context)
     enum_kind = API.LLVMGetEnumAttributeKindForName(kind, Csize_t(length(kind)))
     return EnumAttribute(API.LLVMCreateEnumAttribute(ctx, enum_kind, UInt64(value)))
 end
@@ -53,7 +53,7 @@ value(attr::EnumAttribute) = API.LLVMGetEnumAttributeValue(attr)
 
 ## string attribute
 
-StringAttribute(kind::String, value::String="", ctx::Context=GlobalContext()) =
+StringAttribute(kind::String, value::String=""; ctx::Context) =
     StringAttribute(API.LLVMCreateStringAttribute(ctx, kind, length(kind),
                                                   value, length(value)))
 

--- a/src/core/basicblock.jl
+++ b/src/core/basicblock.jl
@@ -15,13 +15,9 @@ Base.unsafe_convert(::Type{API.LLVMBasicBlockRef}, bb::BasicBlock) = API.LLVMVal
     ref::API.LLVMValueRef
 end
 
-BasicBlock(f::Function, name::String) =
-    BasicBlock(API.LLVMAppendBasicBlock(f, name))
-BasicBlock(f::Function, name::String, ctx::Context) =
+BasicBlock(f::Function, name::String; ctx::Context) =
     BasicBlock(API.LLVMAppendBasicBlockInContext(ctx, f, name))
-BasicBlock(bb::BasicBlock, name::String) =
-    BasicBlock(API.LLVMInsertBasicBlock(bb, name))
-BasicBlock(bb::BasicBlock, name::String, ctx::Context) =
+BasicBlock(bb::BasicBlock, name::String; ctx::Context) =
     BasicBlock(API.LLVMInsertBasicBlockInContext(ctx, bb, name))
 
 unsafe_delete!(::Function, bb::BasicBlock) = API.LLVMDeleteBasicBlock(bb)

--- a/src/core/function.jl
+++ b/src/core/function.jl
@@ -184,7 +184,7 @@ function Function(mod::Module, intr::Intrinsic, params::Vector{<:LLVMType}=LLVMT
 end
 
 function FunctionType(intr::Intrinsic, params::Vector{<:LLVMType}=LLVMType[];
-                  ctx::Context=GlobalContext())
+                      ctx::Context=only(unique(map(context, params))))
     LLVMType(API.LLVMIntrinsicGetType(ctx, intr, params, length(params)))
 end
 

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -90,7 +90,7 @@ function Base.getindex(md::InstructionMetadataDict, kind::MD)
   end
 
 Base.setindex!(md::InstructionMetadataDict, node::Metadata, kind::MD) =
-    API.LLVMSetMetadata(md.inst, kind, Value(node, context(md.inst)))
+    API.LLVMSetMetadata(md.inst, kind, Value(node; ctx=context(md.inst)))
 
 Base.delete!(md::InstructionMetadataDict, kind::MD) =
     API.LLVMSetMetadata(md.inst, kind, C_NULL)

--- a/src/datalayout.jl
+++ b/src/datalayout.jl
@@ -14,8 +14,8 @@ DataLayout(rep::String) = DataLayout(API.LLVMCreateTargetData(rep))
 
 DataLayout(tm::TargetMachine) = DataLayout(API.LLVMCreateTargetDataLayout(tm))
 
-function DataLayout(f::Core.Function, args...)
-    data = DataLayout(args...)
+function DataLayout(f::Core.Function, args...; kwargs...)
+    data = DataLayout(args...; kwargs...)
     try
         f(data)
     finally
@@ -38,12 +38,9 @@ pointersize(data::DataLayout) = API.LLVMPointerSize(data)
 pointersize(data::DataLayout, addrspace::Integer) =
     API.LLVMPointerSizeForAS(data, addrspace)
 
-intptr(data::DataLayout) = IntegerType(API.LLVMIntPtrType(data))
-intptr(data::DataLayout, addrspace::Integer) =
-    IntegerType(API.LLVMIntPtrTypeForAS(data, addrspace))
-intptr(data::DataLayout, ctx::Context) =
+intptr(data::DataLayout; ctx::Context) =
     IntegerType(API.LLVMIntPtrTypeInContext(ctx, data))
-intptr(data::DataLayout, addrspace::Integer, ctx::Context) =
+intptr(data::DataLayout, addrspace::Integer; ctx::Context) =
     IntegerType(API.LLVMIntPtrTypeForASInContext(ctx, data, addrspace))
 
 Base.sizeof(data::DataLayout, typ::LLVMType) =

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -113,8 +113,8 @@ function dispose(engine::ExecutionEngine)
 end
 
 for x in [:ExecutionEngine, :Interpreter, :JIT]
-    @eval function $x(f::Core.Function, args...)
-        engine = $x(args...)
+    @eval function $x(f::Core.Function, args...; kwargs...)
+        engine = $x(args...; kwargs...)
         try
             f(engine)
         finally

--- a/src/interop/asmcall.jl
+++ b/src/interop/asmcall.jl
@@ -5,15 +5,15 @@ export @asmcall
                             {asm, constraints, side_effects, rettyp, argtyp}
     Context() do ctx
         # create a function
-        llvm_rettyp = convert(LLVMType, rettyp, ctx)
-        llvm_argtyp = LLVMType[convert.(LLVMType, [argtyp.parameters...], Ref(ctx))...]
+        llvm_rettyp = convert(LLVMType, rettyp; ctx)
+        llvm_argtyp = LLVMType[convert.(LLVMType, [argtyp.parameters...]; ctx)...]
         llvm_f, llvm_ft = create_function(llvm_rettyp, llvm_argtyp)
 
         inline_asm = InlineAsm(llvm_ft, String(asm), String(constraints), side_effects)
 
         # generate IR
         Builder(ctx) do builder
-            entry = BasicBlock(llvm_f, "entry", ctx)
+            entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 
             val = call!(builder, inline_asm, collect(parameters(llvm_f)))

--- a/src/interop/utils.jl
+++ b/src/interop/utils.jl
@@ -1,18 +1,18 @@
 export tbaa_make_child, tbaa_addrspace
 
-function tbaa_make_child(name::String, ctx::LLVM.Context=Context(); constant::Bool=false)
-    tbaa_root = MDNode([MDString("custom_tbaa", ctx)], ctx)
+function tbaa_make_child(name::String; constant::Bool=false, ctx::LLVM.Context)
+    tbaa_root = MDNode([MDString("custom_tbaa"; ctx)]; ctx)
     tbaa_struct_type =
-        MDNode(Metadata[MDString("custom_tbaa_$name", ctx),
-                        tbaa_root,
-                        ConstantInt(0, ctx)], ctx)
+        MDNode([MDString("custom_tbaa_$name"; ctx),
+                tbaa_root,
+                ConstantInt(0; ctx)]; ctx)
     tbaa_access_tag =
-        MDNode(Metadata[tbaa_struct_type,
-                        tbaa_struct_type,
-                        ConstantInt(0, ctx),
-                        ConstantInt(constant ? 1 : 0, ctx)], ctx)
+        MDNode([tbaa_struct_type,
+                tbaa_struct_type,
+                ConstantInt(0; ctx),
+                ConstantInt(constant ? 1 : 0; ctx)]; ctx)
 
     return tbaa_access_tag
 end
 
-tbaa_addrspace(as, ctx::LLVM.Context=Context()) = tbaa_make_child("addrspace($(as))", ctx)
+tbaa_addrspace(as; ctx::LLVM.Context) = tbaa_make_child("addrspace($(as))"; ctx)

--- a/src/ir.jl
+++ b/src/ir.jl
@@ -1,6 +1,6 @@
 ## reader
 
-function Base.parse(::Type{Module}, ir::String, ctx::Context=GlobalContext())
+function Base.parse(::Type{Module}, ir::String; ctx::Context)
     data = unsafe_wrap(Vector{UInt8}, ir)
     membuf = MemoryBuffer(data, "", false)
 

--- a/src/irbuilder.jl
+++ b/src/irbuilder.jl
@@ -11,13 +11,12 @@ end
 
 Base.unsafe_convert(::Type{API.LLVMBuilderRef}, builder::Builder) = builder.ref
 
-Builder() = Builder(API.LLVMCreateBuilder())
 Builder(ctx::Context) = Builder(API.LLVMCreateBuilderInContext(ctx))
 
 dispose(builder::Builder) = API.LLVMDisposeBuilder(builder)
 
-function Builder(f::Core.Function, args...)
-    builder = Builder(args...)
+function Builder(f::Core.Function, args...; kwargs...)
+    builder = Builder(args...; kwargs...)
     try
         f(builder)
     finally

--- a/src/moduleprovider.jl
+++ b/src/moduleprovider.jl
@@ -12,8 +12,8 @@ Base.unsafe_convert(::Type{API.LLVMModuleProviderRef}, mp::ModuleProvider) = mp.
 ModuleProvider(mod::Module) =
     ModuleProvider(API.LLVMCreateModuleProviderForExistingModule(mod))
 
-function ModuleProvider(f::Core.Function, args...)
-    mp = ModuleProvider(args...)
+function ModuleProvider(f::Core.Function, args...; kwargs...)
+    mp = ModuleProvider(args...; kwargs...)
     try
         f(mp)
     finally

--- a/src/orc.jl
+++ b/src/orc.jl
@@ -6,7 +6,7 @@ export dispose, errormsg, compile!, remove!, add!,
        register!, unregister!, callback!
 export JITTargetMachine
 
-@checked struct OrcJIT 
+@checked struct OrcJIT
     ref::API.LLVMOrcJITStackRef
 end
 
@@ -42,11 +42,11 @@ end
 
 function errormsg(orc::OrcJIT)
     # The error message is owned by `orc`, and will
-    # be disposed along-side the OrcJIT. 
+    # be disposed along-side the OrcJIT.
     unsafe_string(LLVM.API.LLVMOrcGetErrorMsg(orc))
 end
 
-struct OrcModule 
+struct OrcModule
     handle::API.LLVMOrcModuleHandle
 end
 Base.convert(::Type{API.LLVMOrcModuleHandle}, mod::OrcModule) = mod.handle
@@ -154,7 +154,7 @@ function callback!(orc::OrcJIT, callback, ctx)
     return OrcTargetAddress(r_address[])
 end
 
-@checked struct JITEventListener 
+@checked struct JITEventListener
     ref::API.LLVMJITEventListenerRef
 end
 Base.unsafe_convert(::Type{API.LLVMJITEventListenerRef}, listener::JITEventListener) = listener.ref
@@ -172,9 +172,8 @@ IntelJITEventListener()    = JITEventListener(LLVM.API.LLVMCreateIntelJITEventLi
 OProfileJITEventListener() = JITEventListener(LLVM.API.LLVMCreateOProfileJITEventListener())
 PerfJITEventListener()     = JITEventListener(LLVM.API.LLVMCreatePerfJITEventListener())
 
-function JITTargetMachine(;triple = LLVM.triple(),
-                           cpu = "", features = "",
-                           optlevel = LLVM.API.LLVMCodeGenLevelDefault)
+function JITTargetMachine(triple = LLVM.triple(), cpu = "", features = "";
+                          optlevel = LLVM.API.LLVMCodeGenLevelDefault)
 
     # Force ELF on windows,
     # Note: Without this call to normalize Orc get's confused
@@ -186,10 +185,9 @@ function JITTargetMachine(;triple = LLVM.triple(),
     target = LLVM.Target(triple=triple)
     @debug "Configuring OrcJIT with" triple cpu features optlevel
 
-    tm = TargetMachine(target, triple, cpu, features,
-                       optlevel,
-                       LLVM.API.LLVMRelocStatic, # Generate simpler code for JIT
-                       LLVM.API.LLVMCodeModelJITDefault, # Required to init TM as JIT
+    tm = TargetMachine(target, triple, cpu, features; optlevel,
+                       reloc=LLVM.API.LLVMRelocStatic, # Generate simpler code for JIT
+                       code=LLVM.API.LLVMCodeModelJITDefault, # Required to init TM as JIT
                        )
-    return tm 
+    return tm
 end

--- a/src/passmanager.jl
+++ b/src/passmanager.jl
@@ -27,8 +27,8 @@ end
 
 ModulePassManager() = ModulePassManager(API.LLVMCreatePassManager(), [])
 
-function ModulePassManager(f::Core.Function, args...)
-    mpm = ModulePassManager(args...)
+function ModulePassManager(f::Core.Function, args...; kwargs...)
+    mpm = ModulePassManager(args...; kwargs...)
     try
         f(mpm)
     finally
@@ -56,8 +56,8 @@ end
 FunctionPassManager(mod::Module) =
     FunctionPassManager(API.LLVMCreateFunctionPassManagerForModule(mod), [])
 
-function FunctionPassManager(f::Core.Function, args...)
-    fpm = FunctionPassManager(args...)
+function FunctionPassManager(f::Core.Function, args...; kwargs...)
+    fpm = FunctionPassManager(args...; kwargs...)
     try
         f(fpm)
     finally

--- a/src/targetmachine.jl
+++ b/src/targetmachine.jl
@@ -10,7 +10,7 @@ end
 
 Base.unsafe_convert(::Type{API.LLVMTargetMachineRef}, tm::TargetMachine) = tm.ref
 
-TargetMachine(t::Target, triple::String, cpu::String="", features::String="",
+TargetMachine(t::Target, triple::String, cpu::String="", features::String="";
               optlevel::API.LLVMCodeGenOptLevel=API.LLVMCodeGenLevelDefault,
               reloc::API.LLVMRelocMode=API.LLVMRelocDefault,
               code::API.LLVMCodeModel=API.LLVMCodeModelDefault) =
@@ -19,8 +19,8 @@ TargetMachine(t::Target, triple::String, cpu::String="", features::String="",
 
 dispose(tm::TargetMachine) = API.LLVMDisposeTargetMachine(tm)
 
-function TargetMachine(f::Core.Function, args...)
-    tm = TargetMachine(args...)
+function TargetMachine(f::Core.Function, args...; kwargs...)
+    tm = TargetMachine(args...; kwargs...)
     try
         f(tm)
     finally

--- a/test/Kaleidoscope.jl
+++ b/test/Kaleidoscope.jl
@@ -17,7 +17,7 @@ include(joinpath(@__DIR__, "..", "examples", "Kaleidoscope", "Kaleidoscope.jl"))
     """
 
     LLVM.Context() do ctx
-        m = Kaleidoscope.generate_IR(program, ctx)
+        m = Kaleidoscope.generate_IR(program; ctx)
         Kaleidoscope.optimize!(m)
         v = Kaleidoscope.run(m, "entry")
         @test v == 55.0
@@ -42,7 +42,7 @@ end
     """
 
     LLVM.Context() do ctx
-        m = Kaleidoscope.generate_IR(program, ctx)
+        m = Kaleidoscope.generate_IR(program; ctx)
         Kaleidoscope.optimize!(m)
         mktemp() do path, io
             Kaleidoscope.write_objectfile(m, path)
@@ -62,7 +62,7 @@ end
     """
 
     LLVM.Context() do ctx
-        m = Kaleidoscope.generate_IR(program, ctx)
+        m = Kaleidoscope.generate_IR(program; ctx)
         Kaleidoscope.optimize!(m)
         v = Kaleidoscope.run(m, "entry")
         @test v == 13

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -2,11 +2,11 @@
 
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.Int32Type(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
-    entry = BasicBlock(fn, "entry")
+    entry = BasicBlock(fn, "entry"; ctx)
     position!(builder, entry)
 
     ret!(builder)
@@ -19,11 +19,11 @@ end
 
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
-    entry = BasicBlock(fn, "entry")
+    entry = BasicBlock(fn, "entry"; ctx)
     position!(builder, entry)
 
     ret!(builder)

--- a/test/bitcode.jl
+++ b/test/bitcode.jl
@@ -1,17 +1,17 @@
 @testset "bitcode" begin
 
-let
+Context() do ctx
     invalid_bitcode = "invalid"
-    @test_throws LLVMException parse(LLVM.Module, unsafe_wrap(Vector{UInt8}, invalid_bitcode))
+    @test_throws LLVMException parse(LLVM.Module, unsafe_wrap(Vector{UInt8}, invalid_bitcode); ctx)
 end
 
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do source_mod
+LLVM.Module("SomeModule"; ctx) do source_mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(source_mod, "SomeFunction", ft)
 
-    entry = BasicBlock(fn, "entry")
+    entry = BasicBlock(fn, "entry"; ctx)
     position!(builder, entry)
 
     ret!(builder)
@@ -22,14 +22,7 @@ LLVM.Module("SomeModule", ctx) do source_mod
     bitcode_buf = convert(MemoryBuffer, source_mod)
 
     let
-        mod = parse(LLVM.Module, bitcode_buf)
-        verify(mod)
-        @test haskey(functions(mod), "SomeFunction")
-        dispose(mod)
-    end
-
-    let
-        mod = parse(LLVM.Module, bitcode_buf, ctx)
+        mod = parse(LLVM.Module, bitcode_buf; ctx)
         verify(mod)
         @test haskey(functions(mod), "SomeFunction")
         dispose(mod)
@@ -39,14 +32,7 @@ LLVM.Module("SomeModule", ctx) do source_mod
     bitcode = convert(Vector{UInt8}, source_mod)
 
     let
-        mod = parse(LLVM.Module, bitcode)
-        verify(mod)
-        @test haskey(functions(mod), "SomeFunction")
-        dispose(mod)
-    end
-
-    let
-        mod = parse(LLVM.Module, bitcode, ctx)
+        mod = parse(LLVM.Module, bitcode; ctx)
         verify(mod)
         @test haskey(functions(mod), "SomeFunction")
         dispose(mod)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1048,6 +1048,8 @@ LLVM.Module("SomeModule"; ctx) do mod
         @test collect(insts) == [brinst]
     end
 
+    unsafe_delete!(bb1, brinst)    # we'll be deleting bb2, so remove uses of it
+
     # basic block iteration
     let bbs = blocks(fn)
         @test collect(bbs) == [bb1, bb2]

--- a/test/core.jl
+++ b/test/core.jl
@@ -15,13 +15,9 @@ end
 
 @testset "context" begin
 
-global global_ctx
-global_ctx = GlobalContext()
-local_ctx = Context()
-
 let
     ctx = Context()
-    @assert local_ctx != GlobalContext()
+    @assert ctx != GlobalContext()
     dispose(ctx)
 end
 
@@ -44,27 +40,20 @@ Context() do ctx
     @test typeof(LLVMType(typ.ref)) == LLVM.IntegerType           # type reconstructed
     @test_throws UndefRefError LLVMType(LLVM.API.LLVMTypeRef(C_NULL))
 
-    LLVM.IntType(8)
-    @test width(LLVM.IntType(8, ctx)) == 8
+    @test width(LLVM.IntType(8; ctx)) == 8
 
     @test issized(LLVM.Int1Type(ctx))
     @test !issized(LLVM.VoidType(ctx))
 end
 
 # integer
-let
-    typ = LLVM.Int1Type()
-    @test context(typ) == global_ctx
+Context() do ctx
+    typ = LLVM.Int1Type(ctx)
+    @test context(typ) == ctx
 
     show(devnull, typ)
 
     @test !isempty(typ)
-
-    Context() do ctx
-        typ2 = LLVM.Int1Type(ctx)
-        @test context(typ2) == ctx
-        @test typ2 != typ
-    end
 end
 
 # floating-point
@@ -122,19 +111,10 @@ Context() do ctx
 end
 
 # structure
-let
-    st = LLVM.StructType([LLVM.VoidType()])
-    @test context(st) == global_ctx
-    @test !isempty(st)
-
-    st2 = LLVM.StructType("foo")
-    @test context(st2) == global_ctx
-    @test isempty(st2)
-end
 Context() do ctx
     elem = [LLVM.Int32Type(ctx), LLVM.FloatType(ctx)]
 
-    let st = LLVM.StructType(elem, ctx)
+    let st = LLVM.StructType(elem; ctx)
         @test context(st) == ctx
         @test !ispacked(st)
         @test !isopaque(st)
@@ -158,7 +138,7 @@ Context() do ctx
         end
     end
 
-    let st = LLVM.StructType("foo", ctx)
+    let st = LLVM.StructType("foo"; ctx)
         @test name(st) == "foo"
         @test isopaque(st)
         elements!(st, elem)
@@ -168,17 +148,9 @@ Context() do ctx
 end
 
 # other
-let
-    typ = LLVM.VoidType()
-    @test context(typ) == global_ctx
-end
 Context() do ctx
     typ = LLVM.VoidType(ctx)
     @test context(typ) == ctx
-end
-let
-    typ = LLVM.LabelType()
-    @test context(typ) == global_ctx
 end
 Context() do ctx
     typ = LLVM.LabelType(ctx)
@@ -195,7 +167,7 @@ end
 
 # type iteration
 Context() do ctx
-    st = LLVM.StructType("SomeType", ctx)
+    st = LLVM.StructType("SomeType"; ctx)
 
     let ts = types(ctx)
         @test keytype(ts) == String
@@ -216,11 +188,11 @@ end
 
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
-    entry = BasicBlock(fn, "entry")
+    entry = BasicBlock(fn, "entry"; ctx)
     position!(builder, entry)
     @test name(entry) == "entry"
 
@@ -253,19 +225,19 @@ end
 
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
-    entry = BasicBlock(fn, "entry")
+    entry = BasicBlock(fn, "entry"; ctx)
     position!(builder, entry)
 
     valueinst1 = add!(builder, parameters(fn)[1],
-                      ConstantInt(Int32(1), ctx))
+                      ConstantInt(Int32(1); ctx))
     @test !isterminator(valueinst1)
 
     userinst = add!(builder, valueinst1,
-                    ConstantInt(Int32(1), ctx))
+                    ConstantInt(Int32(1); ctx))
 
     # use iteration
     let usepairs = uses(valueinst1)
@@ -284,7 +256,7 @@ LLVM.Module("SomeModule", ctx) do mod
     end
 
     valueinst2 = add!(builder, parameters(fn)[1],
-                    ConstantInt(Int32(2), ctx))
+                    ConstantInt(Int32(2); ctx))
 
     replace_uses!(valueinst1, valueinst2)
     @test user.(collect(uses(valueinst2))) == [userinst]
@@ -301,7 +273,7 @@ Context() do ctx
         top:
           %1 = add i32 %0, 1
           ret void
-        }""", ctx)
+        }"""; ctx)
     fun = functions(mod)["fun"]
 
     for (i, instr) in enumerate(instructions(first(blocks(fun))))
@@ -370,21 +342,21 @@ Context() do ctx
 
     # automatic construction
     let
-        constval = ConstantInt(UInt32(1), ctx)
+        constval = ConstantInt(UInt32(1); ctx)
         @test convert(UInt, constval) == 1
     end
     let
-        constval = ConstantInt(false, ctx)
+        constval = ConstantInt(false; ctx)
         @test llvmtype(constval) == LLVM.Int1Type(ctx)
         @test !convert(Bool, constval)
 
-        constval = ConstantInt(true, ctx)
+        constval = ConstantInt(true; ctx)
         @test convert(Bool, constval)
     end
 
     # issue #81
     for T in [Int32, UInt32, Int64, UInt64]
-        constval = ConstantInt(typemax(T), ctx)
+        constval = ConstantInt(typemax(T); ctx)
         @test convert(T, constval) == typemax(T)
     end
 
@@ -409,7 +381,7 @@ Context() do ctx
         @test convert(Float64, c) == 1.1
     end
     for T in [Float16, Float32, Float64]
-        c = ConstantFP(typemax(T), ctx)
+        c = ConstantFP(typemax(T); ctx)
         @test convert(T, c) == typemax(T)
     end
 
@@ -421,24 +393,24 @@ Context() do ctx
     # from Julia values
     let
         vec = Int32[1,2,3,4]
-        ca = ConstantArray(vec, ctx)
+        ca = ConstantArray(vec; ctx)
         @test size(vec) == size(ca)
         @test length(vec) == length(ca)
-        @test ca[1] == ConstantInt(vec[1], ctx)
-        @test collect(ca) == ConstantInt.(vec, Ref(ctx))
+        @test ca[1] == ConstantInt(vec[1]; ctx)
+        @test collect(ca) == ConstantInt.(vec; ctx)
     end
     let
         vec = Float32[1.1f0,2.2f0,3.3f0,4.4f0]
-        ca = ConstantArray(vec, ctx)
+        ca = ConstantArray(vec; ctx)
         @test size(vec) == size(ca)
         @test length(vec) == length(ca)
-        @test ca[1] == ConstantFP(vec[1], ctx)
-        @test collect(ca) == ConstantFP.(vec, Ref(ctx))
+        @test ca[1] == ConstantFP(vec[1]; ctx)
+        @test collect(ca) == ConstantFP.(vec; ctx)
     end
     let
         # tests for ConstantAggregateZero, constructed indirectly.
         # should behave similarly to ConstantArray since it can get returned there.
-        ca = ConstantArray(Int[], ctx)
+        ca = ConstantArray(Int[]; ctx)
         @test size(ca) == (0,)
         @test length(ca) == 0
         @test isempty(collect(ca))
@@ -447,10 +419,10 @@ Context() do ctx
     # multidimensional
     let
         vec = rand(Int, 2,3,4)
-        ca = ConstantArray(vec, ctx)
+        ca = ConstantArray(vec; ctx)
         @test size(vec) == size(ca)
         @test length(vec) == length(ca)
-        @test collect(ca) == ConstantInt.(vec, Ref(ctx))
+        @test collect(ca) == ConstantInt.(vec; ctx)
     end
 
     end
@@ -460,7 +432,7 @@ Context() do ctx
     # from Julia values
     let
         test_struct = TestStruct(true, -99, 1.5)
-        constant_struct = ConstantStruct(test_struct, ctx; anonymous=true)
+        constant_struct = ConstantStruct(test_struct; ctx, anonymous=true)
         constant_struct_type = llvmtype(constant_struct)
 
         @test constant_struct_type isa LLVM.StructType
@@ -480,7 +452,7 @@ Context() do ctx
     end
     let
         test_struct = TestStruct(false, 52, -2.5)
-        constant_struct = ConstantStruct(test_struct, ctx)
+        constant_struct = ConstantStruct(test_struct; ctx)
         constant_struct_type = llvmtype(constant_struct)
 
         @test constant_struct_type isa LLVM.StructType
@@ -493,20 +465,20 @@ Context() do ctx
         @test collect(operands(constant_struct)) == expected_operands
 
         # re-creating the same type shouldn't fail
-        ConstantStruct(TestStruct(true, 42, 0), ctx)
+        ConstantStruct(TestStruct(true, 42, 0); ctx)
         # unless it's a conflicting type
-        @test_throws ArgumentError ConstantStruct(AnotherTestStruct(1), ctx; name="TestStruct")
+        @test_throws ArgumentError ConstantStruct(AnotherTestStruct(1), "TestStruct"; ctx)
 
     end
     let
         test_struct = TestSingleton()
-        constant_struct = ConstantStruct(test_struct, ctx)
+        constant_struct = ConstantStruct(test_struct; ctx)
         constant_struct_type = llvmtype(constant_struct)
 
         @test isempty(operands(constant_struct))
     end
     let
-        @test_throws ArgumentError ConstantStruct(1, ctx)
+        @test_throws ArgumentError ConstantStruct(1; ctx)
     end
 
     end
@@ -528,8 +500,8 @@ end
 
 # global values
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
-    st = LLVM.StructType("SomeType", ctx)
+LLVM.Module("SomeModule"; ctx) do mod
+    st = LLVM.StructType("SomeType"; ctx)
     ft = LLVM.FunctionType(st, [st])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -562,7 +534,7 @@ end
 
 # global variables
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     @test isempty(globals(mod))
     gv = GlobalVariable(mod, LLVM.Int32Type(ctx), "SomeGlobal")
     @test !isempty(globals(mod))
@@ -570,7 +542,7 @@ LLVM.Module("SomeModule", ctx) do mod
     show(devnull, gv)
 
     @test initializer(gv) === nothing
-    init = ConstantInt(Int32(0), ctx)
+    init = ConstantInt(Int32(0); ctx)
     initializer!(gv, init)
     @test initializer(gv) == init
     initializer!(gv, nothing)
@@ -611,8 +583,8 @@ end
 end
 
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
-    st = LLVM.StructType("SomeType", ctx)
+LLVM.Module("SomeModule"; ctx) do mod
+    st = LLVM.StructType("SomeType"; ctx)
     gv = GlobalVariable(mod, st, "SomeGlobal")
 
     init = null(st)
@@ -622,7 +594,7 @@ end
 end
 
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     gv = GlobalVariable(mod, LLVM.Int32Type(ctx), "SomeGlobal", 1)
 
     @test addrspace(llvmtype(gv)) == 1
@@ -634,18 +606,14 @@ end
 
 @testset "metadata" begin
 
-@test MDString("foo") == MDString("foo", global_ctx)
-
 Context() do ctx
-    str = MDString("foo", ctx)
+    str = MDString("foo"; ctx)
     @test string(str) == "foo"
 end
 
-@test MDNode([MDString("foo")]) == MDNode([MDString("foo", global_ctx)], global_ctx)
-
 Context() do ctx
-    str = MDString("foo", ctx)
-    node = MDNode([str], ctx)
+    str = MDString("foo"; ctx)
+    node = MDNode([str]; ctx)
     ops = operands(node)
     @test length(ops) == 1
     @test ops[1] == str
@@ -684,7 +652,7 @@ mod = parse(LLVM.Module, raw"""
        !16 = distinct !DISubprogram(name: "promote;", linkageName: "promote", scope: !3, file: !3, type: !6, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !4)
        !17 = !DILocation(line: 321, scope: !5)
        !18 = !DILocation(line: 326, scope: !19, inlinedAt: !17)
-       !19 = distinct !DISubprogram(name: "+;", linkageName: "+", scope: !9, file: !9, type: !6, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !4)""", ctx)
+       !19 = distinct !DISubprogram(name: "+;", linkageName: "+", scope: !9, file: !9, type: !6, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !4)"""; ctx)
 
     fun = functions(mod)["test"]
     bb = first(collect(blocks(fun)))
@@ -732,24 +700,17 @@ end
 
 @testset "module" begin
 
-let
-    mod = LLVM.Module("SomeModule")
-    @test context(mod) == global_ctx
+Context() do ctx
+    mod = LLVM.Module("SomeModule"; ctx)
+    @test context(mod) == ctx
 
     @test name(mod) == "SomeModule"
     name!(mod, "SomeOtherName")
     @test name(mod) == "SomeOtherName"
-
-    dispose(mod)
 end
 
 Context() do ctx
-    mod = LLVM.Module("SomeModule", ctx)
-    @test context(mod) == ctx
-end
-
-Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     clone = LLVM.Module(mod)
     @test mod != clone
     @test context(clone) == ctx
@@ -768,7 +729,7 @@ LLVM.Module("SomeModule", ctx) do mod
     datalayout!(mod, dummyLayout)
     @test string(datalayout(mod)) == dummyLayout
 
-    md = Metadata(ConstantInt(42, ctx))
+    md = Metadata(ConstantInt(42; ctx))
 
     mod_flags = flags(mod)
     mod_flags["foobar", LLVM.API.LLVMModuleFlagBehaviorError] = md
@@ -783,8 +744,8 @@ end
 
 # metadata iteration
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
-    node = MDNode([MDString("SomeMDString", ctx)], ctx)
+LLVM.Module("SomeModule"; ctx) do mod
+    node = MDNode([MDString("SomeMDString"; ctx)]; ctx)
 
     let mds = metadata(mod)
         @test keytype(mds) == String
@@ -802,7 +763,7 @@ end
 
 # global variable iteration
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     dummygv = GlobalVariable(mod, LLVM.Int32Type(ctx), "SomeGlobal")
 
     let gvs = globals(mod)
@@ -828,8 +789,8 @@ end
 
 # function iteration
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
-    st = LLVM.StructType("SomeType", ctx)
+LLVM.Module("SomeModule"; ctx) do mod
+    st = LLVM.StructType("SomeType"; ctx)
     ft = LLVM.FunctionType(st, [st])
     @test isempty(functions(mod))
 
@@ -863,7 +824,7 @@ end
 @testset "function" begin
 
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -898,7 +859,7 @@ end
 
 # non-overloaded intrinsic
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     intr_ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     intr_fn = LLVM.Function(mod, "llvm.trap", intr_ft)
     @test isintrinsic(intr_fn)
@@ -925,7 +886,7 @@ end
 
 # overloaded intrinsic
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     intr_ft = LLVM.FunctionType(LLVM.DoubleType(ctx), [LLVM.DoubleType(ctx)])
     intr_fn = LLVM.Function(mod, "llvm.sin.f64", intr_ft)
     @test isintrinsic(intr_fn)
@@ -952,7 +913,7 @@ end
 
 # attributes
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -961,7 +922,7 @@ LLVM.Module("SomeModule", ctx) do mod
 
         @test length(attrs) == 0
 
-        let attr = EnumAttribute("sspreq", 0, ctx)
+        let attr = EnumAttribute("sspreq", 0; ctx)
             @test kind(attr) != 0
             @test value(attr) == 0
             push!(attrs, attr)
@@ -971,11 +932,7 @@ LLVM.Module("SomeModule", ctx) do mod
             @test length(attrs) == 0
         end
 
-        let attr = EnumAttribute("sspreq")
-            @test value(attr) == 0
-        end
-
-        let attr = StringAttribute("nounwind", "", ctx)
+        let attr = StringAttribute("nounwind", ""; ctx)
             @test kind(attr) == "nounwind"
             @test value(attr) == ""
             push!(attrs, attr)
@@ -983,10 +940,6 @@ LLVM.Module("SomeModule", ctx) do mod
 
             delete!(attrs, attr)
             @test length(attrs) == 0
-        end
-
-        let attr = StringAttribute("nounwind")
-            @test value(attr) == ""
         end
     end
 
@@ -1006,7 +959,7 @@ end
 
 # parameter iteration
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -1030,12 +983,12 @@ end
 
 # basic block iteration
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
     @test isempty(blocks(fn))
 
-    entrybb = BasicBlock(fn, "SomeBasicBlock")
+    entrybb = BasicBlock(fn, "SomeBasicBlock"; ctx)
     @test entry(fn) == entrybb
     let bbs = blocks(fn)
         @test eltype(bbs) == BasicBlock
@@ -1060,45 +1013,17 @@ end
 
 @testset "basic blocks" begin
 
-Builder() do builder
-LLVM.Module("SomeModule") do mod
-    ft = LLVM.FunctionType(LLVM.VoidType())
-    fn = LLVM.Function(mod, "SomeFunction", ft)
-    bbs = blocks(fn)
-
-    bb2 = BasicBlock(fn, "SomeOtherBasicBlock")
-    @test LLVM.parent(bb2) == fn
-
-    bb1 = BasicBlock(bb2, "SomeBasicBlock")
-    @test LLVM.parent(bb2) == fn
-
-    @test collect(bbs) == [bb1, bb2]
-
-    move_before(bb2, bb1)
-    @test collect(bbs) == [bb2, bb1]
-
-    move_after(bb2, bb1)
-    @test collect(bbs) == [bb1, bb2]
-
-    @test bb1 in bbs
-    @test bb2 in bbs
-    delete!(fn, bb1)
-    unsafe_delete!(fn, bb2)
-    @test isempty(bbs)
-end
-end
-
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
-    bb2 = BasicBlock(fn, "SomeOtherBasicBlock", ctx)
+    bb2 = BasicBlock(fn, "SomeOtherBasicBlock"; ctx)
     @test LLVM.parent(bb2) == fn
     @test isempty(instructions(bb2))
 
-    bb1 = BasicBlock(bb2, "SomeBasicBlock", ctx)
+    bb1 = BasicBlock(bb2, "SomeBasicBlock"; ctx)
     @test LLVM.parent(bb2) == fn
     position!(builder, bb1)
     brinst = br!(builder, bb2)
@@ -1122,6 +1047,23 @@ LLVM.Module("SomeModule", ctx) do mod
 
         @test collect(insts) == [brinst]
     end
+
+    # basic block iteration
+    let bbs = blocks(fn)
+        @test collect(bbs) == [bb1, bb2]
+
+        move_before(bb2, bb1)
+        @test collect(bbs) == [bb2, bb1]
+
+        move_after(bb2, bb1)
+        @test collect(bbs) == [bb1, bb2]
+
+        @test bb1 in bbs
+        @test bb2 in bbs
+        delete!(fn, bb1)
+        unsafe_delete!(fn, bb2)
+        @test isempty(bbs)
+    end
 end
 end
 end
@@ -1133,7 +1075,7 @@ end
 
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
     @test isempty(parameters(fn))
@@ -1142,9 +1084,9 @@ LLVM.Module("SomeModule", ctx) do mod
     fn = LLVM.Function(mod, "SomeOtherFunction", ft)
     @test !isempty(parameters(fn))
 
-    bb1 = BasicBlock(fn, "entry", ctx)
-    bb2 = BasicBlock(fn, "then", ctx)
-    bb3 = BasicBlock(fn, "else", ctx)
+    bb1 = BasicBlock(fn, "entry"; ctx)
+    bb2 = BasicBlock(fn, "then"; ctx)
+    bb3 = BasicBlock(fn, "else"; ctx)
 
     position!(builder, bb1)
     brinst = br!(builder, parameters(fn)[1], bb2, bb3)
@@ -1197,7 +1139,7 @@ LLVM.Module("SomeModule", ctx) do mod
     @test LLVM.parent(brinst) == bb1
 
     # metadata
-    mdval = MDNode([MDString("whatever", ctx)], ctx)
+    mdval = MDNode([MDString("whatever"; ctx)]; ctx)
     let md = metadata(brinst)
         @test keytype(md) == LLVM.MD
         @test valtype(md) == LLVM.MetadataAsValue
@@ -1239,7 +1181,7 @@ Context() do ctx
         top:
             %1 = freeze i64 undef
             ret i64 %1
-        }""", ctx)
+        }"""; ctx)
     f = first(functions(mod))
     bb = first(blocks(f))
     inst = first(instructions(bb))

--- a/test/datalayout.jl
+++ b/test/datalayout.jl
@@ -9,15 +9,14 @@ DataLayout("E-p:32:32-f128:128:128") do data
     @test byteorder(data) == LLVM.API.LLVMBigEndian
     @test pointersize(data) == pointersize(data, 0) == 4
 
-    @test intptr(data) == intptr(data, 0) == LLVM.Int32Type()
-    @test intptr(data, ctx) == intptr(data, 0, ctx) == LLVM.Int32Type(ctx)
+    @test intptr(data; ctx) == intptr(data, 0; ctx) == LLVM.Int32Type(ctx)
 
-    @test sizeof(data, LLVM.Int32Type()) == storage_size(data, LLVM.Int32Type()) == abi_size(data, LLVM.Int32Type()) == 4
+    @test sizeof(data, LLVM.Int32Type(ctx)) == storage_size(data, LLVM.Int32Type(ctx)) == abi_size(data, LLVM.Int32Type(ctx)) == 4
 
-    @test abi_alignment(data, LLVM.Int32Type()) == frame_alignment(data, LLVM.Int32Type()) == preferred_alignment(data, LLVM.Int32Type()) == 4
+    @test abi_alignment(data, LLVM.Int32Type(ctx)) == frame_alignment(data, LLVM.Int32Type(ctx)) == preferred_alignment(data, LLVM.Int32Type(ctx)) == 4
 
-    LLVM.Module("SomeModule") do mod
-        gv = GlobalVariable(mod, LLVM.Int32Type(), "SomeGlobal")
+    LLVM.Module("SomeModule"; ctx) do mod
+        gv = GlobalVariable(mod, LLVM.Int32Type(ctx), "SomeGlobal")
         @test preferred_alignment(data, gv) == 4
 
         datalayout!(mod, data)
@@ -25,7 +24,7 @@ DataLayout("E-p:32:32-f128:128:128") do data
     end
 
     elem = [LLVM.Int32Type(ctx), LLVM.FloatType(ctx)]
-    let st = LLVM.StructType(elem, ctx)
+    let st = LLVM.StructType(elem; ctx)
         @test element_at(data, st, 4) == 1
         @test offsetof(data, st, 1) == 4
     end

--- a/test/debuginfo.jl
+++ b/test/debuginfo.jl
@@ -24,7 +24,7 @@ Context() do ctx
           !4 = !{}
           !5 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: null, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true, scopeLine: 1, isOptimized: true, unit: !2)
           !6 = !DISubroutineType(types: !4)
-          !7 = !DILocation(line: 1, scope: !5)""", ctx)
+          !7 = !DILocation(line: 1, scope: !5)"""; ctx)
 
     foo = functions(mod)["foo"]
 

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -7,12 +7,12 @@ using InteractiveUtils
 
 @generated function add_one(i)
     Context() do ctx
-        T_int = convert(LLVMType, Int, ctx)
+        T_int = convert(LLVMType, Int; ctx)
 
         f, ft = create_function(T_int, [T_int])
 
         Builder(ctx) do builder
-            entry = BasicBlock(f, "entry", ctx)
+            entry = BasicBlock(f, "entry"; ctx)
             position!(builder, entry)
 
             val = add!(builder, parameters(f)[1], ConstantInt(T_int, 1))
@@ -38,9 +38,9 @@ end
 @test isboxed(NonGhostType2)
 
 Context() do ctx
-    @test isghosttype(GhostType, ctx)
-    @test !isghosttype(NonGhostType1, ctx)
-    @test !isghosttype(NonGhostType2, ctx)
+    @test isghosttype(GhostType; ctx)
+    @test !isghosttype(NonGhostType1; ctx)
+    @test !isghosttype(NonGhostType2; ctx)
 end
 
 end
@@ -103,7 +103,7 @@ end
 
 
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
 ModulePassManager() do pm
 
 demote_float16!(pm)

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1,17 +1,17 @@
 @testset "ir" begin
 
-let
+Context() do ctx
     invalid_ir = "invalid"
-    @test_throws LLVMException parse(LLVM.Module, invalid_ir)
+    @test_throws LLVMException parse(LLVM.Module, invalid_ir; ctx)
 end
 
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do source_mod
+LLVM.Module("SomeModule"; ctx) do source_mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(source_mod, "SomeFunction", ft)
 
-    entry = BasicBlock(fn, "entry")
+    entry = BasicBlock(fn, "entry"; ctx)
     position!(builder, entry)
 
     ret!(builder)
@@ -22,14 +22,7 @@ LLVM.Module("SomeModule", ctx) do source_mod
     ir = string(source_mod)
 
     let
-        mod = parse(LLVM.Module, ir)
-        verify(mod)
-        @test haskey(functions(mod), "SomeFunction")
-        dispose(mod)
-    end
-
-    let
-        mod = parse(LLVM.Module, ir, ctx)
+        mod = parse(LLVM.Module, ir; ctx)
         verify(mod)
         @test haskey(functions(mod), "SomeFunction")
         dispose(mod)

--- a/test/irbuilder.jl
+++ b/test/irbuilder.jl
@@ -1,23 +1,15 @@
 @testset "irbuilder" begin
 
-let
-    builder = Builder()
-    dispose(builder)
-end
-
-Builder() do builder
-end
-
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx), LLVM.Int32Type(ctx),
                                                 LLVM.FloatType(ctx), LLVM.FloatType(ctx),
                                                 LLVM.PointerType(LLVM.Int32Type(ctx)),
                                                 LLVM.PointerType(LLVM.Int32Type(ctx))])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
-    entrybb = BasicBlock(fn, "entry")
+    entrybb = BasicBlock(fn, "entry"; ctx)
     position!(builder, entrybb)
     @assert position(builder) == entrybb
 
@@ -38,8 +30,8 @@ LLVM.Module("SomeModule", ctx) do mod
     retinst3 = ret!(builder, Value[])
     @check_ir retinst3 "ret void undef"
 
-    thenbb = BasicBlock(fn, "then")
-    elsebb = BasicBlock(fn, "else")
+    thenbb = BasicBlock(fn, "then"; ctx)
+    elsebb = BasicBlock(fn, "else"; ctx)
 
     brinst1 = br!(builder, thenbb)
     @check_ir brinst1 "br label %then"

--- a/test/linker.jl
+++ b/test/linker.jl
@@ -3,11 +3,11 @@
 Context() do ctx
 Builder(ctx) do builder
     mod1 = let
-        mod = LLVM.Module("SomeModule", ctx)
+        mod = LLVM.Module("SomeModule"; ctx)
         ft = LLVM.FunctionType(LLVM.VoidType(ctx))
         fn = LLVM.Function(mod, "SomeFunction", ft)
 
-        entry = BasicBlock(fn, "entry")
+        entry = BasicBlock(fn, "entry"; ctx)
         position!(builder, entry)
 
         ret!(builder)
@@ -16,11 +16,11 @@ Builder(ctx) do builder
     end
 
     mod2 = let
-        mod = LLVM.Module("SomeOtherModule", ctx)
+        mod = LLVM.Module("SomeOtherModule"; ctx)
         ft = LLVM.FunctionType(LLVM.VoidType(ctx))
         fn = LLVM.Function(mod, "SomeOtherFunction", ft)
 
-        entry = BasicBlock(fn, "entry")
+        entry = BasicBlock(fn, "entry"; ctx)
         position!(builder, entry)
 
         ret!(builder)

--- a/test/moduleprovider.jl
+++ b/test/moduleprovider.jl
@@ -2,7 +2,7 @@
 
 Context() do ctx
 let
-    mod = LLVM.Module("SomeModule", ctx)
+    mod = LLVM.Module("SomeModule"; ctx)
     mp = ModuleProvider(mod)
     dispose(mp)
 end
@@ -10,7 +10,7 @@ end
 
 Context() do ctx
 let
-    mod = LLVM.Module("SomeModule", ctx)
+    mod = LLVM.Module("SomeModule"; ctx)
     ModuleProvider(mod) do mp
 
     end

--- a/test/orc.jl
+++ b/test/orc.jl
@@ -4,7 +4,7 @@
     tm  = JITTargetMachine()
     OrcJIT(tm) do orc
        Context() do ctx
-            mod = LLVM.Module("jit", ctx)
+            mod = LLVM.Module("jit"; ctx)
             T_Int32 = LLVM.Int32Type(ctx)
             ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
             fn = LLVM.Function(mod, "mysum", ft)
@@ -14,7 +14,7 @@
             wrapper = LLVM.Function(mod, fname, ft)
             # generate IR
             Builder(ctx) do builder
-                entry = BasicBlock(wrapper, "entry", ctx)
+                entry = BasicBlock(wrapper, "entry"; ctx)
                 position!(builder, entry)
 
                 tmp = call!(builder, fn, [parameters(wrapper)...])
@@ -58,7 +58,7 @@ end
                 end
             end
 
-            mod = LLVM.Module("jit", ctx)
+            mod = LLVM.Module("jit"; ctx)
             T_Int32 = LLVM.Int32Type(ctx)
             ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
             fn = LLVM.Function(mod, "mysum", ft)
@@ -68,7 +68,7 @@ end
             wrapper = LLVM.Function(mod, fname, ft)
             # generate IR
             Builder(ctx) do builder
-                entry = BasicBlock(wrapper, "entry", ctx)
+                entry = BasicBlock(wrapper, "entry"; ctx)
                 position!(builder, entry)
 
                 tmp = call!(builder, fn, [parameters(wrapper)...])
@@ -115,7 +115,7 @@ end
     tm  = JITTargetMachine()
     OrcJIT(tm) do orc
             Context() do ctx
-            mod = LLVM.Module("jit", ctx)
+            mod = LLVM.Module("jit"; ctx)
             T_Int32 = LLVM.Int32Type(ctx)
             ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
             fn = LLVM.Function(mod, "mysum", ft)
@@ -125,7 +125,7 @@ end
             wrapper = LLVM.Function(mod, fname, ft)
             # generate IR
             Builder(ctx) do builder
-                entry = BasicBlock(wrapper, "entry", ctx)
+                entry = BasicBlock(wrapper, "entry"; ctx)
                 position!(builder, entry)
 
                 tmp = call!(builder, fn, [parameters(wrapper)...])
@@ -159,7 +159,7 @@ end
     tm  = JITTargetMachine()
     OrcJIT(tm) do orc
         Context() do ctx
-            mod = LLVM.Module("jit", ctx)
+            mod = LLVM.Module("jit"; ctx)
             T_Int32 = LLVM.Int32Type(ctx)
             ft = LLVM.FunctionType(T_Int32, [T_Int32, T_Int32])
             mysum = mangle(orc, "mysum")
@@ -170,7 +170,7 @@ end
             wrapper = LLVM.Function(mod, fname, ft)
             # generate IR
             Builder(ctx) do builder
-                entry = BasicBlock(wrapper, "entry", ctx)
+                entry = BasicBlock(wrapper, "entry"; ctx)
                 position!(builder, entry)
 
                 tmp = call!(builder, fn, [parameters(wrapper)...])
@@ -210,12 +210,12 @@ end
         Context() do ctx
             sym = mangle(orc, "SomeFunction")
 
-            mod = LLVM.Module("jit", ctx)
+            mod = LLVM.Module("jit"; ctx)
             ft = LLVM.FunctionType(LLVM.VoidType(ctx))
             fn = LLVM.Function(mod, sym, ft)
 
             Builder(ctx) do builder
-                entry = BasicBlock(fn, "entry")
+                entry = BasicBlock(fn, "entry"; ctx)
                 position!(builder, entry)
                 ret!(builder)
             end
@@ -284,12 +284,12 @@ end
 
             # 1. IRGen & Optimize the module
             orc_mod = Context() do ctx
-                mod = LLVM.Module("jit", ctx)
+                mod = LLVM.Module("jit"; ctx)
                 ft = LLVM.FunctionType(LLVM.VoidType(ctx))
                 fn = LLVM.Function(mod, sym, ft)
 
                 Builder(ctx) do builder
-                    entry = BasicBlock(fn, "entry")
+                    entry = BasicBlock(fn, "entry"; ctx)
                     position!(builder, entry)
                     ret!(builder)
                 end

--- a/test/pass.jl
+++ b/test/pass.jl
@@ -2,11 +2,11 @@
 
 Context() do ctx
 Builder(ctx) do builder
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
-    bb = BasicBlock(fn, "SomeBasicBlock")
+    bb = BasicBlock(fn, "SomeBasicBlock"; ctx)
     position!(builder, bb)
 
     ret!(builder)

--- a/test/passmanager.jl
+++ b/test/passmanager.jl
@@ -6,7 +6,7 @@ let
 end
 
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
 ModulePassManager() do mpm
     @test !run!(mpm, mod)
 end
@@ -14,9 +14,9 @@ end
 end
 
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
 FunctionPassManager(mod) do fpm
-    ft = LLVM.FunctionType(LLVM.VoidType(), [LLVM.Int32Type()])
+    ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
     @test !initialize!(fpm)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,10 @@ using Test
 
 @testset "LLVM" begin
 
+# HACK: if a test throws within a Context() do block, displaying the LLVM value may crash
+#       because the context has been disposed already. avoid that by disabling `dispose`
+LLVM.dispose(::Context) = return
+
 include("util.jl")
 
 @testset "types" begin

--- a/test/targetmachine.jl
+++ b/test/targetmachine.jl
@@ -18,11 +18,11 @@ TargetMachine(host_t, host_triple) do tm
     # emission
     Context() do ctx
     Builder(ctx) do builder
-    LLVM.Module("SomeModule", ctx) do mod
+    LLVM.Module("SomeModule"; ctx) do mod
         ft = LLVM.FunctionType(LLVM.VoidType(ctx))
         fn = LLVM.Function(mod, "SomeFunction", ft)
 
-        entry = BasicBlock(fn, "entry")
+        entry = BasicBlock(fn, "entry"; ctx)
         position!(builder, entry)
 
         ret!(builder)
@@ -40,7 +40,7 @@ TargetMachine(host_t, host_triple) do tm
     end
 
     Context() do ctx
-    LLVM.Module("SomeModule", ctx) do mod
+    LLVM.Module("SomeModule"; ctx) do mod
         FunctionPassManager(mod) do fpm
             add_transform_info!(fpm)
             add_transform_info!(fpm, tm)

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -15,7 +15,7 @@ PassManagerBuilder() do pmb
     inliner!(pmb, 0)
 
     Context() do ctx
-    LLVM.Module("SomeModule", ctx) do mod
+    LLVM.Module("SomeModule"; ctx) do mod
         FunctionPassManager(mod) do fpm
             populate!(fpm, pmb)
         end
@@ -27,7 +27,7 @@ PassManagerBuilder() do pmb
 end
 
 Context() do ctx
-LLVM.Module("SomeModule", ctx) do mod
+LLVM.Module("SomeModule"; ctx) do mod
 ModulePassManager() do pm
     aggressive_dce!(pm)
     dce!(pm)


### PR DESCRIPTION
This is massively breaking, but may be necessary as even in the tests we were messing up contexts regularly. This PR:
- makes the context compulsory (not defaulting to `GlobalContext()`)
- passes the context as a keyword argument for consistency

The only APIs I'm still passing the context as a regular argument is where there'd otherwise be no arguments, because `LLVM.IntType(; ctx)` looks a little strange. Thoughts?