### PR TITLE
Add support for CFG simplification with options.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -34,9 +34,9 @@ version = "1.3.0"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "99200ba262364a8502e5a0cca0057cf7c60901d7"
+git-tree-sha1 = "a9b1130c4728b0e462a1c28772954650039eb847"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.4+0"
+version = "0.0.7+0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-LLVMExtra_jll = "~0.0.6"
+LLVMExtra_jll = "~0.0.7"
 julia = "1.6"

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -84,6 +84,18 @@ void LLVMExtraGetNamedMetadataOperands2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef 
 
 void LLVMExtraAddNamedMetadataOperand2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef Val);
 
+#if LLVM_VERSION_MAJOR >= 12
+void LLVMAddCFGSimplificationPass2(LLVMPassManagerRef PM,
+                                   int BonusInstThreshold,
+                                   LLVMBool ForwardSwitchCondToPhi,
+                                   LLVMBool ConvertSwitchToLookupTable,
+                                   LLVMBool NeedCanonicalLoop,
+                                   LLVMBool HoistCommonInsts,
+                                   LLVMBool SinkCommonInsts,
+                                   LLVMBool SimplifyCondBranch,
+                                   LLVMBool FoldTwoEntryPHINode);
+#endif
+
 // Bug fixes
 void LLVMExtraSetInitializer(LLVMValueRef GlobalVar, LLVMValueRef ConstantVal);
 void LLVMExtraSetPersonalityFn(LLVMValueRef Fn, LLVMValueRef PersonalityFn);

--- a/deps/LLVMExtra/lib/llvm-api.cpp
+++ b/deps/LLVMExtra/lib/llvm-api.cpp
@@ -278,6 +278,29 @@ char* LLVMExtraPrintMetadataToString(LLVMMetadataRef MD) {
   return strdup(buf.c_str());
 }
 
+#if LLVM_VERSION_MAJOR >= 12
+void LLVMAddCFGSimplificationPass2(LLVMPassManagerRef PM,
+                                   int BonusInstThreshold,
+                                   LLVMBool ForwardSwitchCondToPhi,
+                                   LLVMBool ConvertSwitchToLookupTable,
+                                   LLVMBool NeedCanonicalLoop,
+                                   LLVMBool HoistCommonInsts,
+                                   LLVMBool SinkCommonInsts,
+                                   LLVMBool SimplifyCondBranch,
+                                   LLVMBool FoldTwoEntryPHINode)
+{
+    auto simplifyCFGOptions = SimplifyCFGOptions().bonusInstThreshold(BonusInstThreshold)
+                                                  .forwardSwitchCondToPhi(ForwardSwitchCondToPhi)
+                                                  .convertSwitchToLookupTable(ConvertSwitchToLookupTable)
+                                                  .needCanonicalLoops(NeedCanonicalLoop)
+                                                  .hoistCommonInsts(HoistCommonInsts)
+                                                  .sinkCommonInsts(SinkCommonInsts)
+                                                  .setSimplifyCondBranch(SimplifyCondBranch)
+                                                  .setFoldTwoEntryPHINode(FoldTwoEntryPHINode);
+    unwrap(PM)->add(createCFGSimplificationPass(simplifyCFGOptions));
+}
+#endif
+
 // versions of API without MetadataAsValue
 
 const char *LLVMExtraGetMDString2(LLVMMetadataRef MD, unsigned *Length) {

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -140,6 +140,16 @@ function LLVMExtraDIScopeGetName(Scope, Len)
     ccall((:LLVMExtraDIScopeGetName, libLLVMExtra), Cstring, (LLVMMetadataRef, Ptr{Cuint}), Scope, Len)
 end
 
+function LLVMAddCFGSimplificationPass2(PM, BonusInstThreshold, ForwardSwitchCondToPhi,
+                                       ConvertSwitchToLookupTable, NeedCanonicalLoop,
+                                       HoistCommonInsts, SinkCommonInsts,
+                                       SimplifyCondBranch, FoldTwoEntryPHINode)
+    ccall((:LLVMAddCFGSimplificationPass2, libLLVMExtra), Cvoid,
+          (LLVMPassManagerRef, Cint, LLVMBool, LLVMBool, LLVMBool, LLVMBool, LLVMBool, LLVMBool, LLVMBool),
+          PM, BonusInstThreshold, ForwardSwitchCondToPhi, ConvertSwitchToLookupTable, NeedCanonicalLoop,
+          HoistCommonInsts, SinkCommonInsts, SimplifyCondBranch, FoldTwoEntryPHINode)
+end
+
 # bug fixes
 
 # TODO: upstream

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -34,6 +34,9 @@ ModulePassManager() do pm
     bit_tracking_dce!(pm)
     alignment_from_assumptions!(pm)
     cfgsimplification!(pm)
+    if LLVM.version() >= v"12"
+        cfgsimplification!(pm; hoist_common_insts=true)
+    end
     dead_store_elimination!(pm)
     scalarizer!(pm)
     merged_load_store_motion!(pm)


### PR DESCRIPTION
This is needed to fully copy Base's optimization pipeline on LLVM 12. And it turns out to be actually needed to avoid certain local memory allocations with CUDA.jl.