### PR TITLE
Add support for inspecting and creating operand bundles.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -34,9 +34,9 @@ version = "1.3.0"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9c360e5ce980b88bb31a7b086dbb19469008154b"
+git-tree-sha1 = "6a2af408fe809c4f1a54d2b3f188fdd3698549d6"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.10+0"
+version = "0.0.11+0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-LLVMExtra_jll = "~0.0.10"
+LLVMExtra_jll = "~0.0.11"
 julia = "1.6"

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -135,5 +135,27 @@ void LLVMFunctionDeleteBody(LLVMValueRef Func);
 
 void LLVMDestroyConstant(LLVMValueRef Const);
 
+// operand bundles
+typedef struct LLVMOpaqueOperandBundleUse *LLVMOperandBundleUseRef;
+unsigned LLVMGetNumOperandBundles(LLVMValueRef Instr);
+LLVMOperandBundleUseRef LLVMGetOperandBundle(LLVMValueRef Val, unsigned Index);
+void LLVMDisposeOperandBundleUse(LLVMOperandBundleUseRef Bundle);
+uint32_t LLVMGetOperandBundleUseTagID(LLVMOperandBundleUseRef Bundle);
+const char *LLVMGetOperandBundleUseTagName(LLVMOperandBundleUseRef Bundle, unsigned *Length);
+unsigned LLVMGetOperandBundleUseNumInputs(LLVMOperandBundleUseRef Bundle);
+void LLVMGetOperandBundleUseInputs(LLVMOperandBundleUseRef Bundle, LLVMValueRef *Dest);
+typedef struct LLVMOpaqueOperandBundleDef *LLVMOperandBundleDefRef;
+LLVMOperandBundleDefRef LLVMOperandBundleDefFromUse(LLVMOperandBundleUseRef Bundle);
+LLVMOperandBundleDefRef LLVMCreateOperandBundleDef(const char *Tag, LLVMValueRef *Inputs,
+                                                   unsigned NumInputs);
+void LLVMDisposeOperandBundleDef(LLVMOperandBundleDefRef Bundle);
+const char *LLVMGetOperandBundleDefTag(LLVMOperandBundleDefRef Bundle, unsigned *Length);
+unsigned LLVMGetOperandBundleDefNumInputs(LLVMOperandBundleDefRef Bundle);
+void LLVMGetOperandBundleDefInputs(LLVMOperandBundleDefRef Bundle, LLVMValueRef *Dest);
+LLVMValueRef LLVMBuildCallWithOpBundle(LLVMBuilderRef B, LLVMValueRef Fn,
+                                       LLVMValueRef *Args, unsigned NumArgs,
+                                       LLVMOperandBundleDefRef *Bundles, unsigned NumBundles,
+                                       const char *Name);
+
 LLVM_C_EXTERN_C_END
 #endif

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -342,3 +342,68 @@ end
 function LLVMDestroyConstant(Const)
     ccall((:LLVMDestroyConstant, libLLVMExtra), Cvoid, (LLVMValueRef,), Const)
 end
