### PR TITLE
Add adjustPassManager to run target specific passes

### DIFF
--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -4,6 +4,10 @@
 #include "llvm/Config/llvm-config.h"
 #include <llvm-c/Core.h>
 #include <llvm-c/Types.h>
+typedef struct LLVMOpaqueTargetMachine *LLVMTargetMachineRef;
+// Can't include TargetMachine since that would inclue LLVMInitializeNativeTarget
+// #include <llvm-c/TargetMachine.h>
+#include <llvm-c/Transforms/PassManagerBuilder.h>
 
 LLVM_C_EXTERN_C_BEGIN
 
@@ -159,6 +163,7 @@ LLVMValueRef LLVMBuildCallWithOpBundle(LLVMBuilderRef B, LLVMValueRef Fn,
                                        LLVMValueRef *Args, unsigned NumArgs,
                                        LLVMOperandBundleDefRef *Bundles, unsigned NumBundles,
                                        const char *Name);
+void LLVMAdjustPassManager(LLVMTargetMachineRef TM, LLVMPassManagerBuilderRef PMB);
 
 LLVM_C_EXTERN_C_END
 #endif

--- a/deps/LLVMExtra/lib/llvm-api.cpp
+++ b/deps/LLVMExtra/lib/llvm-api.cpp
@@ -21,6 +21,7 @@
 #endif
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
+#include <llvm/Target/TargetMachine.h>
 
 using namespace llvm;
 using namespace llvm::legacy;
@@ -547,4 +548,10 @@ LLVMValueRef LLVMBuildCallWithOpBundle(LLVMBuilderRef B, LLVMValueRef Fn,
 
     return wrap(unwrap(B)->CreateCall(FnT, unwrap(Fn), makeArrayRef(unwrap(Args), NumArgs),
                                       BundleArray, Name));
+}
+
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(TargetMachine, LLVMTargetMachineRef)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(PassManagerBuilder, LLVMPassManagerBuilderRef)
+void LLVMAdjustPassManager(LLVMTargetMachineRef TM, LLVMPassManagerBuilderRef PMB) {
+  unwrap(TM)->adjustPassManager(*unwrap(PMB));
 }

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -419,3 +419,6 @@ function LLVMBuildCallWithOpBundle(B, Fn, Args, NumArgs, Bundles, NumBundles, Na
     ccall((:LLVMBuildCallWithOpBundle, libLLVMExtra), LLVMValueRef, (LLVMBuilderRef, LLVMValueRef, Ptr{LLVMValueRef}, Cuint, Ptr{LLVMOperandBundleDefRef}, Cuint, Cstring), B, Fn, Args, NumArgs, Bundles, NumBundles, Name)
 end
 
+function LLVMAdjustPassManager(TM, PMB)
+    ccall((:LLVMAdjustPassManager, libLLVMExtra), Cvoid, (LLVMTargetMachineRef, LLVMPassManagerBuilderRef), TM, PMB)
+end

--- a/src/targetmachine.jl
+++ b/src/targetmachine.jl
@@ -18,6 +18,12 @@ TargetMachine(t::Target, triple::String, cpu::String="", features::String="";
     TargetMachine(API.LLVMCreateTargetMachine(t, triple, cpu, features, optlevel,
                                               reloc, code))
 
+function TargetMachine()
+    host_triple = triple()
+    host_t = Target(triple=host_triple)
+    TargetMachine(host_t, host_triple)
+end
+
 dispose(tm::TargetMachine) = API.LLVMDisposeTargetMachine(tm)
 
 function TargetMachine(f::Core.Function, args...; kwargs...)

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -3,7 +3,7 @@
 export PassManagerBuilder, dispose,
        optlevel!, sizelevel!,
        unit_at_a_time!, unroll_loops!, simplify_libcalls!, inliner!,
-       populate!
+       populate!, adjust!
 
 @checked struct PassManagerBuilder
     ref::API.LLVMPassManagerBuilderRef
@@ -50,6 +50,8 @@ populate!(fpm::FunctionPassManager, pmb::PassManagerBuilder) =
 populate!(mpm::ModulePassManager, pmb::PassManagerBuilder) =
     API.LLVMPassManagerBuilderPopulateModulePassManager(pmb, mpm)
 
+adjust!(pmb::PassManagerBuilder, tm::TargetMachine) =
+    API.LLVMAdjustPassManager(tm, pmb)
 
 ## auxiliary
 

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -14,6 +14,10 @@ PassManagerBuilder() do pmb
     simplify_libcalls!(pmb, false)
     inliner!(pmb, 0)
 
+    TargetMachine() do tm
+        adjust!(pmb, tm)
+    end
+
     Context() do ctx
     LLVM.Module("SomeModule"; ctx) do mod
         FunctionPassManager(mod) do fpm


### PR DESCRIPTION
Both opt and clang call `TM->adjustPassManager(PMB)` to add the target specific passes,
like NVVMReflect to the pass list.
