### PR TITLE
Support CustomDefinitionGenerator in OrcV2

### DIFF
--- a/src/orcv2.jl
+++ b/src/orcv2.jl
@@ -87,7 +87,7 @@ end
 
 include("executionengine/ts_module.jl")
 
-@checked struct LLVMSymbol <: AbstractString
+@checked struct LLVMSymbol
     ref::API.LLVMOrcSymbolStringPoolEntryRef
 end
 Base.unsafe_convert(::Type{API.LLVMOrcSymbolStringPoolEntryRef}, sym::LLVMSymbol) = sym.ref

--- a/src/orcv2.jl
+++ b/src/orcv2.jl
@@ -87,7 +87,7 @@ end
 
 include("executionengine/ts_module.jl")
 
-@checked struct LLVMSymbol
+@checked struct LLVMSymbol <: AbstractString
     ref::API.LLVMOrcSymbolStringPoolEntryRef
 end
 Base.unsafe_convert(::Type{API.LLVMOrcSymbolStringPoolEntryRef}, sym::LLVMSymbol) = sym.ref

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LLVMExtra_jll = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
+NUMA_jll = "7f51dc2b-bb24-59f8-b771-bb1490e4195d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/orcv2.jl
+++ b/test/orcv2.jl
@@ -302,4 +302,21 @@ end
     end
 end
 
+import NUMA_jll
+
+@testset "CustomDefinitionGenerator" begin
+    @dispose lljit=LLJIT() begin
+        if NUMA_jll.is_available()
+            @test_throws lookup(lljit, "numa_available")
+
+            dg = LLVM.DynamicLibDefinitionGenerator(NUMA_jll.libnuma)
+            jd = JITDylib(lljit)
+            LLVM.add!(jd, dg)
+
+            addr = lookup(lljit, "numa_available")
+            @test addr !== C_NULL
+        end
+    end
+end
+
 end

--- a/test/orcv2.jl
+++ b/test/orcv2.jl
@@ -307,7 +307,7 @@ import NUMA_jll
 @testset "CustomDefinitionGenerator" begin
     @dispose lljit=LLJIT() begin
         if NUMA_jll.is_available()
-            @test_throws lookup(lljit, "numa_available")
+            @test_throws ErrorException lookup(lljit, "numa_available")
 
             dg = LLVM.DynamicLibDefinitionGenerator(NUMA_jll.libnuma)
             jd = JITDylib(lljit)


### PR DESCRIPTION
- Make LLVMSymbol a subtype of AbstractString so that we can pass it directly to Libdl.dlsym
- Add CustomDefinitionGenerator
- Add a DynamicLibDefintionGenerator

TODO:
- [x] Test
- [ ] ?Async
- [ ] Resource cleanup

The last two will necessitate a change to LLVMExtra
