### PR TITLE
Add support for replacing values in metadata.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -34,9 +34,9 @@ version = "1.4.1"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]
-git-tree-sha1 = "00d23b26d194507028b9a1c2728a691ab9914262"
+git-tree-sha1 = "771bfe376249626d3ca12bcd58ba243d3f961576"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.15+0"
+version = "0.0.16+0"
 
 [[LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-LLVMExtra_jll = "=0.0.15"
+LLVMExtra_jll = "=0.0.16"
 julia = "1.6"

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -154,6 +154,8 @@ LLVMValueRef LLVMBuildCallWithOpBundle(LLVMBuilderRef B, LLVMValueRef Fn,
                                        LLVMOperandBundleDefRef *Bundles, unsigned NumBundles,
                                        const char *Name);
 LLVMValueRef LLVMMetadataAsValue2(LLVMContextRef C, LLVMMetadataRef Metadata);
+void LLVMReplaceAllMetadataUsesWith(LLVMValueRef Old, LLVMValueRef New);
+void LLVMReplaceMDNodeOperandWith(LLVMMetadataRef MD, unsigned I, LLVMMetadataRef New);
 
 LLVM_C_EXTERN_C_END
 #endif

--- a/deps/LLVMExtra/lib/llvm-api.cpp
+++ b/deps/LLVMExtra/lib/llvm-api.cpp
@@ -526,3 +526,11 @@ LLVMValueRef LLVMMetadataAsValue2(LLVMContextRef C, LLVMMetadataRef Metadata) {
   else
     return wrap(MetadataAsValue::get(*unwrap(C), MD));
 }
+
+void LLVMReplaceAllMetadataUsesWith(LLVMValueRef Old, LLVMValueRef New) {
+  ValueAsMetadata::handleRAUW(unwrap<Value>(Old), unwrap<Value>(New));
+}
+
+void LLVMReplaceMDNodeOperandWith(LLVMMetadataRef MD, unsigned I, LLVMMetadataRef New) {
+    unwrap<MDNode>(MD)->replaceOperandWith(I, unwrap(New));
+}

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -398,3 +398,11 @@ end
 function LLVMMetadataAsValue2(C, MD)
     ccall((:LLVMMetadataAsValue2, libLLVMExtra), LLVMValueRef, (LLVMContextRef, LLVMMetadataRef), C, MD)
 end
+
+function LLVMReplaceAllMetadataUsesWith(OldVal, NewVal)
+    ccall((:LLVMReplaceAllMetadataUsesWith, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), OldVal, NewVal)
+end
+
+function LLVMReplaceMDNodeOperandWith(MD, I, New)
+    ccall((:LLVMReplaceMDNodeOperandWith, libLLVMExtra), Cvoid, (LLVMMetadataRef, Cuint, LLVMMetadataRef), MD, I, New)
+end

--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -111,6 +111,11 @@ function operands(md::MDNode)
     return [Metadata(op) for op in ops]
 end
 
+# TODO: setindex?
+function replace_operand(md::MDNode, i, new::Metadata)
+    API.LLVMReplaceMDNodeOperandWith(md, i-1, new)
+end
+
 
 ## tuples
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -816,6 +816,34 @@ Context() do ctx
 end
 
 Context() do ctx
+    mod = LLVM.Module("SomeModule"; ctx)
+    ft = LLVM.FunctionType(LLVM.VoidType(ctx))
+    f1 = LLVM.Function(mod, "f1", ft)
+
+    push!(metadata(mod)["function"], MDNode([f1]; ctx))
+    @test Value(operands(operands(metadata(mod)["function"])[1])[1]; ctx) == f1
+
+    f2 = LLVM.Function(mod, "f2", ft)
+    replace_metadata_uses!(f1, f2)
+    @test Value(operands(operands(metadata(mod)["function"])[1])[1]; ctx) == f2
+end
+
+# different type; requires a hack
+Context() do ctx
+    mod = LLVM.Module("SomeModule"; ctx)
+    ft1 = LLVM.FunctionType(LLVM.VoidType(ctx))
+    f1 = LLVM.Function(mod, "f1", ft1)
+
+    push!(metadata(mod)["function"], MDNode([f1]; ctx))
+    @test Value(operands(operands(metadata(mod)["function"])[1])[1]; ctx) == f1
+
+    ft2 = LLVM.FunctionType(LLVM.Int32Type(ctx))
+    f2 = LLVM.Function(mod, "f2", ft2)
+    replace_metadata_uses!(f1, f2)
+    @test Value(operands(operands(metadata(mod)["function"])[1])[1]; ctx) == f2
+end
+
+Context() do ctx
     str = MDString("foo"; ctx)
     node = MDNode([str]; ctx)
     ops = operands(node)


### PR DESCRIPTION
Hack inspired by https://discourse.llvm.org/t/replacing-module-metadata-uses-of-function/62431/4
We should probably remove the type assertion from `ValueAsMetadata::doRAUW` in upstream LLVM.

When we have https://reviews.llvm.org/D125388 we can simplify this.