### PR TITLE
Update jl_type_to_llvm to require a context in >= v1.9

### DIFF
--- a/test/interop.jl
+++ b/test/interop.jl
@@ -32,12 +32,13 @@ end
 end
 @eval mutable struct NonGhostType2 end
 
+@test isboxed(NonGhostType2)
 @test isghosttype(GhostType)
 @test !isghosttype(NonGhostType1)
 @test !isghosttype(NonGhostType2)
-@test isboxed(NonGhostType2)
 
 Context() do ctx
+    @test isboxed(NonGhostType2; ctx)
     @test isghosttype(GhostType; ctx)
     @test !isghosttype(NonGhostType1; ctx)
     @test !isghosttype(NonGhostType2; ctx)


### PR DESCRIPTION
This PR should update jl_type_to_llvm calls to pass the context along, which is required when JuliaLang/julia#43827 is merged. 