### PR TITLE
Add support for extracting a Value from a ValueAsMetadata.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -33,10 +33,10 @@ uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.4.1"
 
 [[LLVMExtra_jll]]
-deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "5558ad3c8972d602451efe9d81c78ec14ef4f5ef"
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]
+git-tree-sha1 = "00d23b26d194507028b9a1c2728a691ab9914262"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.14+2"
+version = "0.0.15+0"
 
 [[LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -84,9 +84,9 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "de893592a221142f3db370f48290e3a2ef39998f"
+git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.4"
+version = "1.3.0"
 
 [[Printf]]
 deps = ["Unicode"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-LLVMExtra_jll = "=0.0.14"
+LLVMExtra_jll = "=0.0.15"
 julia = "1.6"

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -153,6 +153,7 @@ LLVMValueRef LLVMBuildCallWithOpBundle(LLVMBuilderRef B, LLVMValueRef Fn,
                                        LLVMValueRef *Args, unsigned NumArgs,
                                        LLVMOperandBundleDefRef *Bundles, unsigned NumBundles,
                                        const char *Name);
+LLVMValueRef LLVMMetadataAsValue2(LLVMContextRef C, LLVMMetadataRef Metadata);
 
 LLVM_C_EXTERN_C_END
 #endif

--- a/deps/LLVMExtra/lib/llvm-api.cpp
+++ b/deps/LLVMExtra/lib/llvm-api.cpp
@@ -518,3 +518,11 @@ LLVMValueRef LLVMBuildCallWithOpBundle(LLVMBuilderRef B, LLVMValueRef Fn,
     return wrap(unwrap(B)->CreateCall(FnT, unwrap(Fn), makeArrayRef(unwrap(Args), NumArgs),
                                       BundleArray, Name));
 }
+
+LLVMValueRef LLVMMetadataAsValue2(LLVMContextRef C, LLVMMetadataRef Metadata) {
+  auto *MD = unwrap(Metadata);
+  if (auto *VAM = dyn_cast<ValueAsMetadata>(MD))
+    return wrap(VAM->getValue());
+  else
+    return wrap(MetadataAsValue::get(*unwrap(C), MD));
+}

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -395,3 +395,6 @@ function LLVMBuildCallWithOpBundle(B, Fn, Args, NumArgs, Bundles, NumBundles, Na
     ccall((:LLVMBuildCallWithOpBundle, libLLVMExtra), LLVMValueRef, (LLVMBuilderRef, LLVMValueRef, Ptr{LLVMValueRef}, Cuint, Ptr{LLVMOperandBundleDefRef}, Cuint, Cstring), B, Fn, Args, NumArgs, Bundles, NumBundles, Name)
 end
 
+function LLVMMetadataAsValue2(C, MD)
+    ccall((:LLVMMetadataAsValue2, libLLVMExtra), LLVMValueRef, (LLVMContextRef, LLVMMetadataRef), C, MD)
+end

--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -48,7 +48,11 @@ end
 end
 register(MetadataAsValue, API.LLVMMetadataAsValueValueKind)
 
-Value(md::Metadata; ctx::Context) = MetadataAsValue(API.LLVMMetadataAsValue(ctx, md))
+# NOTE: this can be used to both pack e.g. metadata as a value, and to extract the
+#       value from an ValueAsMetadata, so we don't type-assert narrowly here
+Value(md::Metadata; ctx::Context) = Value(API.LLVMMetadataAsValue2(ctx, md))
+
+Base.convert(T::Type{<:Value}, val::Metadata) = Value(val)::T
 
 # NOTE: we can't do this automatically, as we can't query the context of metadata...
 #       add wrappers to do so? would also simplify, e.g., `string(::MDString)`
@@ -72,7 +76,7 @@ register(LocalAsMetadata, API.LLVMLocalAsMetadataMetadataKind)
 #       metadata from an MetadataAsValue, so we don't type-assert narrowly here
 Metadata(val::Value) = Metadata(API.LLVMValueAsMetadata(val))
 
-Base.convert(::Type{Metadata}, val::Value) = Metadata(val)
+Base.convert(T::Type{<:Metadata}, val::Value) = Metadata(val)::T
 
 
 ## values

--- a/test/core.jl
+++ b/test/core.jl
@@ -779,6 +779,33 @@ end
 Context() do ctx
     str = MDString("foo"; ctx)
     @test string(str) == "foo"
+
+    # wrap as Value
+    val = Value(str; ctx)
+    @test val isa LLVM.MetadataAsValue
+
+    # back to Metadata
+    md = Metadata(val)
+    @test md == str
+
+    # more specific conversion
+    @test convert(MDString, val) == str
+end
+
+Context() do ctx
+    int = ConstantInt(42; ctx)
+    @test convert(Int, int) == 42
+
+    # wrap as Metadata
+    md = Metadata(int)
+    @test md isa LLVM.ValueAsMetadata
+
+    # back to Value
+    val = Value(md; ctx)
+    @test val == int
+
+    # more specific conversion
+    @test convert(ConstantInt, val) == int
 end
 
 Context() do ctx


### PR DESCRIPTION
Upstream ValueAsMetadata handles the extraction, MetadataAsValue doesn't: https://github.com/llvm/llvm-project/blob/6c2a01ce3a824622e4491e913023c304841363b1/llvm/lib/IR/Core.cpp#L1157-L1168=