### PR TITLE
Introduce at-dispose to replace do-block constructors.

### DIFF
--- a/examples/Kaleidoscope/codegen.jl
+++ b/examples/Kaleidoscope/codegen.jl
@@ -23,7 +23,7 @@ Base.show(io::IO, cg::CodeGen) = print(io, "CodeGen")
 
 function create_entry_block_allocation(cg::CodeGen, fn::LLVM.Function, varname::String)
     local alloc
-    LLVM.Builder(cg.ctx) do builder
+    LLVM.@dispose builder=LLVM.Builder(cg.ctx) begin
         # Set the builder at the start of the function
         entry_block = LLVM.entry(fn)
         if isempty(LLVM.instructions(entry_block))

--- a/examples/constrained.jl
+++ b/examples/constrained.jl
@@ -33,7 +33,7 @@ meta(::Type{FPExceptStrict}) = "fpexcept.strict"
                                {F, round, fpexcept, T<:AbstractFloat, N}
     @assert N >= 0
 
-    Context() do ctx
+    @dispose ctx=Context() begin
         typ = convert(LLVMType, T; ctx)
 
         # create a function
@@ -50,7 +50,7 @@ meta(::Type{FPExceptStrict}) = "fpexcept.strict"
                                 intrinsic_typ)
 
         # generate IR
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
             val = call!(builder, intrinsic,

--- a/examples/generated.jl
+++ b/examples/generated.jl
@@ -9,7 +9,7 @@ struct CustomPtr{T}
 end
 
 @generated function Base.unsafe_load(p::CustomPtr{T}, i::Integer=1) where T
-    Context() do ctx
+    @dispose ctx=Context() begin
         # get the element type
         eltyp = convert(LLVMType, T; ctx)
 
@@ -21,7 +21,7 @@ end
         llvmf, _ = create_function(eltyp, paramtyps)
 
         # generate IR
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvmf, "entry"; ctx)
             position!(builder, entry)
 

--- a/examples/sum.jl
+++ b/examples/sum.jl
@@ -11,7 +11,7 @@ else
     y = Int32(2)
 end
 
-Context() do ctx
+@dispose ctx=Context() begin
     # set-up
     mod = LLVM.Module("my_module"; ctx)
 
@@ -21,7 +21,7 @@ Context() do ctx
     sum = LLVM.Function(mod, "sum", fun_type)
 
     # generate IR
-    Builder(ctx) do builder
+    @dispose builder=Builder(ctx) begin
         entry = BasicBlock(sum, "entry"; ctx)
         position!(builder, entry)
 
@@ -33,7 +33,7 @@ Context() do ctx
     end
 
     # analysis and execution
-    Interpreter(mod) do engine
+    @dispose engine=Interpreter(mod) begin
         args = [GenericValue(LLVM.Int32Type(ctx), x),
                 GenericValue(LLVM.Int32Type(ctx), y)]
 

--- a/examples/sum_integrated.jl
+++ b/examples/sum_integrated.jl
@@ -12,13 +12,13 @@ else
     y = Int32(2)
 end
 
-Context() do ctx
+@dispose ctx=Context() begin
     param_types = [LLVM.Int32Type(ctx), LLVM.Int32Type(ctx)]
     ret_type = LLVM.Int32Type(ctx)
     sum, _ = create_function(ret_type, param_types)
 
     # generate IR
-    Builder(ctx) do builder
+    @dispose builder=Builder(ctx) begin
         entry = BasicBlock(sum, "entry"; ctx)
         position!(builder, entry)
 

--- a/examples/sum_orc.jl
+++ b/examples/sum_orc.jl
@@ -22,7 +22,7 @@ function codegen!(mod::LLVM.Module, name, tm)
     sum = LLVM.Function(mod, name, ft)
 
     # generate IR
-    Builder(ctx) do builder
+    @dispose builder=Builder(ctx) begin
         entry = BasicBlock(sum, "entry"; ctx)
         position!(builder, entry)
 
@@ -32,7 +32,7 @@ function codegen!(mod::LLVM.Module, name, tm)
 
     verify(mod)
 
-    ModulePassManager() do pm
+    @dispose pm=ModulePassManager() begin
         add_library_info!(pm, triple(mod))
         add_transform_info!(pm, tm)
         run!(pm, mod)
@@ -61,7 +61,7 @@ if LLVM.has_orc_v2()
     finalizer(LLVM.dispose, lljit)
     JIT = lljit
 else
-    Context() do ctx
+    @dispose ctx=Context() begin
         # Setup jit
         tm = JITTargetMachine()
 

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -281,7 +281,7 @@ end
 
 # FIXME: remove on LLVM 12
 function LLVMGetTypeByName2(ctx::Context, name)
-    Module("dummy"; ctx) do mod
+    @dispose mod=Module("dummy"; ctx) begin
         API.LLVMGetTypeByName(mod, name)
     end
 end

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -537,8 +537,8 @@ linkage!(val::GlobalValue, linkage::API.LLVMLinkage) =
 function section(val::GlobalValue)
   #=
   The following started to fail on LLVM 4.0:
-    Context() do ctx
-      LLVM.Module("SomeModule"; ctx) do mod
+    @dispose ctx=Context() begin
+      @dispose mod=LLVM.Module("SomeModule"; ctx) begin
         st = LLVM.StructType("SomeType"; ctx)
         ft = LLVM.FunctionType(st, [st])
         fn = LLVM.Function(mod, "SomeFunction", ft)

--- a/src/executionengine/lljit.jl
+++ b/src/executionengine/lljit.jl
@@ -75,7 +75,7 @@ end
 
 if version() < v"13"
 function apply_datalayout!(lljit::LLJIT, mod::LLVM.Module)
-    LLVM.API.LLVMOrcLLJITApplyDataLayout(lljit, mod)
+    API.LLVMOrcLLJITApplyDataLayout(lljit, mod)
 end
 else
 function datalayout(lljit::LLJIT)

