### PR TITLE
Support for iterating DICompileUnits in debug info.

### DIFF
--- a/src/debuginfo.jl
+++ b/src/debuginfo.jl
@@ -139,6 +139,16 @@ register(DISubProgram, API.LLVMDISubprogramMetadataKind)
 line(subprogram::DISubProgram) = Int(API.LLVMDISubprogramGetLine(subprogram))
 
 
+## compile unit
+
+export DICompileUnit
+
+@checked struct DICompileUnit <: DIScope
+    ref::API.LLVMMetadataRef
+end
+register(DICompileUnit, API.LLVMDICompileUnitMetadataKind)
+
+
 ## other
 
 export DEBUG_METADATA_VERSION, strip_debuginfo!


### PR DESCRIPTION
There aren't methods for using these structs, but we currently fail if we don't recognize it. Maybe that's not the best design, but let's just add support using the existing set-up for now.