### PR TITLE
Add generated Interop.addrspacecast for LLVMPtr

### DIFF
--- a/src/interop/pointer.jl
+++ b/src/interop/pointer.jl
@@ -114,7 +114,7 @@ Base.:(+)(x::Integer, y::LLVMPtr) = y + x
 Base.unsigned(x::LLVMPtr) = UInt(x)
 Base.signed(x::LLVMPtr) = Int(x)
 
-@generated function Base.reinterpret(::Type{LLVMPtr{TDest, ASDest}}, src::LLVMPtr{TSrc, ASSrc}) where {TDest, ASDest, TSrc, ASSrc}
+@generated function addrspacecast(::Type{LLVMPtr{TDest, ASDest}}, src::LLVMPtr{TSrc, ASSrc}) where {TDest, ASDest, TSrc, ASSrc}
     @dispose ctx=Context() begin
         T_dest = convert(LLVMType, LLVMPtr{TDest, ASDest}; ctx)
         T_src = convert(LLVMType, LLVMPtr{TSrc, ASSrc}; ctx)

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -203,10 +203,10 @@ end
 end
 
 @testset "reinterpret with addrspacecast" begin
-    ptr = reinterpret(Core.LLVMPtr{Int64, 4}, C_NULL)
+    ptr = reinterpret(Core.LLVMPtr{Int64, 4}, 0)
     for eltype_dest in (Int64, Int32), AS_dest in (4, 3)
         T_dest = Core.LLVMPtr{eltype_dest, AS_dest}
-        ir = sprint(io->code_llvm(io, reinterpret, Tuple{Type{T_dest}, typeof(ptr)}))
+        ir = sprint(io->code_llvm(io, LLVM.Interop.addrspacecast, Tuple{Type{T_dest}, typeof(ptr)}))
         if AS_dest == 3
             @test contains(ir, r"addrspacecast i8 addrspace\(4\)\* %\d+ to i8 addrspace\(3\)\*")
         else


### PR DESCRIPTION
Base's reinterpret only calls bitcast, which is insufficient when the source and destination pointers have different address spaces.