--- a/src/executionengine/ts_module.jl
+++ b/src/executionengine/ts_module.jl
@@ -42,7 +42,7 @@ end
 Construct a ThreadSafeModule from a fresh LLVM.Module and a private context.
 """
 function ThreadSafeModule(name::String)
-    ThreadSafeContext() do ctx
+    ctx = @dispose ctx=ThreadSafeContext() begin
         mod = LLVM.Module(name; ctx=context(ctx))
         ThreadSafeModule(mod; ctx)
     end

--- a/src/interop/asmcall.jl
+++ b/src/interop/asmcall.jl
@@ -3,7 +3,7 @@ export @asmcall
 @generated function _asmcall(::Val{asm}, ::Val{constraints}, ::Val{side_effects},
                              ::Val{rettyp}, ::Val{argtyp}, args...) where
                             {asm, constraints, side_effects, rettyp, argtyp}
-    Context() do ctx
+    @dispose ctx=Context() begin
         # create a function
         llvm_rettyp = convert(LLVMType, rettyp; ctx)
         llvm_argtyp = LLVMType[convert.(LLVMType, [argtyp.parameters...]; ctx)...]
@@ -12,7 +12,7 @@ export @asmcall
         inline_asm = InlineAsm(llvm_ft, String(asm), String(constraints), side_effects)
 
         # generate IR
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 

--- a/src/interop/atomics.jl
+++ b/src/interop/atomics.jl
@@ -166,7 +166,7 @@ end
 @generated function atomic_pointerref(ptr::LLVMPtr{T,A}, order::AllOrdering) where {T,A}
     sizeof(T) == 0 && return T.instance
     llvm_order = _valueof(llvm_from_julia_ordering(order()))
-    Context() do ctx
+    @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T; ctx)
 
         T_ptr = convert(LLVMType, ptr; ctx)
@@ -178,7 +178,7 @@ end
         llvm_f, _ = create_function(eltyp, param_types)
 
         # generate IR
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 
@@ -213,7 +213,7 @@ end
         end
     end
     llvm_order = _valueof(llvm_from_julia_ordering(order()))
-    Context() do ctx
+    @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T; ctx)
         T_ptr = convert(LLVMType, ptr; ctx)
         T_typed_ptr = LLVM.PointerType(eltyp, A)
@@ -223,7 +223,7 @@ end
         llvm_f, _ = create_function(LLVM.VoidType(ctx), param_types)
 
         # generate IR
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 
@@ -273,7 +273,7 @@ const AtomicRMWBinOpVal = Union{(Val{binop} for (_, _, binop) in binoptable)...}
     val::T,
     order::LLVMOrderingVal,
 ) where {T,A}
-    Context() do ctx
+    @dispose ctx=Context() begin
         T_val = convert(LLVMType, T; ctx)
         T_ptr = convert(LLVMType, ptr; ctx)
 
@@ -281,7 +281,7 @@ const AtomicRMWBinOpVal = Union{(Val{binop} for (_, _, binop) in binoptable)...}
 
         llvm_f, _ = create_function(T_val, [T_ptr, T_val])
 
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 
@@ -406,7 +406,7 @@ end
 ) where {T,A}
     llvm_success = _valueof(success_order())
     llvm_fail = _valueof(fail_order())
-    Context() do ctx
+    @dispose ctx=Context() begin
         T_val = convert(LLVMType, T; ctx)
         T_pointee = T_val
         if T_val isa LLVM.FloatingPointType
@@ -420,7 +420,7 @@ end
 
         llvm_f, _ = create_function(T_val, [T_ptr, T_val, T_val, T_success])
 
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 

--- a/src/interop/base.jl
+++ b/src/interop/base.jl
@@ -57,7 +57,7 @@ function isboxed(typ::Type; ctx::Union{Nothing,Context}=nothing)
     isboxed_ref = Ref{Bool}()
     if VERSION >= v"1.9.0-DEV.115"
         if ctx === nothing
-            Context() do ctx
+            @dispose ctx=Context() begin
                 ccall(:jl_type_to_llvm, LLVM.API.LLVMTypeRef,
                       (Any, LLVM.API.LLVMContextRef, Ptr{Bool}), typ, ctx, isboxed_ref)
             end
@@ -126,7 +126,7 @@ This only works for types created by the Julia compiler (living in its LLVM cont
 isghosttype(@nospecialize(T::LLVMType)) = T == LLVM.VoidType(context(T)) || isempty(T)
 function isghosttype(@nospecialize(t::Type); ctx::Union{Nothing,Context}=nothing)
     if ctx === nothing
-        Context() do ctx′
+        @dispose ctx′=Context() begin
             T = convert(LLVMType, t; ctx=ctx′, allow_boxed=true)
             isghosttype(T)
         end

--- a/src/interop/pointer.jl
+++ b/src/interop/pointer.jl
@@ -8,7 +8,7 @@ using Core: LLVMPtr
 
 @generated function pointerref(ptr::LLVMPtr{T,A}, i::Integer, ::Val{align}) where {T,A,align}
     sizeof(T) == 0 && return T.instance
-    Context() do ctx
+    @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T; ctx)
 
         T_int = convert(LLVMType, Int; ctx)
@@ -21,7 +21,7 @@ using Core: LLVMPtr
         llvm_f, _ = create_function(eltyp, param_types)
 
         # generate IR
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 
@@ -43,7 +43,7 @@ end
 
 @generated function pointerset(ptr::LLVMPtr{T,A}, x::T, i::Integer, ::Val{align}) where {T,A,align}
     sizeof(T) == 0 && return
-    Context() do ctx
+    @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T; ctx)
 
         T_int = convert(LLVMType, Int; ctx)
@@ -56,7 +56,7 @@ end
         llvm_f, _ = create_function(LLVM.VoidType(ctx), param_types)
 
         # generate IR
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 
@@ -125,14 +125,14 @@ Base.signed(x::LLVMPtr) = Int(x)
     argexprs = Expr[:(args[$i]) for i in 1:length(args)]
 
     # build IR that calls the intrinsic, casting types if necessary
-    Context() do ctx
+    @dispose ctx=Context() begin
         T_ret = convert(LLVMType, rettyp; ctx)
         T_args = LLVMType[convert(LLVMType, typ; ctx) for typ in argtyps]
 
         llvm_f, _ = create_function(T_ret, T_args)
         mod = LLVM.parent(llvm_f)
 
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 

--- a/src/jitevents.jl
+++ b/src/jitevents.jl
@@ -6,7 +6,7 @@ export JITEventListener, GDBRegistrationListener, IntelJITEventListener,
 end
 Base.unsafe_convert(::Type{API.LLVMJITEventListenerRef}, listener::JITEventListener) = listener.ref
 
-GDBRegistrationListener()  = JITEventListener(LLVM.API.LLVMCreateGDBRegistrationListener())
-IntelJITEventListener()    = JITEventListener(LLVM.API.LLVMCreateIntelJITEventListener())
-OProfileJITEventListener() = JITEventListener(LLVM.API.LLVMCreateOProfileJITEventListener())
-PerfJITEventListener()     = JITEventListener(LLVM.API.LLVMCreatePerfJITEventListener())
+GDBRegistrationListener()  = JITEventListener(API.LLVMCreateGDBRegistrationListener())
+IntelJITEventListener()    = JITEventListener(API.LLVMCreateIntelJITEventListener())
+OProfileJITEventListener() = JITEventListener(API.LLVMCreateOProfileJITEventListener())
+PerfJITEventListener()     = JITEventListener(API.LLVMCreatePerfJITEventListener())

--- a/src/orc.jl
+++ b/src/orc.jl
@@ -40,7 +40,7 @@ end
 function errormsg(orc::OrcJIT)
     # The error message is owned by `orc`, and will
     # be disposed along-side the OrcJIT.
-    unsafe_string(LLVM.API.LLVMOrcGetErrorMsg(orc))
+    unsafe_string(API.LLVMOrcGetErrorMsg(orc))
 end
 
 struct OrcModule
@@ -99,7 +99,7 @@ function compile!(orc::OrcJIT, mod::Module, resolver = @cfunction(resolver, UInt
 end
 
 function Base.delete!(orc::OrcJIT, mod::OrcModule)
-    LLVM.API.LLVMOrcRemoveModule(orc, mod)
+    API.LLVMOrcRemoveModule(orc, mod)
 end
 
 function add!(orc::OrcJIT, obj::MemoryBuffer, resolver = @cfunction(resolver, UInt64, (Cstring, Ptr{Cvoid})), resolver_ctx = orc)
@@ -110,9 +110,9 @@ end
 
 function mangle(orc::OrcJIT, name)
     r_symbol = Ref{Cstring}()
-    LLVM.API.LLVMOrcGetMangledSymbol(orc, r_symbol, name)
+    API.LLVMOrcGetMangledSymbol(orc, r_symbol, name)
     symbol = unsafe_string(r_symbol[])
-    LLVM.API.LLVMOrcDisposeMangledSymbol(r_symbol[])
+    API.LLVMOrcDisposeMangledSymbol(r_symbol[])
     return symbol
 end
 
@@ -126,11 +126,11 @@ Base.pointer(addr::OrcTargetAddress) = reinterpret(Ptr{Cvoid}, addr.ptr % UInt) 
 OrcTargetAddress(ptr::Ptr{Cvoid}) = OrcTargetAddress(reinterpret(UInt, ptr))
 
 function create_stub!(orc::OrcJIT, name, initial)
-    LLVM.API.LLVMOrcCreateIndirectStub(orc, name, initial)
+    API.LLVMOrcCreateIndirectStub(orc, name, initial)
 end
 
 function set_stub!(orc::OrcJIT, name, new)
-    LLVM.API.LLVMOrcSetIndirectStubPointer(orc, name, new)
+    API.LLVMOrcSetIndirectStubPointer(orc, name, new)
 end
 
 function address(orc::OrcJIT, name)
@@ -152,9 +152,9 @@ function callback!(orc::OrcJIT, callback, ctx)
 end
 
 function register!(orc::OrcJIT, listener::JITEventListener)
-    LLVM.API.LLVMOrcRegisterJITEventListener(orc, listener)
+    API.LLVMOrcRegisterJITEventListener(orc, listener)
 end
 
 function unregister!(orc::OrcJIT, listener::JITEventListener)
-    LLVM.API.LLVMOrcUnregisterJITEventListener(orc, listener)
+    API.LLVMOrcUnregisterJITEventListener(orc, listener)
 end

--- a/src/orcv2.jl
+++ b/src/orcv2.jl
@@ -46,7 +46,7 @@ end
 Base.unsafe_convert(::Type{API.LLVMOrcObjectLayerRef}, oll::ObjectLinkingLayer) = oll.ref
 
 function ObjectLinkingLayer(es::ExecutionSession)
-    ref = LLVM.API.LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager(es)
+    ref = API.LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager(es)
     ObjectLinkingLayer(ref)
 end
 
@@ -62,7 +62,7 @@ mutable struct ObjectLinkingLayerCreator
     cb
 end
 
-function ollc_callback(ctx::Ptr{Cvoid}, es::LLVM.API.LLVMOrcExecutionSessionRef, triple::Ptr{Cchar})
+function ollc_callback(ctx::Ptr{Cvoid}, es::API.LLVMOrcExecutionSessionRef, triple::Ptr{Cchar})
     es = ExecutionSession(es)
     triple = Base.unsafe_string(triple)
 
@@ -80,8 +80,8 @@ end
 """
 function linkinglayercreator!(builder::LLJITBuilder, creator::ObjectLinkingLayerCreator)
     cb = @cfunction(ollc_callback,
-                    LLVM.API.LLVMOrcObjectLayerRef,
-                    (Ptr{Cvoid}, LLVM.API.LLVMOrcExecutionSessionRef, Ptr{Cchar}))
+                    API.LLVMOrcObjectLayerRef,
+                    (Ptr{Cvoid}, API.LLVMOrcExecutionSessionRef, Ptr{Cchar}))
     linkinglayercreator!(builder, cb, Base.pointer_from_objref(creator))
 end
 
