### PR TITLE
Bump LLVMExtra for Julia 1.8 compatibility.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -34,9 +34,9 @@ version = "1.3.0"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c5fc4bef251ecd37685bea1c4068a9cfa41e8b9a"
+git-tree-sha1 = "62115afed394c016c2d3096c5b85c407b48be96b"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.13+0"
+version = "0.0.13+1"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/src/executionengine/lljit.jl
+++ b/src/executionengine/lljit.jl
@@ -73,8 +73,17 @@ function triple(lljit::LLJIT)
     Base.unsafe_string(cstr)
 end
 
+if version() < v"13"
 function apply_datalayout!(lljit::LLJIT, mod::LLVM.Module)
     LLVM.API.LLVMOrcLLJITApplyDataLayout(lljit, mod)
+end
+else
+function datalayout(lljit::LLJIT)
+    Base.unsafe_string(API.LLVMOrcLLJITGetDataLayoutStr(lljit))
+end
+function apply_datalayout!(lljit::LLJIT, mod::LLVM.Module)
+    datalayout!(mod, datalayout(lljit))
+end
 end
 
 function get_prefix(lljit::LLJIT)


### PR DESCRIPTION
Fixes https://github.com/maleadt/LLVM.jl/issues/276