### PR TITLE
Rename llvmtype to value_type, remove llvmeltype.

### DIFF
--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -84,6 +84,7 @@ void LLVMExtraGetNamedMetadataOperands2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef 
 void LLVMExtraAddNamedMetadataOperand2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef Val);
 
 LLVMTypeRef LLVMGetFunctionType(LLVMValueRef Fn);
+LLVMTypeRef LLVMGetGlobalValueType(LLVMValueRef Fn);
 
 #if LLVM_VERSION_MAJOR >= 12
 void LLVMAddCFGSimplificationPass2(LLVMPassManagerRef PM,

--- a/deps/LLVMExtra/lib/llvm-api.cpp
+++ b/deps/LLVMExtra/lib/llvm-api.cpp
@@ -567,8 +567,12 @@ LLVMValueRef LLVMConstDataArray(LLVMTypeRef ElementTy, const void *Data, unsigne
     return wrap(ConstantDataArray::getRaw(S, NumElements, unwrap(ElementTy)));
 }
 
-LLVMTypeRef  LLVMGetFunctionType(LLVMValueRef Fn) {
+LLVMTypeRef LLVMGetFunctionType(LLVMValueRef Fn) {
     auto Ftype = unwrap<Function>(Fn)->getFunctionType();
     return wrap(Ftype);
 }
 
+LLVMTypeRef LLVMGetGlobalValueType(LLVMValueRef GV) {
+    auto Ftype = unwrap<GlobalValue>(GV)->getValueType();
+    return wrap(Ftype);
+}

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -425,6 +425,10 @@ function LLVMGetFunctionType(Fn)
     ccall((:LLVMGetFunctionType,libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMGetGlobalValueType(Fn)
+    ccall((:LLVMGetGlobalValueType,libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
+end
+
 function LLVMGetBuilderContext(B)
     ccall((:LLVMGetBuilderContext, libLLVMExtra), LLVMContextRef, (LLVMBuilderRef,), B)
 end

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -579,7 +579,7 @@ InlineAsm(typ::FunctionType, asm::String, constraints::String,
 
 abstract type GlobalValue <: Constant end
 
-export GlobalValue,
+export GlobalValue, global_value_type,
        isdeclaration,
        linkage, linkage!,
        section, section!,
@@ -589,6 +589,8 @@ export GlobalValue,
        alignment, alignment!
 
 parent(val::GlobalValue) = Module(API.LLVMGetGlobalParent(val))
+
+global_value_type(val::GlobalValue) = LLVMType(API.LLVMGetGlobalValueType(val))
 
 isdeclaration(val::GlobalValue) = convert(Core.Bool, API.LLVMIsDeclaration(val))
 

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -133,8 +133,8 @@ abstract type ConstantDataSequential <: Constant end
 #      but cannot support that as explained above).
 
 # array interface
-Base.eltype(cda::ConstantDataSequential) = llvmeltype(cda)
-Base.length(cda::ConstantDataSequential) = length(llvmtype(cda))
+Base.eltype(cda::ConstantDataSequential) = eltype(value_type(cda))
+Base.length(cda::ConstantDataSequential) = length(value_type(cda))
 Base.size(cda::ConstantDataSequential) = (length(cda),)
 function Base.getindex(cda::ConstantDataSequential, idx::Integer)
     @boundscheck 1 <= idx <= length(cda) || throw(BoundsError(cda, idx))
@@ -191,7 +191,7 @@ register(ConstantAggregateZero, API.LLVMConstantAggregateZeroValueKind)
 # array interface
 # FIXME: can we reuse the ::ConstantArray functionality with ConstantAggregateZero values?
 #        probably works fine if we just get rid of the refcheck
-Base.eltype(caz::ConstantAggregateZero) = llvmeltype(caz)
+Base.eltype(caz::ConstantAggregateZero) = eltype(value_type(caz))
 Base.size(caz::ConstantAggregateZero) = (0,)
 Base.length(caz::ConstantAggregateZero) = 0
 Base.axes(caz::ConstantAggregateZero) = (Base.OneTo(0),)
@@ -215,7 +215,7 @@ register(ConstantArray, API.LLVMConstantArrayValueKind)
 
 # generic constructor taking an array of constants
 function ConstantArray(typ::LLVMType, data::AbstractArray{T,N}=T[]) where {T<:Constant,N}
-    @assert all(x->x==typ, llvmtype.(data))
+    @assert all(x->x==typ, value_type.(data))
 
     if N == 1
         # XXX: this can return a ConstDataArray (presumably as an optimization?)
@@ -223,7 +223,7 @@ function ConstantArray(typ::LLVMType, data::AbstractArray{T,N}=T[]) where {T<:Co
     end
 
     ca_vec = map(x->ConstantArray(typ, x), eachslice(data, dims=1))
-    ca_typ = llvmtype(first(ca_vec))
+    ca_typ = value_type(first(ca_vec))
 
     return ConstantArray(API.LLVMConstArray(ca_typ, ca_vec, length(ca_vec)))
 end
@@ -252,10 +252,10 @@ function Base.collect(ca::ConstantArray)
 end
 
 # array interface
-Base.eltype(ca::ConstantArray) = llvmeltype(ca)
+Base.eltype(ca::ConstantArray) = eltype(value_type(ca))
 function Base.size(ca::ConstantArray)
     dims = Int[]
-    typ = llvmtype(ca)
+    typ = value_type(ca)
     while typ isa ArrayType
         push!(dims, length(typ))
         typ = eltype(typ)
@@ -326,13 +326,13 @@ function ConstantStruct(value::T, name=String(nameof(T)); ctx::Context,
         ConstantStruct(constants; ctx, packed)
     elseif haskey(types(ctx), name)
         typ = types(ctx)[name]
-        if collect(elements(typ)) != llvmtype.(constants)
-            throw(ArgumentError("Cannot create struct $name {$(join(llvmtype.(constants), ", "))} as it is already defined in this context as {$(join(elements(typ), ", "))}."))
+        if collect(elements(typ)) != value_type.(constants)
+            throw(ArgumentError("Cannot create struct $name {$(join(value_type.(constants), ", "))} as it is already defined in this context as {$(join(elements(typ), ", "))}."))
         end
         ConstantStruct(typ, constants)
     else
         typ = StructType(name; ctx)
-        elements!(typ, llvmtype.(constants))
+        elements!(typ, value_type.(constants))
         ConstantStruct(typ, constants)
     end
 end

--- a/src/interop/base.jl
+++ b/src/interop/base.jl
@@ -109,7 +109,7 @@ function Base.convert(::Type{LLVMType}, typ::Type; ctx::Context,
         llvmtyp = let
             mod = parse(LLVM.Module, buf; ctx)
             gv = first(globals(mod))
-            eltype(value_type(gv))
+            global_value_type(gv)
         end
     end
 

--- a/src/interop/base.jl
+++ b/src/interop/base.jl
@@ -109,7 +109,7 @@ function Base.convert(::Type{LLVMType}, typ::Type; ctx::Context,
         llvmtyp = let
             mod = parse(LLVM.Module, buf; ctx)
             gv = first(globals(mod))
-            llvmeltype(gv)
+            eltype(value_type(gv))
         end
     end
 

--- a/src/irbuilder.jl
+++ b/src/irbuilder.jl
@@ -55,7 +55,7 @@ debuglocation!(builder::Builder, inst::Instruction) =
 ## build methods
 
 # TODO/IDEAS:
-# - dynamic dispatch based on `llvmtype` (eg. disambiguating `add!` and `fadd!`)
+# - dynamic dispatch based on `value_type` (eg. disambiguating `add!` and `fadd!`)
 
 # NOTE: the return values for these operations are, according to the C API, always a Value.
 #       however, the C++ API learns us that we can be more strict.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -50,7 +50,7 @@ function clone(f::Function; value_map::Dict{Value,Value}=Dict{Value,Value}())
     # the VMap. If so, we need to not add the arguments to the arg ty vector
     for arg in parameters(f)
         if !in(arg, keys(value_map))    # Haven't mapped the argument to anything yet?
-            push!(argtypes, llvmtype(arg))
+            push!(argtypes, value_type(arg))
         end
     end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -815,7 +815,10 @@ end
 @dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     gv = GlobalVariable(mod, LLVM.Int32Type(ctx), "SomeGlobal", 1)
 
+    @test value_type(gv) isa LLVM.PointerType
     @test addrspace(value_type(gv)) == 1
+
+    @test global_value_type(gv) == LLVM.Int32Type(ctx)
 end
 
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -228,7 +228,7 @@ end
 
     show(devnull, val)
 
-    @test llvmtype(val) == LLVM.PointerType(typ)
+    @test value_type(val) == LLVM.PointerType(typ)
     @test_throws ErrorException sizeof(val)
     @test name(val) == "foo"
     @test !isconstant(val)
@@ -367,7 +367,7 @@ end
     end
     let
         constval = ConstantInt(false; ctx)
-        @test llvmtype(constval) == LLVM.Int1Type(ctx)
+        @test value_type(constval) == LLVM.Int1Type(ctx)
         @test !convert(Bool, constval)
 
         constval = ConstantInt(true; ctx)
@@ -459,7 +459,7 @@ end
     let
         test_struct = TestStruct(true, -99, 1.5)
         constant_struct = ConstantStruct(test_struct; ctx, anonymous=true)
-        constant_struct_type = llvmtype(constant_struct)
+        constant_struct_type = value_type(constant_struct)
 
         @test constant_struct_type isa LLVM.StructType
         @test context(constant_struct) == ctx
@@ -479,7 +479,7 @@ end
     let
         test_struct = TestStruct(false, 52, -2.5)
         constant_struct = ConstantStruct(test_struct; ctx)
-        constant_struct_type = llvmtype(constant_struct)
+        constant_struct_type = value_type(constant_struct)
 
         @test constant_struct_type isa LLVM.StructType
 
@@ -499,7 +499,7 @@ end
     let
         test_struct = TestSingleton()
         constant_struct = ConstantStruct(test_struct; ctx)
-        constant_struct_type = llvmtype(constant_struct)
+        constant_struct_type = value_type(constant_struct)
 
         @test isempty(operands(constant_struct))
     end
@@ -517,7 +517,7 @@ end
         eltyp = LLVM.Int32Type(ctx)
         cda = ConstantDataArray(eltyp, vec)
         @test cda isa ConstantDataArray
-        @test llvmtype(cda) == LLVM.ArrayType(eltyp, 4)
+        @test value_type(cda) == LLVM.ArrayType(eltyp, 4)
         @test collect(cda) == ConstantInt.(vec; ctx)
     end
 
@@ -697,7 +697,7 @@ end
         ce = const_ptrtoint(ptr, LLVM.Int32Type(ctx))::LLVM.Constant
         @check_ir ce "i32 0"
 
-        ce = const_inttoptr(ce, llvmtype(ptr))::LLVM.Constant
+        ce = const_inttoptr(ce, value_type(ptr))::LLVM.Constant
         if supports_typed_ptrs
             @check_ir ce "i32* null"
         else
@@ -815,7 +815,7 @@ end
 @dispose ctx=Context() mod=LLVM.Module("SomeModule"; ctx) begin
     gv = GlobalVariable(mod, LLVM.Int32Type(ctx), "SomeGlobal", 1)
 
-    @test addrspace(llvmtype(gv)) == 1
+    @test addrspace(value_type(gv)) == 1
 end
 
 end
@@ -1165,7 +1165,7 @@ end
     @test fn isa LLVM.Function
 
     if supports_typed_ptrs
-        @test llvmeltype(fn) == ft
+        @test eltype(value_type(fn)) == ft
     end
     @test isintrinsic(fn)
 
@@ -1192,7 +1192,7 @@ end
     fn = LLVM.Function(mod, intr, [LLVM.DoubleType(ctx)])
     @test fn isa LLVM.Function
     if supports_typed_ptrs
-        @test llvmeltype(fn) == ft
+        @test eltype(value_type(fn)) == ft
     end
     @test isintrinsic(fn)
 

--- a/test/instructions.jl
+++ b/test/instructions.jl
@@ -273,7 +273,7 @@
     @check_ir bitcastinst "bitcast i32 %0 to float"
     if supports_typed_ptrs
         i32ptr1 = parameters(fn)[5]
-        i32ptr1typ = llvmtype(i32ptr1)
+        i32ptr1typ = value_type(i32ptr1)
         i32ptr1typ2 = LLVM.PointerType(eltype(i32ptr1typ), 2)
         addrspacecastinst = addrspacecast!(builder, i32ptr1, i32ptr1typ2)
         @check_ir addrspacecastinst "addrspacecast i32* %4 to i32 addrspace(2)*"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -28,7 +28,7 @@
         # basic clone
         let new_f = clone(f)
             @test new_f != f
-            @test llvmtype(new_f) == llvmtype(f)
+            @test value_type(new_f) == value_type(f)
             for (bb1, bb2) in zip(blocks(f), blocks(new_f))
                 for (inst1, inst2) in zip(instructions(bb2), instructions(bb2))
                     @test inst1 == inst2
@@ -85,9 +85,9 @@
 
             # the add should now be a 64-bit addition
             add = first(instructions(first(blocks(new_f))))
-            @test llvmtype(operands(add)[1]) == LLVM.Int64Type(ctx)
-            @test llvmtype(operands(add)[2]) == LLVM.Int64Type(ctx)
-            @test llvmtype(add) == LLVM.Int64Type(ctx)
+            @test value_type(operands(add)[1]) == LLVM.Int64Type(ctx)
+            @test value_type(operands(add)[2]) == LLVM.Int64Type(ctx)
+            @test value_type(add) == LLVM.Int64Type(ctx)
         end
     end
 end


### PR DESCRIPTION
This PR removes the (IMO unclear) `llvmtype` function, and replaces it with `value_type` which I think more clearly conveys the meaning, i.e., returning the LLVMType of this object when treated as an LLVM `Value`. It is consistent with other type getters we have, e.g., `function_type` to return the FunctionType when treating this object as an LLVM `Function`, and we might add others later to fetch type information from specific types in the LLVM hierarchy.
(`return_type(::FunctionType)` doesn't fit this scheme, but is clear enough to be its own thing).

Forcing users to replace `llvmtype` with `value_type` or `function_type` should also 'help' with the silent breakage of `eltype(llvmtype(::Function))` (a relatively common pattern) which will be illegal on LLVM 15+ under opaque pointers.

Packages affected: AMDGPU, BPFNative, Enzyme, GPUCompiler, LLVMCGUtils, SIMDPirates, WASMCompiler.