@@ -376,6 +376,6 @@ function dispose(lcm::LazyCallThroughManager)
 end
 
 function reexports(lctm::LazyCallThroughManager, ism::IndirectStubsManager, jd::JITDylib, symbols)
-    ref = LLVM.API.LLVMOrcLazyReexports(lctm, ism, jd, symbols, length(symbols))
+    ref = API.LLVMOrcLazyReexports(lctm, ism, jd, symbols, length(symbols))
     MaterializationUnit(ref)
 end

--- a/src/support.jl
+++ b/src/support.jl
@@ -11,7 +11,7 @@ end
 Permanently add the symbol `name` with the value `ptr`. These symbols are searched
 before any libraries.
 """
-add_symbol(name, ptr) = LLVM.API.LLVMAddSymbol(name, ptr)
+add_symbol(name, ptr) = API.LLVMAddSymbol(name, ptr)
 
 """
     load_library_permantly(path)
@@ -19,11 +19,11 @@ add_symbol(name, ptr) = LLVM.API.LLVMAddSymbol(name, ptr)
 This function permanently loads the dynamic library at the given path.
 It is safe to call this function multiple times for the same library.
 """
-load_library_permantly(path) = LLVM.API.LLVMLoadLibraryPermanently(path)
+load_library_permantly(path) = API.LLVMLoadLibraryPermanently(path)
 
 """
     find_symbol(name)
 
 Search the global symbols for `name` and return the pointer to it.
 """
-find_symbol(name) = LLVM.API.LLVMSearchForAddressOfSymbol(name)
+find_symbol(name) = API.LLVMSearchForAddressOfSymbol(name)

--- a/src/targetmachine.jl
+++ b/src/targetmachine.jl
@@ -79,7 +79,7 @@ add_library_info!(pm::PassManager, triple::String) =
 
 function JITTargetMachine(triple = LLVM.triple(),
                           cpu = "", features = "";
-                          optlevel = LLVM.API.LLVMCodeGenLevelDefault)
+                          optlevel = API.LLVMCodeGenLevelDefault)
 
     # Force ELF on windows,
     # Note: Without this call to normalize Orc get's confused
@@ -93,8 +93,8 @@ function JITTargetMachine(triple = LLVM.triple(),
 
     tm = TargetMachine(target, triple, cpu, features;
                        optlevel,
-                       reloc = LLVM.API.LLVMRelocStatic, # Generate simpler code for JIT
-                       code = LLVM.API.LLVMCodeModelJITDefault, # Required to init TM as JIT
+                       reloc = API.LLVMRelocStatic, # Generate simpler code for JIT
+                       code = API.LLVMCodeModelJITDefault, # Required to init TM as JIT
                        )
     return tm
 end

--- a/test/Kaleidoscope.jl
+++ b/test/Kaleidoscope.jl
@@ -16,7 +16,7 @@ include(joinpath(@__DIR__, "..", "examples", "Kaleidoscope", "Kaleidoscope.jl"))
         }
     """
 
