### PR TITLE
add `llvmeltype`

### DIFF
--- a/src/core/value.jl
+++ b/src/core/value.jl
@@ -40,9 +40,10 @@ end
 
 ## general APIs
 
-export llvmtype, name, name!, replace_uses!, isconstant, isundef, context
+export llvmtype, llvmeltype, name, name!, replace_uses!, isconstant, isundef, context
 
 llvmtype(val::Value) = LLVMType(API.LLVMTypeOf(val))
+llvmeltype(val::Value) = eltype(llvmtype(val))
 
 name(val::Value) = unsafe_string(API.LLVMGetValueName(val))
 name!(val::Value, name::String) = API.LLVMSetValueName(val, name)

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -133,7 +133,7 @@ register(ConstantAggregateZero, API.LLVMConstantAggregateZeroValueKind)
 # array interface
 # FIXME: can we reuse the ::ConstantArray functionality with ConstantAggregateZero values?
 #        probably works fine if we just get rid of the refcheck
-Base.eltype(caz::ConstantAggregateZero) = eltype(llvmtype(caz))
+Base.eltype(caz::ConstantAggregateZero) = llvmeltype(caz)
 Base.size(caz::ConstantAggregateZero) = (0,)
 Base.length(caz::ConstantAggregateZero) = 0
 Base.axes(caz::ConstantAggregateZero) = (Base.OneTo(0),)
@@ -196,7 +196,7 @@ function Base.collect(ca::ConstantArray)
 end
 
 # array interface
-Base.eltype(ca::ConstantArray) = eltype(llvmtype(ca))
+Base.eltype(ca::ConstantArray) = llvmeltype(ca)
 function Base.size(ca::ConstantArray)
     dims = Int[]
     typ = llvmtype(ca)

--- a/src/interop/base.jl
+++ b/src/interop/base.jl
@@ -91,7 +91,7 @@ function Base.convert(::Type{LLVMType}, typ::Type; ctx::Union{Nothing,Context}=n
         llvmtyp = let
             mod = parse(LLVM.Module, buf; ctx)
             gv = first(globals(mod))
-            eltype(llvmtype(gv))
+            llvmeltype(gv)
         end
     end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -49,8 +49,8 @@ function clone(f::Function; value_map::Dict{Value,Value}=Dict{Value,Value}())
     end
 
     # Create a new function type...
-    vararg = isvararg(eltype(llvmtype(f)))
-    fty = FunctionType(return_type(eltype(llvmtype(f))), argtypes; vararg)
+    vararg = isvararg(llvmeltype(f))
+    fty = FunctionType(return_type(llvmeltype(f)), argtypes; vararg)
 
     # Create the new function...
     new_f = Function(parent(f), name(f), fty)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1047,7 +1047,7 @@ LLVM.Module("SomeModule"; ctx) do mod
 
     fn = LLVM.Function(mod, intr)
     @test fn isa LLVM.Function
-    @test eltype(llvmtype(fn)) == ft
+    @test llvmeltype(fn) == ft
     @test isintrinsic(fn)
 
     @test intr == Intrinsic("llvm.trap")
@@ -1074,7 +1074,7 @@ LLVM.Module("SomeModule"; ctx) do mod
 
     fn = LLVM.Function(mod, intr, [LLVM.DoubleType(ctx)])
     @test fn isa LLVM.Function
-    @test eltype(llvmtype(fn)) == ft
+    @test llvmeltype(fn) == ft
     @test isintrinsic(fn)
 
     @test intr == Intrinsic("llvm.sin")


### PR DESCRIPTION
This adds a quick way to get the eltype of a  `PointerType`. 