+
+mutable struct LLVMOpaqueOperandBundleUse end
+
+const LLVMOperandBundleUseRef = Ptr{LLVMOpaqueOperandBundleUse}
+
+function LLVMGetNumOperandBundles(Instr)
+    ccall((:LLVMGetNumOperandBundles, libLLVMExtra), Cuint, (LLVMValueRef,), Instr)
+end
+
+function LLVMGetOperandBundle(Val, Index)
+    ccall((:LLVMGetOperandBundle, libLLVMExtra), LLVMOperandBundleUseRef, (LLVMValueRef, Cuint), Val, Index)
+end
+
+function LLVMDisposeOperandBundleUse(Bundle)
+    ccall((:LLVMDisposeOperandBundleUse, libLLVMExtra), Cvoid, (LLVMOperandBundleUseRef,), Bundle)
+end
+
+function LLVMGetOperandBundleUseTagID(Bundle)
+    ccall((:LLVMGetOperandBundleUseTagID, libLLVMExtra), UInt32, (LLVMOperandBundleUseRef,), Bundle)
+end
+
+function LLVMGetOperandBundleUseTagName(Bundle, Length)
+    ccall((:LLVMGetOperandBundleUseTagName, libLLVMExtra), Cstring, (LLVMOperandBundleUseRef, Ptr{Cuint}), Bundle, Length)
+end
+
+function LLVMGetOperandBundleUseNumInputs(Bundle)
+    ccall((:LLVMGetOperandBundleUseNumInputs, libLLVMExtra), Cuint, (LLVMOperandBundleUseRef,), Bundle)
+end
+
+function LLVMGetOperandBundleUseInputs(Bundle, Dest)
+    ccall((:LLVMGetOperandBundleUseInputs, libLLVMExtra), Cvoid, (LLVMOperandBundleUseRef, Ptr{LLVMValueRef}), Bundle, Dest)
+end
+
+mutable struct LLVMOpaqueOperandBundleDef end
+
+const LLVMOperandBundleDefRef = Ptr{LLVMOpaqueOperandBundleDef}
+
+function LLVMOperandBundleDefFromUse(Bundle)
+    ccall((:LLVMOperandBundleDefFromUse, libLLVMExtra), LLVMOperandBundleDefRef, (LLVMOperandBundleUseRef,), Bundle)
+end
+
+function LLVMCreateOperandBundleDef(Tag, Inputs, NumInputs)
+    ccall((:LLVMCreateOperandBundleDef, libLLVMExtra), LLVMOperandBundleDefRef, (Cstring, Ptr{LLVMValueRef}, Cuint), Tag, Inputs, NumInputs)
+end
+
+function LLVMDisposeOperandBundleDef(Bundle)
+    ccall((:LLVMDisposeOperandBundleDef, libLLVMExtra), Cvoid, (LLVMOperandBundleDefRef,), Bundle)
+end
+
+function LLVMGetOperandBundleDefTag(Bundle, Length)
+    ccall((:LLVMGetOperandBundleDefTag, libLLVMExtra), Cstring, (LLVMOperandBundleDefRef, Ptr{Cuint}), Bundle, Length)
+end
+
+function LLVMGetOperandBundleDefNumInputs(Bundle)
+    ccall((:LLVMGetOperandBundleDefNumInputs, libLLVMExtra), Cuint, (LLVMOperandBundleDefRef,), Bundle)
+end
+
+function LLVMGetOperandBundleDefInputs(Bundle, Dest)
+    ccall((:LLVMGetOperandBundleDefInputs, libLLVMExtra), Cvoid, (LLVMOperandBundleDefRef, Ptr{LLVMValueRef}), Bundle, Dest)
+end
+
+function LLVMBuildCallWithOpBundle(B, Fn, Args, NumArgs, Bundles, NumBundles, Name)
+    ccall((:LLVMBuildCallWithOpBundle, libLLVMExtra), LLVMValueRef, (LLVMBuilderRef, LLVMValueRef, Ptr{LLVMValueRef}, Cuint, Ptr{LLVMOperandBundleDefRef}, Cuint, Cstring), B, Fn, Args, NumArgs, Bundles, NumBundles, Name)
+end
+

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -135,7 +135,7 @@ end
 
 export callconv, callconv!,
        istailcall, tailcall!,
-       called_value, num_arg_operands,
+       called_value, arguments,
        OperandBundleUse, OperandBundleDef, operand_bundles
 
 callconv(inst::Instruction) = API.LLVMGetInstructionCallConv(inst)