-    LLVM.Context() do ctx
+    @dispose ctx=Context() begin
         m = Kaleidoscope.generate_IR(program; ctx)
         Kaleidoscope.optimize!(m)
         v = Kaleidoscope.run(m, "entry")
@@ -41,7 +41,7 @@ end
     }
     """
 
-    LLVM.Context() do ctx
+    @dispose ctx=Context() begin
         m = Kaleidoscope.generate_IR(program; ctx)
         Kaleidoscope.optimize!(m)
         mktemp() do path, io
@@ -61,7 +61,7 @@ end
     def entry() foo(2, 3)
     """
 
-    LLVM.Context() do ctx
+    @dispose ctx=Context() begin
         m = Kaleidoscope.generate_IR(program; ctx)
         Kaleidoscope.optimize!(m)
         v = Kaleidoscope.run(m, "entry")

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -1,8 +1,6 @@
 @testset "analysis" begin
 
-Context() do ctx
-Builder(ctx) do builder
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.Int32Type(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -14,12 +12,8 @@ LLVM.Module("SomeModule"; ctx) do mod
     @test_throws LLVMException verify(mod)
     @test_throws LLVMException verify(fn)
 end
-end
-end
 
-Context() do ctx
-Builder(ctx) do builder
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -30,8 +24,6 @@ LLVM.Module("SomeModule"; ctx) do mod
 
     verify(mod)
     verify(fn)
-end
-end
 end
 
 end

--- a/test/bitcode.jl
+++ b/test/bitcode.jl
@@ -1,13 +1,11 @@
 @testset "bitcode" begin
 
-Context() do ctx
+@dispose ctx=Context() begin
     invalid_bitcode = "invalid"
     @test_throws LLVMException parse(LLVM.Module, unsafe_wrap(Vector{UInt8}, invalid_bitcode); ctx)
 end
 
-Context() do ctx
-Builder(ctx) do builder
-LLVM.Module("SomeModule"; ctx) do source_mod
+@dispose ctx=Context() builder=Builder(ctx) source_mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(source_mod, "SomeFunction", ft)
 
@@ -46,8 +44,6 @@ LLVM.Module("SomeModule"; ctx) do source_mod
 
         @test read(io) == bitcode
     end
-end
-end
 end
 
 end

--- a/test/buffer.jl
+++ b/test/buffer.jl
@@ -7,15 +7,18 @@ let
     dispose(membuf)
 end
 
+MemoryBuffer(data) do buf
+end
+
 @test_throws LLVMException MemoryBufferFile("nonexisting")
 
-MemoryBuffer(data) do membuf
+@dispose membuf=MemoryBuffer(data) begin
     @test pointer(data) != pointer(membuf)
     @test length(membuf) == length(data)
     @test convert(Vector{UInt8}, membuf) == data
 end
 
-MemoryBuffer(data, "SomeBuffer", false) do membuf
+@dispose membuf=MemoryBuffer(data, "SomeBuffer", false) begin
     @test pointer(data) == pointer(membuf)
 end
 
@@ -25,7 +28,10 @@ mktemp() do path, _
         dispose(membuf)
     end
 
-    MemoryBufferFile(path) do membuf
+    MemoryBufferFile(path) do buf
+    end
+
+    @dispose membuf=MemoryBufferFile(path) begin
     end
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -23,12 +23,14 @@ end
 
 Context() do ctx end
 
+@dispose ctx=Context() begin end
+
 end
 
 
 @testset "type" begin
 
-Context() do ctx
+@dispose ctx=Context() begin
     typ = LLVM.Int1Type(ctx)
     @test typeof(typ.ref) == LLVM.API.LLVMTypeRef                 # untyped
 
@@ -49,7 +51,7 @@ Context() do ctx
 end
 
 # integer
-Context() do ctx
+@dispose ctx=Context() begin
     typ = LLVM.Int1Type(ctx)
     @test context(typ) == ctx
 
@@ -61,7 +63,7 @@ end
 # floating-point
 
 # function
-Context() do ctx
+@dispose ctx=Context() begin
     x = LLVM.Int1Type(ctx)
     y = [LLVM.Int8Type(ctx), LLVM.Int16Type(ctx)]
     ft = LLVM.FunctionType(x, y)
@@ -74,7 +76,7 @@ Context() do ctx
 end
 
 # sequential
-Context() do ctx
+@dispose ctx=Context() begin
     eltyp = LLVM.Int32Type(ctx)
 
     ptrtyp = LLVM.PointerType(eltyp)
@@ -86,7 +88,7 @@ Context() do ctx
     ptrtyp = LLVM.PointerType(eltyp, 1)
     @test addrspace(ptrtyp) == 1
 end
-Context() do ctx
+@dispose ctx=Context() begin
     eltyp = LLVM.Int32Type(ctx)
 
     arrtyp = LLVM.ArrayType(eltyp, 2)
@@ -96,13 +98,13 @@ Context() do ctx
 
     @test length(arrtyp) == 2
 end
-Context() do ctx
+@dispose ctx=Context() begin
     eltyp = LLVM.Int32Type(ctx)
 
     arrtyp = LLVM.ArrayType(eltyp, 0)
     @test isempty(arrtyp)
 end
-Context() do ctx
+@dispose ctx=Context() begin
     eltyp = LLVM.Int32Type(ctx)
 
     vectyp = LLVM.VectorType(eltyp, 2)
@@ -113,7 +115,7 @@ Context() do ctx
 end
 
 # structure
-Context() do ctx
+@dispose ctx=Context() begin
     elem = [LLVM.Int32Type(ctx), LLVM.FloatType(ctx)]
 
     let st = LLVM.StructType(elem; ctx)
@@ -150,25 +152,25 @@ Context() do ctx
 end
 
 # other
-Context() do ctx
+@dispose ctx=Context() begin
     typ = LLVM.VoidType(ctx)
     @test context(typ) == ctx
 end
-Context() do ctx
+@dispose ctx=Context() begin
     typ = LLVM.LabelType(ctx)
     @test context(typ) == ctx
 end
-Context() do ctx
+@dispose ctx=Context() begin
     typ = LLVM.MetadataType(ctx)
     @test context(typ) == ctx
 end
-Context() do ctx
+@dispose ctx=Context() begin
     typ = LLVM.TokenType(ctx)
     @test context(typ) == ctx
 end
 
 # type iteration
-Context() do ctx
+@dispose ctx=Context() begin
     st = LLVM.StructType("SomeType"; ctx)
 
     let ts = types(ctx)
@@ -188,9 +190,7 @@ end
 
 @testset "value" begin
 
-Context() do ctx
-Builder(ctx) do builder
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -222,14 +222,10 @@ LLVM.Module("SomeModule"; ctx) do mod
     name!(val, "bar")
     @test name(val) == "bar"
 end
-end
-end
 
 # usage
 
-Context() do ctx
-Builder(ctx) do builder
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -265,12 +261,10 @@ LLVM.Module("SomeModule"; ctx) do mod
     replace_uses!(valueinst1, valueinst2)
     @test user.(collect(uses(valueinst2))) == [userinst]
 end
-end
-end
 
 # users
 
-Context() do ctx
+@dispose ctx=Context() begin
     # operand iteration
     mod = parse(LLVM.Module,  """
         define void @fun(i32) {
@@ -299,7 +293,7 @@ end
 
 # constants
 
-Context() do ctx
+@dispose ctx=Context() begin
     @testset "constants" begin
 
     typ = LLVM.Int32Type(ctx)
@@ -333,7 +327,7 @@ Context() do ctx
 end
 
 # scalar
-Context() do ctx
+@dispose ctx=Context() begin
     @testset "integer constants" begin
 
     # manual construction of small values
@@ -508,7 +502,7 @@ Context() do ctx
 end
 
 # constant expressions
-Context() do ctx
+@dispose ctx=Context() begin
     @testset "constant expressions" begin
 
     # inline assembly
@@ -676,8 +670,7 @@ Context() do ctx
 end
 
 # global values
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     st = LLVM.StructType("SomeType"; ctx)
     ft = LLVM.FunctionType(st, [st])
     fn = LLVM.Function(mod, "SomeFunction", ft)
@@ -707,11 +700,9 @@ LLVM.Module("SomeModule"; ctx) do mod
     alignment!(fn, 4)
     @test alignment(fn) == 4
 end
-end
 
 # global variables
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     @test isempty(globals(mod))
     gv = GlobalVariable(mod, LLVM.Int32Type(ctx), "SomeGlobal")
     @test !isempty(globals(mod))
@@ -757,10 +748,8 @@ LLVM.Module("SomeModule"; ctx) do mod
         @test isempty(gvars)
     end
 end
-end
 
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     st = LLVM.StructType("SomeType"; ctx)
     gv = GlobalVariable(mod, st, "SomeGlobal")
 
@@ -768,14 +757,11 @@ LLVM.Module("SomeModule"; ctx) do mod
     initializer!(gv, init)
     @test initializer(gv) == init
 end
-end
 
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     gv = GlobalVariable(mod, LLVM.Int32Type(ctx), "SomeGlobal", 1)
 
     @test addrspace(llvmtype(gv)) == 1
-end
 end
 
 end
@@ -783,7 +769,7 @@ end
 
 @testset "metadata" begin
 
-Context() do ctx
+@dispose ctx=Context() begin
     str = MDString("foo"; ctx)
     @test string(str) == "foo"
 
@@ -799,7 +785,7 @@ Context() do ctx
     @test convert(MDString, val) == str
 end
 
-Context() do ctx
+@dispose ctx=Context() begin
     int = ConstantInt(42; ctx)
     @test convert(Int, int) == 42
 
@@ -815,7 +801,7 @@ Context() do ctx
     @test convert(ConstantInt, val) == int
 end
 
-Context() do ctx
+@dispose ctx=Context() begin
     mod = LLVM.Module("SomeModule"; ctx)
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     f1 = LLVM.Function(mod, "f1", ft)
@@ -829,7 +815,7 @@ Context() do ctx
 end
 
 # different type; requires a hack
-Context() do ctx
+@dispose ctx=Context() begin
     mod = LLVM.Module("SomeModule"; ctx)
     ft1 = LLVM.FunctionType(LLVM.VoidType(ctx))
     f1 = LLVM.Function(mod, "f1", ft1)
@@ -843,7 +829,7 @@ Context() do ctx
     @test Value(operands(operands(metadata(mod)["function"])[1])[1]; ctx) == f2
 end
 
-Context() do ctx
+@dispose ctx=Context() begin
     str = MDString("foo"; ctx)
     node = MDNode([str]; ctx)
     ops = operands(node)
@@ -852,7 +838,7 @@ Context() do ctx
 end
 
 # null metadata, represented as null pointers in the API, by `nothing` in Julia
-Context() do ctx
+@dispose ctx=Context() begin
     ir = """
             !0 = !{i32 42, null, !"string"}
             !foo = !{!0}
@@ -870,7 +856,7 @@ end
 
 @testset "debuginfo" begin
 
-Context() do ctx
+@dispose ctx=Context() begin
 mod = parse(LLVM.Module, raw"""
        define double @test(i64 signext %0, double %1) !dbg !5 {
        top:
@@ -949,17 +935,20 @@ end
 
 @testset "module" begin
 
-Context() do ctx
-    mod = LLVM.Module("SomeModule"; ctx)
-    @test context(mod) == ctx
+@dispose ctx=Context() begin
+    let mod = LLVM.Module("SomeModule"; ctx)
+        @test context(mod) == ctx
 
-    @test name(mod) == "SomeModule"
-    name!(mod, "SomeOtherName")
-    @test name(mod) == "SomeOtherName"
+        @test name(mod) == "SomeModule"
+        name!(mod, "SomeOtherName")
+        @test name(mod) == "SomeOtherName"
+    end
+
+    LLVM.Module("SomeModule"; ctx) do mod
+    end
 end
 
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     clone = copy(mod)
     @test mod != clone
     @test context(clone) == ctx
@@ -989,11 +978,9 @@ LLVM.Module("SomeModule"; ctx) do mod
     @test mod_flags["foobar"] == md
     @test_throws KeyError mod_flags["foobaz"]
 end
-end
 
 # metadata iteration
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     node = MDNode([MDString("SomeMDString"; ctx)]; ctx)
 
     let mds = metadata(mod)
@@ -1008,11 +995,9 @@ LLVM.Module("SomeModule"; ctx) do mod
         @test node in operands(mds["SomeMDNode"])
     end
 end
-end
 
 # global variable iteration
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     dummygv = GlobalVariable(mod, LLVM.Int32Type(ctx), "SomeGlobal")
 
     let gvs = globals(mod)
@@ -1034,11 +1019,9 @@ LLVM.Module("SomeModule"; ctx) do mod
         @test_throws KeyError gvs["SomeOtherGlobal"]
     end
 end
-end
 
 # function iteration
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     st = LLVM.StructType("SomeType"; ctx)
     ft = LLVM.FunctionType(st, [st])
     @test isempty(functions(mod))
@@ -1065,15 +1048,13 @@ LLVM.Module("SomeModule"; ctx) do mod
         @test_throws KeyError fns["SomeOtherFunction"]
     end
 end
-end
 
 end
 
 
 @testset "function" begin
 
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -1104,11 +1085,9 @@ LLVM.Module("SomeModule"; ctx) do mod
         @test isempty(fns)
     end
 end
-end
 
 # non-overloaded intrinsic
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     intr_ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     intr_fn = LLVM.Function(mod, "llvm.trap", intr_ft)
     @test isintrinsic(intr_fn)
@@ -1131,11 +1110,9 @@ LLVM.Module("SomeModule"; ctx) do mod
 
     @test intr == Intrinsic("llvm.trap")
 end
-end
 
 # overloaded intrinsic
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     intr_ft = LLVM.FunctionType(LLVM.DoubleType(ctx), [LLVM.DoubleType(ctx)])
     intr_fn = LLVM.Function(mod, "llvm.sin.f64", intr_ft)
     @test isintrinsic(intr_fn)
@@ -1158,11 +1135,9 @@ LLVM.Module("SomeModule"; ctx) do mod
 
     @test intr == Intrinsic("llvm.sin")
 end
-end
 
 # attributes
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -1217,11 +1192,9 @@ LLVM.Module("SomeModule"; ctx) do mod
         @test length(attrs) == 0
     end
 end
-end
 
 # parameter iteration
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -1241,11 +1214,9 @@ LLVM.Module("SomeModule"; ctx) do mod
         @test collect(params) == [intparam]
     end
 end
-end
 
 # basic block iteration
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
     @test isempty(blocks(fn))
@@ -1271,16 +1242,13 @@ LLVM.Module("SomeModule"; ctx) do mod
     empty!(fn)
     @test isempty(blocks(fn))
 end
-end
 
 end
 
 
 @testset "basic blocks" begin
 
-Context() do ctx
-Builder(ctx) do builder
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -1332,17 +1300,13 @@ LLVM.Module("SomeModule"; ctx) do mod
         @test isempty(bbs)
     end
 end
-end
-end
 
 end
 
 
 @testset "instructions" begin
 
-Context() do ctx
-Builder(ctx) do builder
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
     @test isempty(parameters(fn))
@@ -1438,11 +1402,9 @@ LLVM.Module("SomeModule"; ctx) do mod
     unsafe_delete!(bb1, brinst)
     @test !(brinst in instructions(bb1))
 end
-end
-end
 
 # new freeze instruction (used in 1.7 with JuliaLang/julia#38977)
-Context() do ctx
+@dispose ctx=Context() begin
     mod = parse(LLVM.Module,  """
         define i64 @julia_f_246(i64 %0) {
         top:

--- a/test/debuginfo.jl
+++ b/test/debuginfo.jl
@@ -2,7 +2,7 @@
 
 DEBUG_METADATA_VERSION()
 
-Context() do ctx
+@dispose ctx=Context() begin
       mod = parse(LLVM.Module,  """
           define void @foo() !dbg !5 {
           top:

--- a/test/instructions.jl
+++ b/test/instructions.jl
@@ -1,8 +1,6 @@
 @testset "irbuilder" begin
 
-Context() do ctx
-Builder(ctx) do builder
-LLVM.Module("SomeModule"; ctx) do mod
+@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx), LLVM.Int32Type(ctx),
                                                 LLVM.FloatType(ctx), LLVM.FloatType(ctx),
                                                 LLVM.PointerType(LLVM.Int32Type(ctx)),
@@ -281,8 +279,6 @@ LLVM.Module("SomeModule"; ctx) do mod
 
     position!(builder)
 end
-end
-end
 
 end
 
@@ -304,7 +300,7 @@ end
             ret void
         }
         """
-    Context() do ctx
+    @dispose ctx=Context() begin
         mod = parse(LLVM.Module, ir; ctx)
 
         @testset "iteration" begin
@@ -367,7 +363,7 @@ end
             @test sprint(io->print(io, bundle1)) == "\"unknown\"(i32 1, i64 2)"
 
             # use in a call
-            Builder(ctx) do builder
+            @dispose builder=Builder(ctx) begin
                 position!(builder, inst)
                 inst = call!(builder, functions(mod)["x"], Value[], [bundle1])
 

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -6,12 +6,12 @@ using InteractiveUtils
 @testset "base" begin
 
 @generated function add_one(i)
-    Context() do ctx
+    @dispose ctx=Context() begin
         T_int = convert(LLVMType, Int; ctx)
 
         f, ft = create_function(T_int, [T_int])
 
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(f, "entry"; ctx)
             position!(builder, entry)
 
@@ -37,7 +37,7 @@ end
 @test !isghosttype(NonGhostType1)
 @test !isghosttype(NonGhostType2)
 
-Context() do ctx
+@dispose ctx=Context() begin
     @test isboxed(NonGhostType2; ctx)
     @test isghosttype(GhostType; ctx)
     @test !isghosttype(NonGhostType1; ctx)
@@ -103,9 +103,7 @@ end
 @testset "passes" begin
 
 
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
-ModulePassManager() do pm
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) pm=ModulePassManager() begin
 
 demote_float16!(pm)
 julia_licm!(pm)
@@ -125,8 +123,6 @@ late_lower_gc_frame!(pm)
 final_lower_gc!(pm)
 cpu_features!(pm)
 
-end
-end
 end
 
 end

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1,13 +1,21 @@
 @testset "ir" begin
 
-Context() do ctx
+@dispose ctx=Context() begin
     invalid_ir = "invalid"
     @test_throws LLVMException parse(LLVM.Module, invalid_ir; ctx)
 end
 
-Context() do ctx
-Builder(ctx) do builder
-LLVM.Module("SomeModule"; ctx) do source_mod
+@dispose ctx=Context() begin
+    let builder = Builder(ctx)
+        dispose(builder)
+    end
+
+    Builder(ctx) do builder
+    end
+end
+
+
+@dispose ctx=Context() builder=Builder(ctx) source_mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(source_mod, "SomeFunction", ft)
 
@@ -27,8 +35,6 @@ LLVM.Module("SomeModule"; ctx) do source_mod
         @test haskey(functions(mod), "SomeFunction")
         dispose(mod)
     end
-end
-end
 end
 
 end

--- a/test/linker.jl
+++ b/test/linker.jl
@@ -1,7 +1,6 @@
 @testset "linker" begin
 
-Context() do ctx
-Builder(ctx) do builder
+@dispose ctx=Context() builder=Builder(ctx) begin
     mod1 = let
         mod = LLVM.Module("SomeModule"; ctx)
         ft = LLVM.FunctionType(LLVM.VoidType(ctx))
@@ -31,7 +30,6 @@ Builder(ctx) do builder
     link!(mod1, mod2)
     @test haskey(functions(mod1), "SomeFunction")
     @test haskey(functions(mod1), "SomeOtherFunction")
-end
 end
 
 end

--- a/test/moduleprovider.jl
+++ b/test/moduleprovider.jl
@@ -1,20 +1,22 @@
 @testset "moduleprovider" begin
 
-Context() do ctx
-let
+@dispose ctx=Context() begin
     mod = LLVM.Module("SomeModule"; ctx)
     mp = ModuleProvider(mod)
     dispose(mp)
 end
-end
 
-Context() do ctx
-let
+@dispose ctx=Context() begin
     mod = LLVM.Module("SomeModule"; ctx)
-    ModuleProvider(mod) do mp
-
+    ModuleProvider(mod) do md
     end
 end
+
+@dispose ctx=Context() begin
+    mod = LLVM.Module("SomeModule"; ctx)
+    @dispose mp=ModuleProvider(mod) begin
+
+    end
 end
 
 end

--- a/test/passmanager.jl
+++ b/test/passmanager.jl
@@ -5,25 +5,17 @@ let
     dispose(mpm)
 end
 
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
-ModulePassManager() do mpm
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) mpm=ModulePassManager() begin
     @test !run!(mpm, mod)
 end
-end
-end
 
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
-FunctionPassManager(mod) do fpm
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) fpm=FunctionPassManager(mod) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
     @test !initialize!(fpm)
     @test !run!(fpm, fn)
     @test !finalize!(fpm)
-end
-end
 end
 
 end

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -6,6 +6,9 @@ let
 end
 
 PassManagerBuilder() do pmb
+end
+
+@dispose pmb=PassManagerBuilder() begin
     optlevel!(pmb, 0)
     sizelevel!(pmb, 0)
 
@@ -14,21 +17,17 @@ PassManagerBuilder() do pmb
     simplify_libcalls!(pmb, false)
     inliner!(pmb, 0)
 
-    Context() do ctx
-    LLVM.Module("SomeModule"; ctx) do mod
-        FunctionPassManager(mod) do fpm
+    @dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
+        @dispose fpm=FunctionPassManager(mod) begin
             populate!(fpm, pmb)
         end
-        ModulePassManager() do mpm
+        @dispose mpm=ModulePassManager() begin
             populate!(mpm, pmb)
         end
     end
-    end
 end
 
-Context() do ctx
-LLVM.Module("SomeModule"; ctx) do mod
-ModulePassManager() do pm
+@dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) pm=ModulePassManager() begin
     aggressive_dce!(pm)
     dce!(pm)
     bit_tracking_dce!(pm)
@@ -107,8 +106,6 @@ ModulePassManager() do pm
     internalize!(pm, true)
     internalize!(pm, false)
     internalize!(pm, ["SomeFunction", "SomeOtherFunction"])
-end
-end
 end
 
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,7 +1,7 @@
 @testset "utils" begin
 
 @testset "cloning" begin
-    Context() do ctx
+    @dispose ctx=Context() begin
         # set-up
         mod = LLVM.Module("my_module"; ctx)
 
@@ -11,7 +11,7 @@
         f = LLVM.Function(mod, "f", fun_type)
 
         # generate IR
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(f, "entry"; ctx)
             position!(builder, entry)
 


### PR DESCRIPTION
I noticed, once again, that our use of do-block constructors (which we use for scoped resource clean-up) resulted in bad code, presumably because of the closures involved (https://github.com/JuliaLang/julia/issues/15276). GPUCompiler already had a bunch of explicit calls to `LLVM.dispose` to avoid the closure creation in hot code, but that doesn't scale and looks bad. So I explored two possibilities:

1. make the GC manage resources
2. replace do-block syntax with something that doesn't require closures

I started out with 1., and a WIP branch can be found here: https://github.com/maleadt/LLVM.jl/tree/tb/finalizers. Although initial results were promising, I ditched the effort after realizing two major issues:

- objects referring to the same memory can be constructed separately, e.g., a `LLVM.Module` object can also be created by calling `parent(::BasicBlock)`. That would then require handle-based refcounting, or an object factory like CUDA.jl's unique `Context` constructors (which suffer from the same problem as you can look up the current context using API calls), both of which are messy.
- objects can be constructed without a reference to its owning parent. For example, LLVM.Function needs to keep its parent Module alive, but you can also look-up a function from a CallInst. Our generic infrastructure now assumes that you can create all Values equally, whereas in the new design Function objects (which are a subtype of Value) would now also need a Module argument. Worse, it's not always possible to look that up by calling `parent`, as instructions can be deleted from their parent BasicBlock without their memory being reclaimed. In that scenario, we'd end up with a Function object that doesn't root its parent Module, potentially resulting in early-frees.

Given this complexity, I decided to go with 2. and keep the responsibility of tying object lifetimes to their respective owners to the user. This has also been working fine, in part because we dispose early which results in bugs being discovered relatively early, whereas bugs in a finalizer-based approach may be lurking for a long time.

The result is a `@dispose` macro which replaces the do-block syntax. The effect is pretty dramatic: on the LLVM.jl test-suite, `perf` reports that the total executed instruction count drops by 20%!

```
$ perf stat -B /home/tim/.cache/jl/installs/bin/linux/x64/1.8/julia-1.8-latest-linux-x86_64/bin/julia --project test/runtests.jl                                             [master]
┌ Warning: It is recommended to run the LLVM.jl test suite with -g2
└ @ Main ~/Julia/pkg/LLVM/test/runtests.jl:5
JIT session error: Symbols not found: [ mysum ]
Test Summary: | Pass  Total   Time
LLVM          | 1686   1686  19.3s

 Performance counter stats for '/home/tim/.cache/jl/installs/bin/linux/x64/1.8/julia-1.8-latest-linux-x86_64/bin/julia --project test/runtests.jl':

         24,574.63 msec task-clock                #    1.250 CPUs utilized
               982      context-switches          #   39.960 /sec
                85      cpu-migrations            #    3.459 /sec
           135,062      page-faults               #    5.496 K/sec
   110,672,199,590      cycles                    #    4.504 GHz                      (82.48%)
       445,623,166      stalled-cycles-frontend   #    0.40% frontend cycles idle     (81.61%)
     2,037,997,644      stalled-cycles-backend    #    1.84% backend cycles idle      (83.41%)
   166,889,246,973      instructions              #    1.51  insn per cycle
                                                  #    0.01  stalled cycles per insn  (84.16%)
    33,943,204,016      branches                  #    1.381 G/sec                    (84.21%)
     1,016,486,605      branch-misses             #    2.99% of all branches          (84.20%)

      19.664647623 seconds time elapsed

      20.904811000 seconds user
       3.653577000 seconds sys
```

```
Test Summary: | Pass  Total   Time
LLVM          | 1676   1676  15.2s

 Performance counter stats for '/home/tim/.cache/jl/installs/bin/linux/x64/1.8/julia-1.8-latest-linux-x86_64/bin/julia --project test/runtests.jl':

         20,417.89 msec task-clock                #    1.316 CPUs utilized
             1,011      context-switches          #   49.515 /sec
                85      cpu-migrations            #    4.163 /sec
           126,260      page-faults               #    6.184 K/sec
    94,119,265,188      cycles                    #    4.610 GHz                      (82.71%)
       377,228,483      stalled-cycles-frontend   #    0.40% frontend cycles idle     (81.26%)
     1,948,056,334      stalled-cycles-backend    #    2.07% backend cycles idle      (83.07%)
   136,612,268,983      instructions              #    1.45  insn per cycle
                                                  #    0.01  stalled cycles per insn  (84.33%)
    27,600,681,223      branches                  #    1.352 G/sec                    (84.37%)
       874,709,734      branch-misses             #    3.17% of all branches          (84.36%)

      15.513353511 seconds time elapsed

      16.665442000 seconds user
       3.742267000 seconds sys
```

The effect on GPUCompiler is also impressive:

```
 Section                     ncalls     time    %tot     avg     alloc    %tot      avg
 ──────────────────────────────────────────────────────────────────────────────────────
 IR generation                  218    6.54s   53.8%  30.0ms   1.68GiB   72.3%  7.87MiB
   rewrite                      218    3.39s   27.9%  15.6ms    259MiB   10.9%  1.19MiB
     lower throw                174   68.3ms    0.6%   393μs   14.6MiB    0.6%  86.1KiB
     hide trap                   61   2.07ms    0.0%  33.9μs   30.5KiB    0.0%     512B
     hide unreachable            78   1.72ms    0.0%  22.1μs    149KiB    0.0%  1.91KiB
       find                      78   1.02ms    0.0%  13.1μs   17.6KiB    0.0%     231B
       predecessors              78    266μs    0.0%  3.41μs   19.6KiB    0.0%     257B
       replace                   78   42.7μs    0.0%   548ns   1.88KiB    0.0%    24.6B
     lower throw (extra)         43    327μs    0.0%  7.61μs   11.3KiB    0.0%     270B
   emission                     218    1.63s   13.4%  7.47ms   1.00GiB   43.1%  4.69MiB
   clean-up                     218   1.05ms    0.0%  4.80μs   62.2KiB    0.0%     292B
 IR post-processing             218    3.82s   31.4%  17.5ms    300MiB   12.6%  1.38MiB
   optimization                  96    3.72s   30.6%  38.8ms    297MiB   12.5%  3.09MiB
     nvvmreflect                223   32.9μs    0.0%   147ns     0.00B    0.0%    0.00B
   clean-up                     218   8.93ms    0.1%  41.0μs   10.2KiB    0.0%    48.0B
 Validation                      16    1.26s   10.4%  78.7ms    239MiB   10.0%  14.9MiB
 lower byval                     17    224ms    1.8%  13.2ms   37.7MiB    1.6%  2.22MiB
 LLVM back-end                   38    197ms    1.6%  5.18ms   18.4MiB    0.8%   495KiB
   machine-code generation       38    167ms    1.4%  4.40ms   10.4MiB    0.4%   281KiB
     remove freeze                1   13.9ms    0.1%  13.9ms   2.19MiB    0.1%  2.19MiB
     remove trap                  1    667ns    0.0%   667ns     0.00B    0.0%    0.00B
   preparation                   38   29.7ms    0.2%   782μs   7.94MiB    0.3%   214KiB
 validation                     221    104ms    0.9%   470μs   63.0MiB    2.7%   292KiB
 Library linking                218   11.3ms    0.1%  51.7μs   65.7KiB    0.0%     308B
   runtime library               21   10.7ms    0.1%   512μs   2.95KiB    0.0%     144B
   target libraries             102   42.0μs    0.0%   412ns     0.00B    0.0%    0.00B
 Julia front-end                219   1.26ms    0.0%  5.77μs   94.7KiB    0.0%     443B
 Debug info removal              37   43.0μs    0.0%  1.16μs     0.00B    0.0%    0.00B
 ──────────────────────────────────────────────────────────────────────────────────────

Test Summary: | Pass  Broken  Total   Time
GPUCompiler   |  134       4    138  38.6s
```

```

 Section                     ncalls     time    %tot     avg     alloc    %tot      avg
 ──────────────────────────────────────────────────────────────────────────────────────
 IR generation                  218    3.88s   49.4%  17.8ms   1.52GiB   71.2%  7.14MiB
   emission                     218    1.60s   20.4%  7.35ms   1.00GiB   46.7%  4.68MiB
   rewrite                      218    822ms   10.5%  3.77ms    103MiB    4.7%   485KiB
     lower throw                174    122ms    1.6%   701μs   14.6MiB    0.7%  86.1KiB
     hide trap                   61   2.06ms    0.0%  33.7μs   30.5KiB    0.0%     512B
     hide unreachable            78   1.65ms    0.0%  21.2μs    149KiB    0.0%  1.91KiB
       find                      78   1.01ms    0.0%  12.9μs   17.6KiB    0.0%     231B
       predecessors              78    249μs    0.0%  3.19μs   19.6KiB    0.0%     257B
       replace                   78   44.8μs    0.0%   575ns   1.88KiB    0.0%    24.6B
     lower throw (extra)         43    328μs    0.0%  7.63μs   11.3KiB    0.0%     268B
   clean-up                     218   1.03ms    0.0%  4.71μs   61.9KiB    0.0%     291B
 IR post-processing             218    2.27s   28.8%  10.4ms    275MiB   12.6%  1.26MiB
   optimization                  96    2.17s   27.6%  22.6ms    271MiB   12.4%  2.83MiB
     nvvmreflect                223   31.9μs    0.0%   143ns     0.00B    0.0%    0.00B
   clean-up                     218   8.45ms    0.1%  38.8μs   10.2KiB    0.0%    48.0B
 Validation                      16    1.26s   16.0%  78.6ms    239MiB   10.9%  14.9MiB
 LLVM back-end                   38    183ms    2.3%  4.80ms   18.3MiB    0.8%   494KiB
   machine-code generation       38    159ms    2.0%  4.18ms   10.4MiB    0.5%   280KiB
     remove freeze                1   5.85ms    0.1%  5.85ms   2.19MiB    0.1%  2.19MiB
     remove trap                  1    583ns    0.0%   583ns     0.00B    0.0%    0.00B
   preparation                   38   23.5ms    0.3%   619μs   7.94MiB    0.4%   214KiB
 lower byval                     17    162ms    2.1%  9.53ms   34.9MiB    1.6%  2.05MiB
 validation                     221   97.8ms    1.2%   443μs   62.7MiB    2.9%   290KiB
 Library linking                218   11.5ms    0.1%  52.8μs   65.7KiB    0.0%     308B
   runtime library               21   11.0ms    0.1%   522μs   2.95KiB    0.0%     144B
   target libraries             102   45.6μs    0.0%   447ns     0.00B    0.0%    0.00B
 Julia front-end                219   1.23ms    0.0%  5.59μs   94.7KiB    0.0%     443B
 Debug info removal              37   40.3μs    0.0%  1.09μs     0.00B    0.0%    0.00B
 ──────────────────────────────────────────────────────────────────────────────────────

Test Summary: | Pass  Broken  Total   Time
GPUCompiler   |  134       4    138  34.5s
```

So a 10% improvement on fairly realistic use of LLVM.jl.