### PR TITLE
Improve opaque pointer support.

### DIFF
--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -169,5 +169,11 @@ LLVMBool LLVMContextSupportsTypedPointers(LLVMContextRef C);
 // constant data
 LLVMValueRef LLVMConstDataArray(LLVMTypeRef ElementTy, const void *Data, unsigned NumElements);
 
+// missing opaque pointer APIs
+#if LLVM_VERSION_MAJOR >= 13 && LLVM_VERSION_MAJOR < 15
+LLVMBool LLVMPointerTypeIsOpaque(LLVMTypeRef Ty);
+LLVMTypeRef LLVMPointerTypeInContext(LLVMContextRef C, unsigned AddressSpace);
+#endif
+
 LLVM_C_EXTERN_C_END
 #endif

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -432,3 +432,12 @@ end
 function LLVMGetBuilderContext(B)
     ccall((:LLVMGetBuilderContext, libLLVMExtra), LLVMContextRef, (LLVMBuilderRef,), B)
 end
+
+if v"13" <= version() < v"15"
+function LLVMPointerTypeIsOpaque(Ty)
+    ccall((:LLVMPointerTypeIsOpaque, libLLVMExtra), LLVMBool, (LLVMTypeRef,), Ty)
+end
+function LLVMPointerTypeInContext(C, AddressSpace)
+    ccall((:LLVMPointerTypeInContext, libLLVMExtra), LLVMTypeRef, (LLVMContextRef, Cuint), C, AddressSpace)
+end
+end

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -4,9 +4,3 @@ macro check_ir(inst, str)
         @test occursin($(str), inst)
     end
 end
-
-const supports_typed_ptrs = begin
-    @dispose ctx=Context() begin
-        supports_typed_pointers(ctx)
-    end
-end

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -3,6 +3,12 @@ using InteractiveUtils
 
 @testset "interop" begin
 
+# many of these tests don't use explicit contexts, as they rely on high-level functionality.
+# that functionality should be using default context options, so query those here.
+supports_typed_ptrs = @dispose ctx=Context() begin
+    supports_typed_pointers(ctx)
+end
+
 @testset "base" begin
 
 @generated function add_one(i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,9 @@ if Base.JLOptions().debug_level < 2
     @warn "It is recommended to run the LLVM.jl test suite with -g2"
 end
 
+using InteractiveUtils
+@info "System information:\n" * sprint(io->versioninfo(io))
+
 @testset "LLVM" begin
 
 # HACK: if a test throws within a Context() do block, displaying the LLVM value may crash

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -86,7 +86,7 @@ end
     speculative_execution_if_has_branch_divergence!(pm)
     simple_loop_unroll!(pm)
     inductive_range_check_elimination!(pm)
-    if supports_typed_ptrs
+    if supports_typed_pointers(ctx)
         argument_promotion!(pm)
     end
     constant_merge!(pm)


### PR DESCRIPTION
I flushed out some issues by running with `-force-opaque-pointers` (on LLVM 13) and `--opaque-pointers` (on LLVM 15):
- pointer opaqueness is a property of the pointer; it's possible to mix both (`%59 = addrspacecast i32* %4 to ptr addrspace(2)`)
- the context preference isn't static, and may change due to IR upgrade operations (see https://github.com/maleadt/LLVM.jl/issues/336#issuecomment-1481106558)

Sadly we can't test this on CI, as Julia gates support for opaque pointers behind the compile-time `JL_LLVM_OPAQUE_POINTERS` flag, instead of checking the context or input types.

Fixes https://github.com/maleadt/LLVM.jl/issues/336#issuecomment-1481106558