@@ -147,7 +147,10 @@ tailcall!(inst::Instruction, bool) = API.LLVMSetTailCall(inst, convert(Bool, boo
 
 called_value(inst::Instruction) = Value(API.LLVMGetCalledValue(inst))
 
-num_arg_operands(inst::Instruction) = Int(API.LLVMGetNumArgOperands(inst))
+function arguments(inst::Instruction)
+    nargs = API.LLVMGetNumArgOperands(inst)
+    operands(inst)[1:nargs]
+end
 
 # operand bundles
 

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -131,23 +131,24 @@ end
 
 ## call sites and invocations
 
-# TODO: restrict these to CallBase instructions
+# TODO: add this to the actual type hierarchy
+const CallBase = Union{CallBrInst, CallInst, InvokeInst}
 
 export callconv, callconv!,
        istailcall, tailcall!,
        called_value, arguments,
        OperandBundleUse, OperandBundleDef, operand_bundles
 
-callconv(inst::Instruction) = API.LLVMGetInstructionCallConv(inst)
-callconv!(inst::Instruction, cc) =
+callconv(inst::CallBase) = API.LLVMGetInstructionCallConv(inst)
+callconv!(inst::CallBase, cc) =
     API.LLVMSetInstructionCallConv(inst, cc)
 
-istailcall(inst::Instruction) = convert(Core.Bool, API.LLVMIsTailCall(inst))
-tailcall!(inst::Instruction, bool) = API.LLVMSetTailCall(inst, convert(Bool, bool))
+istailcall(inst::CallBase) = convert(Core.Bool, API.LLVMIsTailCall(inst))
+tailcall!(inst::CallBase, bool) = API.LLVMSetTailCall(inst, convert(Bool, bool))
 
-called_value(inst::Instruction) = Value(API.LLVMGetCalledValue(inst))
+called_value(inst::CallBase) = Value(API.LLVMGetCalledValue(inst))
 
-function arguments(inst::Instruction)
+function arguments(inst::CallBase)
     nargs = API.LLVMGetNumArgOperands(inst)
     operands(inst)[1:nargs]
 end

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -131,9 +131,12 @@ end
 
 ## call sites and invocations
 
+# TODO: restrict these to CallBase instructions
+
 export callconv, callconv!,
        istailcall, tailcall!,
-       called_value
+       called_value, num_arg_operands,
+       OperandBundleUse, OperandBundleDef, operand_bundles
 
 callconv(inst::Instruction) = API.LLVMGetInstructionCallConv(inst)
 callconv!(inst::Instruction, cc) =
@@ -143,6 +146,93 @@ istailcall(inst::Instruction) = convert(Core.Bool, API.LLVMIsTailCall(inst))
 tailcall!(inst::Instruction, bool) = API.LLVMSetTailCall(inst, convert(Bool, bool))
 
 called_value(inst::Instruction) = Value(API.LLVMGetCalledValue(inst))
+
+num_arg_operands(inst::Instruction) = Int(API.LLVMGetNumArgOperands(inst))
+
+# operand bundles
+
+# XXX: these objects are just C structures, whose lifetime isn't tied to LLVM IR structures.
+#      that means we need to create a copy when passing them to Julia, necessitating disposal.
+
+@checked mutable struct OperandBundleUse
+    ref::API.LLVMOperandBundleUseRef
+end
+Base.unsafe_convert(::Type{API.LLVMOperandBundleUseRef}, bundle::OperandBundleUse) =
+    bundle.ref
+
+struct OperandBundleIterator <: AbstractVector{OperandBundleUse}
+    inst::Instruction
+end
+
+operand_bundles(inst::Instruction) = OperandBundleIterator(inst)
+
+Base.size(iter::OperandBundleIterator) = (API.LLVMGetNumOperandBundles(iter.inst),)
+
+Base.IndexStyle(::OperandBundleIterator) = IndexLinear()
+
+function Base.getindex(iter::OperandBundleIterator, i::Int)
+    @boundscheck 1 <= i <= length(iter) || throw(BoundsError(iter, i))
+    bundle = OperandBundleUse(API.LLVMGetOperandBundle(iter.inst, i-1))
+    finalizer(bundle) do obj
+        API.LLVMDisposeOperandBundleUse(obj)
+    end
+end
+
+tag_id(bundle::OperandBundleUse) = API.LLVMGetOperandBundleTagID(bundle)
+
+function tag_name(bundle::OperandBundleUse)
+    len = Ref{Cuint}()
+    data = API.LLVMGetOperandBundleUseTagName(bundle, len)
+    unsafe_string(convert(Ptr{Int8}, data), len[])
+end
+
+function inputs(bundle::OperandBundleUse)
+    nvals = API.LLVMGetOperandBundleUseNumInputs(bundle)
+    vals = Vector{API.LLVMValueRef}(undef, nvals)
+    API.LLVMGetOperandBundleUseInputs(bundle, vals)
+    return [Value(val) for val in vals]
+end
+
+@checked mutable struct OperandBundleDef
+    ref::API.LLVMOperandBundleDefRef
+end
+Base.unsafe_convert(::Type{API.LLVMOperandBundleDefRef}, bundle::OperandBundleDef) =
+    bundle.ref
+
+function tag_name(bundle::OperandBundleDef)
+    len = Ref{Cuint}()
+    data = API.LLVMGetOperandBundleDefTag(bundle, len)
+    unsafe_string(convert(Ptr{Int8}, data), len[])
+end
+
+function OperandBundleDef(bundle_use::OperandBundleUse)
+    bundle_def = OperandBundleDef(API.LLVMOperandBundleDefFromUse(bundle_use))
+    finalizer(bundle_def) do obj
+        API.LLVMDisposeOperandBundleDef(obj)
+    end
+end
+
+function OperandBundleDef(tag::String, inputs::Vector{<:Value}=Value[])
+    bundle = OperandBundleDef(API.LLVMCreateOperandBundleDef(tag, inputs, length(inputs)))
+    finalizer(bundle) do obj
+        API.LLVMDisposeOperandBundleDef(obj)
+    end
+end
+
+function inputs(bundle::OperandBundleDef)
+    nvals = API.LLVMGetOperandBundleDefNumInputs(bundle)
+    vals = Vector{API.LLVMValueRef}(undef, nvals)
+    API.LLVMGetOperandBundleDefInputs(bundle, vals)
+    return [Value(val) for val in vals]
+end
+
+function Base.show(io::IO, bundle::Union{OperandBundleUse,OperandBundleDef})
+    # mimic how bundles are rendered in LLVM IR
+    print(io, "\"", tag_name(bundle), "\"(")
+    join(io, inputs(bundle), ", ")
+    print(io, ")")
+end
+
 
 
 ## terminators

--- a/src/irbuilder.jl
+++ b/src/irbuilder.jl
@@ -347,6 +347,13 @@ call!(builder::Builder, Fn::Value, Args::Vector{<:Value},
     Instruction(API.LLVMBuildCallWithOpBundle(builder, Fn, Args, length(Args), Bundles,
                                               length(Bundles), Name))
 
+# convenience function that performs the OperandBundle(Iterator|Use)->Def conversion
+call!(builder::Builder, Fn::Value, Args::Vector{<:Value},
+      Bundles, Name::String="") =
+    Instruction(API.LLVMBuildCallWithOpBundle(builder, Fn, Args, length(Args),
+                                              OperandBundleDef.(Bundles),
+                                              length(Bundles), Name))
+
 va_arg!(builder::Builder, List::Value, Ty::LLVMType, Name::String="") =
     Instruction(API.LLVMBuildVAArg(builder, List, Ty, Name))
 

--- a/src/irbuilder.jl
+++ b/src/irbuilder.jl
@@ -342,6 +342,11 @@ select!(builder::Builder, If::Value, Then::Value, Else::Value, Name::String="") 
 call!(builder::Builder, Fn::Value, Args::Vector{<:Value}=Value[], Name::String="") =
     Instruction(API.LLVMBuildCall(builder, Fn, Args, length(Args), Name))
 
+call!(builder::Builder, Fn::Value, Args::Vector{<:Value},
+      Bundles::Vector{OperandBundleDef}, Name::String="") =
+    Instruction(API.LLVMBuildCallWithOpBundle(builder, Fn, Args, length(Args), Bundles,
+                                              length(Bundles), Name))
+
 va_arg!(builder::Builder, List::Value, Ty::LLVMType, Name::String="") =
     Instruction(API.LLVMBuildVAArg(builder, List, Ty, Name))
 

--- a/test/instructions.jl
+++ b/test/instructions.jl
@@ -313,10 +313,10 @@ end
             @test length(operands(cy)) == 3
             @test length(operands(cz)) == 2
 
-            ## num_arg_operands excludes all those
-            @test num_arg_operands(cx) == 0
-            @test num_arg_operands(cy) == 0
-            @test num_arg_operands(cz) == 0
+            ## arguments excludes all those
+            @test length(arguments(cx)) == 0
+            @test length(arguments(cy)) == 0
+            @test length(arguments(cz)) == 0
 
             let bundles = operand_bundles(cx)
                 @test isempty(bundles)

--- a/test/instructions.jl
+++ b/test/instructions.jl
@@ -382,6 +382,10 @@ end
                 @test LLVM.tag_name(bundle3) == "unknown"
                 @test LLVM.inputs(bundle3) == inputs
                 @test sprint(io->print(io, bundle3)) == "\"unknown\"(i32 1, i64 2)"
+
+                # creating a call should perform the necessary conversion automatically
+                call!(builder, functions(mod)["x"], Value[], operand_bundles(inst))
+                call!(builder, functions(mod)["x"], Value[], [bundle2])
             end
         end
     end

--- a/test/instructions.jl
+++ b/test/instructions.jl
@@ -281,3 +281,108 @@ end
 end
 
 end
+
+
+@testset "operand bundles" begin
+    ir = """
+        declare void @x()
+        declare void @y()
+        declare void @z()
+
+        define void @f() {
+            call void @x()
+            call void @y() [ "deopt"(i32 1, i64 2) ]
+            call void @z() [ "deopt"(), "unknown"(i8* null) ]
+            ret void
+        }
+
+        define void @g() {
+            ret void
+        }
+        """
+    Context() do ctx
+        mod = parse(LLVM.Module, ir; ctx)
+
+        @testset "iteration" begin
+            f = functions(mod)["f"]
+            bb = first(blocks(f))
+            cx, cy, cz = instructions(bb)
+
+            ## operands includes the function, and each operand bundle input separately
+            @test length(operands(cx)) == 1
+            @test length(operands(cy)) == 3
+            @test length(operands(cz)) == 2
+
+            ## num_arg_operands excludes all those
+            @test num_arg_operands(cx) == 0
+            @test num_arg_operands(cy) == 0
+            @test num_arg_operands(cz) == 0
+
+            let bundles = operand_bundles(cx)
+                @test isempty(bundles)
+            end
+
+            let bundles = operand_bundles(cy)
+                @test length(bundles) == 1
+                bundle = first(bundles)
+                @test LLVM.tag_name(bundle) == "deopt"
+                @test sprint(io->print(io, bundle)) == "\"deopt\"(i32 1, i64 2)"
+
+                inputs = LLVM.inputs(bundle)
+                @test length(inputs) == 2
+                @test inputs[1] == LLVM.ConstantInt(Int32(1); ctx)
+                @test inputs[2] == LLVM.ConstantInt(Int64(2); ctx)
+            end
+
+            let bundles = operand_bundles(cz)
+                @test length(bundles) == 2
+                let bundle = bundles[1]
+                    inputs = LLVM.inputs(bundle)
+                    @test length(inputs) == 0
+                    @test sprint(io->print(io, bundle)) == "\"deopt\"()"
+                end
+                let bundle = bundles[2]
+                    inputs = LLVM.inputs(bundle)
+                    @test length(inputs) == 1
+                    @test sprint(io->print(io, bundle)) == "\"unknown\"(i8* null)"
+                end
+            end
+        end
+
+        @testset "creation" begin
+            g = functions(mod)["g"]
+            bb = first(blocks(g))
+            inst = first(instructions(bb))
+
+            # direct creation
+            inputs = [LLVM.ConstantInt(Int32(1); ctx), LLVM.ConstantInt(Int64(2); ctx)]
+            bundle1 = OperandBundleDef("unknown", inputs)
+            @test bundle1 isa OperandBundleDef
+            @test LLVM.tag_name(bundle1) == "unknown"
+            @test LLVM.inputs(bundle1) == inputs
+            @test sprint(io->print(io, bundle1)) == "\"unknown\"(i32 1, i64 2)"
+
+            # use in a call
+            Builder(ctx) do builder
+                position!(builder, inst)
+                inst = call!(builder, functions(mod)["x"], Value[], [bundle1])
+
+                bundles = operand_bundles(inst)
+                @test length(bundles) == 1
+
+                bundle2 = bundles[1]
+                @test bundle2 isa OperandBundleUse
+                @test LLVM.tag_name(bundle2) == "unknown"
+                @test LLVM.inputs(bundle2) == inputs
+                @test sprint(io->print(io, bundle2)) == "\"unknown\"(i32 1, i64 2)"
+
+                # creating from a use
+                bundle3 = OperandBundleDef(bundle2)
+                @test bundle3 isa OperandBundleDef
+                @test LLVM.tag_name(bundle3) == "unknown"
+                @test LLVM.inputs(bundle3) == inputs
+                @test sprint(io->print(io, bundle3)) == "\"unknown\"(i32 1, i64 2)"
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,7 +61,7 @@ end
 include("support.jl")
 include("core.jl")
 include("linker.jl")
-include("irbuilder.jl")
+include("instructions.jl")
 include("buffer.jl")
 include("bitcode.jl")
 include("ir.jl")


### PR DESCRIPTION
Apparently `operands(call::Instruction)` doesn't only include the function type, but also any operand bundle inputs. Because of that, GPUCompiler.jl was incorrectly rewriting some calls as emitted by Julia (notably `ccall`s which encode rooted values using operand bundles). We can't just drop those, since then the alloc optimization pass may do incorrect stuff, so add support to the C API for enumerating and creating calls with operand bundles attached to them.