### PR TITLE
Refactor in anticipation of breaking release

### DIFF
--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -158,6 +158,10 @@ LLVMValueRef LLVMBuildCallWithOpBundle(LLVMBuilderRef B, LLVMValueRef Fn,
                                        LLVMValueRef *Args, unsigned NumArgs,
                                        LLVMOperandBundleDefRef *Bundles, unsigned NumBundles,
                                        const char *Name);
+LLVMValueRef LLVMBuildCallWithOpBundle2(LLVMBuilderRef B, LLVMTypeRef Ty, LLVMValueRef Fn,
+                                        LLVMValueRef *Args, unsigned NumArgs,
+                                        LLVMOperandBundleDefRef *Bundles, unsigned NumBundles,
+                                        const char *Name);
 LLVMValueRef LLVMMetadataAsValue2(LLVMContextRef C, LLVMMetadataRef Metadata);
 void LLVMReplaceAllMetadataUsesWith(LLVMValueRef Old, LLVMValueRef New);
 void LLVMReplaceMDNodeOperandWith(LLVMMetadataRef MD, unsigned I, LLVMMetadataRef New);

--- a/deps/LLVMExtra/lib/llvm-api.cpp
+++ b/deps/LLVMExtra/lib/llvm-api.cpp
@@ -525,8 +525,25 @@ LLVMValueRef LLVMBuildCallWithOpBundle(LLVMBuilderRef B, LLVMValueRef Fn,
     llvm::IRBuilder<> *Builder = unwrap(B);
     llvm::ArrayRef<llvm::Value*> args = makeArrayRef(unwrap(Args), NumArgs);
 
-    FunctionType *FnT = unwrap<Function>(Fn)->getFunctionType();
+    Value *V = unwrap(Fn);
+    FunctionType *FnT = cast<FunctionType>(V->getType()->getPointerElementType());
     llvm::CallInst *CI = Builder->CreateCall(FnT, unwrap(Fn), args ,BundleArray, Name);
+    return wrap(CI);
+}
+
+LLVMValueRef LLVMBuildCallWithOpBundle2(LLVMBuilderRef B, LLVMTypeRef Ty, LLVMValueRef Fn,
+                                        LLVMValueRef *Args, unsigned NumArgs,
+                                        LLVMOperandBundleDefRef *Bundles, unsigned NumBundles,
+                                        const char *Name) {
+    SmallVector<OperandBundleDef, 1> BundleArray;
+    for (auto *Bundle : makeArrayRef(Bundles, NumBundles))
+        BundleArray.push_back(*unwrap<OperandBundleDef>(Bundle));
+
+    llvm::IRBuilder<> *Builder = unwrap(B);
+    llvm::ArrayRef<llvm::Value*> args = makeArrayRef(unwrap(Args), NumArgs);
+
+    FunctionType *FTy = unwrap<FunctionType>(Ty);
+    llvm::CallInst *CI = Builder->CreateCall(FTy, unwrap(Fn), args ,BundleArray, Name);
     return wrap(CI);
 }
 

--- a/examples/Kaleidoscope/codegen.jl
+++ b/examples/Kaleidoscope/codegen.jl
@@ -1,13 +1,13 @@
 mutable struct CodeGen
     ctx::LLVM.Context
-    builder::LLVM.Builder
+    builder::LLVM.IRBuilder
     current_scope::CurrentScope
     mod::LLVM.Module
 
     CodeGen(ctx::LLVM.Context) =
         new(
             ctx,
-            LLVM.Builder(ctx),
+            LLVM.IRBuilder(ctx),
             CurrentScope(),
             LLVM.Module("KaleidoscopeModule"; ctx),
         )
@@ -23,7 +23,7 @@ Base.show(io::IO, cg::CodeGen) = print(io, "CodeGen")
 
 function create_entry_block_allocation(cg::CodeGen, fn::LLVM.Function, varname::String)
     local alloc
-    LLVM.@dispose builder=LLVM.Builder(cg.ctx) begin
+    LLVM.@dispose builder=LLVM.IRBuilder(cg.ctx) begin
         # Set the builder at the start of the function
         entry_block = LLVM.entry(fn)
         if isempty(LLVM.instructions(entry_block))

--- a/examples/constrained.jl
+++ b/examples/constrained.jl
@@ -45,7 +45,7 @@ meta(::Type{FPExceptStrict}) = "fpexcept.strict"
         intrinsic_fun = LLVM.Function(mod, intrinsic, [typ])
         ftype = LLVM.FunctionType(intrinsic,[typ])
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
             val = call!(builder, ftype, intrinsic_fun,

--- a/examples/generated.jl
+++ b/examples/generated.jl
@@ -21,7 +21,7 @@ end
         llvmf, _ = create_function(eltyp, paramtyps)
 
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(llvmf, "entry"; ctx)
             position!(builder, entry)
 

--- a/examples/sum.jl
+++ b/examples/sum.jl
@@ -21,7 +21,7 @@ end
     sum = LLVM.Function(mod, "sum", fun_type)
 
     # generate IR
-    @dispose builder=Builder(ctx) begin
+    @dispose builder=IRBuilder(ctx) begin
         entry = BasicBlock(sum, "entry"; ctx)
         position!(builder, entry)
 

--- a/examples/sum_integrated.jl
+++ b/examples/sum_integrated.jl
@@ -18,7 +18,7 @@ end
     sum, _ = create_function(ret_type, param_types)
 
     # generate IR
-    @dispose builder=Builder(ctx) begin
+    @dispose builder=IRBuilder(ctx) begin
         entry = BasicBlock(sum, "entry"; ctx)
         position!(builder, entry)
 

--- a/examples/sum_orc.jl
+++ b/examples/sum_orc.jl
@@ -22,7 +22,7 @@ function codegen!(mod::LLVM.Module, name, tm)
     sum = LLVM.Function(mod, name, ft)
 
     # generate IR
-    @dispose builder=Builder(ctx) begin
+    @dispose builder=IRBuilder(ctx) begin
         entry = BasicBlock(sum, "entry"; ctx)
         position!(builder, entry)
 

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -399,6 +399,10 @@ function LLVMBuildCallWithOpBundle(B, Fn, Args, NumArgs, Bundles, NumBundles, Na
     ccall((:LLVMBuildCallWithOpBundle, libLLVMExtra), LLVMValueRef, (LLVMBuilderRef, LLVMValueRef, Ptr{LLVMValueRef}, Cuint, Ptr{LLVMOperandBundleDefRef}, Cuint, Cstring), B, Fn, Args, NumArgs, Bundles, NumBundles, Name)
 end
 
+function LLVMBuildCallWithOpBundle2(B, Ty, Fn, Args, NumArgs, Bundles, NumBundles, Name)
+    ccall((:LLVMBuildCallWithOpBundle2, libLLVMExtra), LLVMValueRef, (LLVMBuilderRef, LLVMTypeRef, LLVMValueRef, Ptr{LLVMValueRef}, Cuint, Ptr{LLVMOperandBundleDefRef}, Cuint, Cstring), B, Ty, Fn, Args, NumArgs, Bundles, NumBundles, Name)
+end
+
 function LLVMMetadataAsValue2(C, MD)
     ccall((:LLVMMetadataAsValue2, libLLVMExtra), LLVMValueRef, (LLVMContextRef, LLVMMetadataRef), C, MD)
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -15,10 +15,6 @@ end
 # calling `refcheck` on the ref field argument
 macro checked(typedef)
     # decode structure definition
-    if Meta.isexpr(typedef, :macrocall)
-        # handle `@compat` prefixing 0.6-style type declarations
-        typedef = macroexpand(typedef)
-    end
     if Meta.isexpr(typedef, :struct)
         structure = typedef.args[2]
         body = typedef.args[3]

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -465,6 +465,7 @@ const_ashr(lhs::Constant, rhs::Constant) =
 
 function const_gep(val::Constant, Indices::Vector{<:Constant})
     supports_typed_pointers(context(val)) || throw_typedpointererror()
+    Base.depwarn("const_gep without specifying the destination type is deprecated", :const_gep)
     Value(API.LLVMConstGEP(val, Indices, length(Indices)))
 end
 
@@ -474,6 +475,7 @@ end
 
 function const_inbounds_gep(val::Constant, Indices::Vector{<:Constant})
     supports_typed_pointers(context(val)) || throw_typedpointererror()
+    Base.depwarn("const_inbounds_gep without specifying the destination type is deprecated", :const_inbounds_gep)
     Value(API.LLVMConstInboundsGEP(val, Indices, length(Indices)))
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,1 +1,3 @@
 # deprecated methods
+
+Base.@deprecate_binding Builder IRBuilder

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -4,3 +4,5 @@ Base.@deprecate llvmtype(x) value_type(x)
 Base.@deprecate llvmeltype(x) eltype(value_type(x))
 
 Base.@deprecate_binding Builder IRBuilder
+
+# NOTE: there's more deprecated methods in irbuilder.jl

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,3 +1,6 @@
 # deprecated methods
 
+Base.@deprecate llvmtype(x) value_type(x)
+Base.@deprecate llvmeltype(x) eltype(value_type(x))
+
 Base.@deprecate_binding Builder IRBuilder

--- a/src/interop.jl
+++ b/src/interop.jl
@@ -3,9 +3,6 @@ module Interop
 using ..LLVM
 import ..LLVM: API
 
-
-const jlctx = Ref{LLVM.Context}()
-
 include("interop/base.jl")
 include("interop/asmcall.jl")
 include("interop/passes.jl")

--- a/src/interop/asmcall.jl
+++ b/src/interop/asmcall.jl
@@ -12,7 +12,7 @@ export @asmcall
         inline_asm = InlineAsm(llvm_ft, String(asm), String(constraints), side_effects)
 
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 

--- a/src/interop/pointer.jl
+++ b/src/interop/pointer.jl
@@ -24,14 +24,13 @@ using Core: LLVMPtr
         @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
-            if supports_typed_pointers(ctx)
+            ptr = if supports_typed_pointers(ctx)
                 typed_ptr = bitcast!(builder, parameters(llvm_f)[1], T_typed_ptr)
-                typed_ptr = inbounds_gep!(builder, typed_ptr, [parameters(llvm_f)[2]])
-                ld = load!(builder, typed_ptr)
+                inbounds_gep!(builder, eltyp, typed_ptr, [parameters(llvm_f)[2]])
             else
-                ptr = inbounds_gep!(builder, eltyp, parameters(llvm_f)[1],[parameters(llvm_f)[2]])
-                ld = load!(builder, eltyp, ptr)
+                inbounds_gep!(builder, eltyp, parameters(llvm_f)[1], [parameters(llvm_f)[2]])
             end
+            ld = load!(builder, eltyp, ptr)
             if A != 0
                 metadata(ld)[LLVM.MD_tbaa] = tbaa_addrspace(A; ctx)
             end
@@ -62,16 +61,14 @@ end
         @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
-            if supports_typed_pointers(ctx)
+            ptr = if supports_typed_pointers(ctx)
                 typed_ptr = bitcast!(builder, parameters(llvm_f)[1], T_typed_ptr)
-                typed_ptr = inbounds_gep!(builder, typed_ptr, [parameters(llvm_f)[3]])
-                val = parameters(llvm_f)[2]
-                st = store!(builder, val, typed_ptr)
+                inbounds_gep!(builder, eltyp, typed_ptr, [parameters(llvm_f)[3]])
             else
-                ptr = inbounds_gep!(builder, eltyp, parameters(llvm_f)[1], [parameters(llvm_f)[3]])
-                val = parameters(llvm_f)[2]
-                st = store!(builder, val, ptr)
+                inbounds_gep!(builder, eltyp, parameters(llvm_f)[1], [parameters(llvm_f)[3]])
             end
+            val = parameters(llvm_f)[2]
+            st = store!(builder, val, ptr)
             if A != 0
                 metadata(st)[LLVM.MD_tbaa] = tbaa_addrspace(A; ctx)
             end

--- a/src/interop/pointer.jl
+++ b/src/interop/pointer.jl
@@ -21,7 +21,7 @@ using Core: LLVMPtr
         llvm_f, _ = create_function(eltyp, param_types)
 
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
             if supports_typed_pointers(ctx)
@@ -59,7 +59,7 @@ end
         llvm_f, _ = create_function(LLVM.VoidType(ctx), param_types)
 
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
             if supports_typed_pointers(ctx)
@@ -129,7 +129,7 @@ Base.signed(x::LLVMPtr) = Int(x)
         llvm_f, _ = create_function(T_dest, [T_src])
         mod = LLVM.parent(llvm_f)
 
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 
@@ -164,7 +164,7 @@ end
         llvm_f, _ = create_function(T_ret, T_args)
         mod = LLVM.parent(llvm_f)
 
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 

--- a/src/irbuilder.jl
+++ b/src/irbuilder.jl
@@ -1,24 +1,24 @@
 # An instruction builder represents a point within a basic block and is the exclusive means
 # of building instructions using the C interface.
 
-export Builder,
+export IRBuilder,
        position!,
        debuglocation, debuglocation!
 
-@checked struct Builder
+@checked struct IRBuilder
     ref::API.LLVMBuilderRef
 end
 
-Base.unsafe_convert(::Type{API.LLVMBuilderRef}, builder::Builder) = builder.ref
+Base.unsafe_convert(::Type{API.LLVMBuilderRef}, builder::IRBuilder) = builder.ref
 
-Builder(ctx::Context) = Builder(API.LLVMCreateBuilderInContext(ctx))
+IRBuilder(ctx::Context) = IRBuilder(API.LLVMCreateBuilderInContext(ctx))
 
-dispose(builder::Builder) = API.LLVMDisposeBuilder(builder)
+dispose(builder::IRBuilder) = API.LLVMDisposeBuilder(builder)
 
-context(builder::Builder) = Context(API.LLVMGetBuilderContext(builder))
+context(builder::IRBuilder) = Context(API.LLVMGetBuilderContext(builder))
 
-function Builder(f::Core.Function, args...; kwargs...)
-    builder = Builder(args...; kwargs...)
+function IRBuilder(f::Core.Function, args...; kwargs...)
+    builder = IRBuilder(args...; kwargs...)
     try
         f(builder)
     finally
@@ -26,29 +26,29 @@ function Builder(f::Core.Function, args...; kwargs...)
     end
 end
 
-Base.position(builder::Builder) = BasicBlock(API.LLVMGetInsertBlock(builder))
-position!(builder::Builder, inst::Instruction) =
+Base.position(builder::IRBuilder) = BasicBlock(API.LLVMGetInsertBlock(builder))
+position!(builder::IRBuilder, inst::Instruction) =
     API.LLVMPositionBuilderBefore(builder, inst)
-position!(builder::Builder, bb::BasicBlock) =
+position!(builder::IRBuilder, bb::BasicBlock) =
     API.LLVMPositionBuilderAtEnd(builder, bb)
-position!(builder::Builder) = API.LLVMClearInsertionPosition(builder)
+position!(builder::IRBuilder) = API.LLVMClearInsertionPosition(builder)
 
-Base.insert!(builder::Builder, inst::Instruction) =
+Base.insert!(builder::IRBuilder, inst::Instruction) =
     API.LLVMInsertIntoBuilder(builder, inst)
-Base.insert!(builder::Builder, inst::Instruction, name::String) =
+Base.insert!(builder::IRBuilder, inst::Instruction, name::String) =
     API.LLVMInsertIntoBuilderWithName(builder, inst, name)
 
-function debuglocation(builder::Builder)
+function debuglocation(builder::IRBuilder)
     ref = API.LLVMGetCurrentDebugLocation2(builder)
     ref == C_NULL ? nothing : Metadata(ref)
 end
-debuglocation!(builder::Builder) =
+debuglocation!(builder::IRBuilder) =
     API.LLVMSetCurrentDebugLocation2(builder, C_NULL)
-debuglocation!(builder::Builder, loc::Metadata) =
+debuglocation!(builder::IRBuilder, loc::Metadata) =
     API.LLVMSetCurrentDebugLocation2(builder, loc)
-debuglocation!(builder::Builder, loc::MetadataAsValue) =
+debuglocation!(builder::IRBuilder, loc::MetadataAsValue) =
     API.LLVMSetCurrentDebugLocation2(builder, Metadata(loc))
-debuglocation!(builder::Builder, inst::Instruction) =
+debuglocation!(builder::IRBuilder, inst::Instruction) =
     API.LLVMSetInstDebugLocation(builder, inst)
 
 
@@ -86,376 +86,376 @@ export ret!, br!, switch!, indirectbr!, invoke!, resume!, unreachable!,
 
 # terminator instructions
 
-ret!(builder::Builder) =
+ret!(builder::IRBuilder) =
     Instruction(API.LLVMBuildRetVoid(builder))
 
-ret!(builder::Builder, V::Value) =
+ret!(builder::IRBuilder, V::Value) =
     Instruction(API.LLVMBuildRet(builder, V))
 
-ret!(builder::Builder, RetVals::Vector{<:Value}) =
+ret!(builder::IRBuilder, RetVals::Vector{<:Value}) =
     Instruction(API.LLVMBuildAggregateRet(builder, RetVals, length(RetVals)))
 
-br!(builder::Builder, Dest::BasicBlock) =
+br!(builder::IRBuilder, Dest::BasicBlock) =
     Instruction(API.LLVMBuildBr(builder, Dest))
 
-br!(builder::Builder, If::Value, Then::BasicBlock, Else::BasicBlock) =
+br!(builder::IRBuilder, If::Value, Then::BasicBlock, Else::BasicBlock) =
     Instruction(API.LLVMBuildCondBr(builder, If, Then, Else))
 
-switch!(builder::Builder, V::Value, Else::BasicBlock, NumCases::Integer=10) =
+switch!(builder::IRBuilder, V::Value, Else::BasicBlock, NumCases::Integer=10) =
     Instruction(API.LLVMBuildSwitch(builder, V, Else, NumCases))
 
-indirectbr!(builder::Builder, Addr::Value, NumDests::Integer=10) =
+indirectbr!(builder::IRBuilder, Addr::Value, NumDests::Integer=10) =
     Instruction(API.LLVMBuildIndirectBr(builder, Addr, NumDests))
 
-function invoke!(builder::Builder, Fn::Value, Args::Vector{<:Value}, Then::BasicBlock,
+function invoke!(builder::IRBuilder, Fn::Value, Args::Vector{<:Value}, Then::BasicBlock,
                  Catch::BasicBlock, Name::String="")
     supports_typed_pointers(context(builder)) || throw_typedpointererror()
     Instruction(API.LLVMBuildInvoke(builder, Fn, Args, length(Args), Then, Catch, Name))
 end
 
-function invoke!(builder::Builder, Ty::LLVMType, Fn::Value, Args::Vector{<:Value},
+function invoke!(builder::IRBuilder, Ty::LLVMType, Fn::Value, Args::Vector{<:Value},
                  Then::BasicBlock, Catch::BasicBlock, Name::String="")
     Instruction(API.LLVMBuildInvoke2(builder, Ty, Fn, Args, length(Args), Then, Catch, Name))
 end
 
-resume!(builder::Builder, Exn::Value) =
+resume!(builder::IRBuilder, Exn::Value) =
     Instruction(API.LLVMBuildResume(builder, Exn))
 
-unreachable!(builder::Builder) =
+unreachable!(builder::IRBuilder) =
     Instruction(API.LLVMBuildUnreachable(builder))
 
 
 # binary operations
 
-binop!(builder::Builder, Op::API.LLVMOpcode, LHS::Value, RHS::Value, Name::String="") =
+binop!(builder::IRBuilder, Op::API.LLVMOpcode, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildBinOp(builder, Op, LHS, RHS, Name))
 
-add!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+add!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildAdd(builder, LHS, RHS, Name))
 
-nswadd!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+nswadd!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildNSWAdd(builder, LHS, RHS, Name))
 
-nuwadd!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+nuwadd!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildNUWAdd(builder, LHS, RHS, Name))
 
-fadd!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+fadd!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildFAdd(builder, LHS, RHS, Name))
 
-sub!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+sub!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildSub(builder, LHS, RHS, Name))
 
-nswsub!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+nswsub!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildNSWSub(builder, LHS, RHS, Name))
 
-nuwsub!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+nuwsub!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildNUWSub(builder, LHS, RHS, Name))
 
-fsub!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+fsub!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildFSub(builder, LHS, RHS, Name))
 
-mul!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+mul!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildMul(builder, LHS, RHS, Name))
 
-nswmul!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+nswmul!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildNSWMul(builder, LHS, RHS, Name))
 
-nuwmul!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+nuwmul!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildNUWMul(builder, LHS, RHS, Name))
 
-fmul!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+fmul!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildFMul(builder, LHS, RHS, Name))
 
-udiv!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+udiv!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildUDiv(builder, LHS, RHS, Name))
 
-sdiv!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+sdiv!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildSDiv(builder, LHS, RHS, Name))
 
-exactsdiv!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+exactsdiv!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildExactSDiv(builder, LHS, RHS, Name))
 
-fdiv!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+fdiv!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildFDiv(builder, LHS, RHS, Name))
 
-urem!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+urem!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildURem(builder, LHS, RHS, Name))
 
-srem!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+srem!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildSRem(builder, LHS, RHS, Name))
 
-frem!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+frem!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildFRem(builder, LHS, RHS, Name))
 
 
 # bitwise binary operations
 
-shl!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+shl!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildShl(builder, LHS, RHS, Name))
 
-lshr!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+lshr!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildLShr(builder, LHS, RHS, Name))
 
-ashr!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+ashr!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildAShr(builder, LHS, RHS, Name))
 
-and!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+and!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildAnd(builder, LHS, RHS, Name))
 
-or!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+or!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildOr(builder, LHS, RHS, Name))
 
-xor!(builder::Builder, LHS::Value, RHS::Value, Name::String="") =
+xor!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildXor(builder, LHS, RHS, Name))
 
 
 # vector operations
 
-extract_element!(builder::Builder, VecVal::Value, Index::Value, Name::String="") =
+extract_element!(builder::IRBuilder, VecVal::Value, Index::Value, Name::String="") =
     Value(API.LLVMBuildExtractElement(builder, VecVal, Index, Name))
 
-insert_element!(builder::Builder, VecVal::Value, EltVal::Value, Index::Value, Name::String="") =
+insert_element!(builder::IRBuilder, VecVal::Value, EltVal::Value, Index::Value, Name::String="") =
     Value(API.LLVMBuildInsertElement(builder, VecVal, EltVal, Index, Name))
 
-shuffle_vector!(builder::Builder, V1::Value, V2::Value, Mask::Value, Name::String="") =
+shuffle_vector!(builder::IRBuilder, V1::Value, V2::Value, Mask::Value, Name::String="") =
     Value(API.LLVMBuildShuffleVector(builder, V1, V2, Mask, Name))
 
 
 # aggregate operations
 
-extract_value!(builder::Builder, AggVal::Value, Index, Name::String="") =
+extract_value!(builder::IRBuilder, AggVal::Value, Index, Name::String="") =
     Value(API.LLVMBuildExtractValue(builder, AggVal, Index, Name))
 
-insert_value!(builder::Builder, AggVal::Value, EltVal::Value, Index, Name::String="") =
+insert_value!(builder::IRBuilder, AggVal::Value, EltVal::Value, Index, Name::String="") =
     Value(API.LLVMBuildInsertValue(builder, AggVal, EltVal, Index, Name))
 
 
 # memory access and addressing operations
 
-alloca!(builder::Builder, Ty::LLVMType, Name::String="") =
+alloca!(builder::IRBuilder, Ty::LLVMType, Name::String="") =
     Instruction(API.LLVMBuildAlloca(builder, Ty, Name))
 
-array_alloca!(builder::Builder, Ty::LLVMType, Val::Value, Name::String="") =
+array_alloca!(builder::IRBuilder, Ty::LLVMType, Val::Value, Name::String="") =
     Instruction(API.LLVMBuildArrayAlloca(builder, Ty, Val, Name))
 
-malloc!(builder::Builder, Ty::LLVMType, Name::String="") =
+malloc!(builder::IRBuilder, Ty::LLVMType, Name::String="") =
     Instruction(API.LLVMBuildMalloc(builder, Ty, Name))
 
-array_malloc!(builder::Builder, Ty::LLVMType, Val::Value, Name::String="") =
+array_malloc!(builder::IRBuilder, Ty::LLVMType, Val::Value, Name::String="") =
     Instruction(API.LLVMBuildArrayMalloc(builder, Ty, Val, Name))
 
-memset!(builder::Builder, Ptr::Value, Val::Value, Len::Value, Align::Integer) =
+memset!(builder::IRBuilder, Ptr::Value, Val::Value, Len::Value, Align::Integer) =
     Instruction(API.LLVMBuildMemSet(builder, Ptr, Val, Len, Align))
 
-memcpy!(builder::Builder, Dst::Value, DstAlign::Integer, Src::Value, SrcAlign::Integer, Size::Value) =
+memcpy!(builder::IRBuilder, Dst::Value, DstAlign::Integer, Src::Value, SrcAlign::Integer, Size::Value) =
     Instruction(API.LLVMBuildMemCpy(builder, Dst, DstAlign, Src, SrcAlign, Size))
 
-memmove!(builder::Builder, Dst::Value, DstAlign::Integer, Src::Value, SrcAlign::Integer,
+memmove!(builder::IRBuilder, Dst::Value, DstAlign::Integer, Src::Value, SrcAlign::Integer,
          Size::Value) =
     Instruction(API.LLVMBuildMemMove(builder, Dst, DstAlign, Src, SrcAlign, Size))
 
-free!(builder::Builder, PointerVal::Value) =
+free!(builder::IRBuilder, PointerVal::Value) =
     Instruction(API.LLVMBuildFree(builder, PointerVal))
 
-function load!(builder::Builder, PointerVal::Value, Name::String="")
+function load!(builder::IRBuilder, PointerVal::Value, Name::String="")
     supports_typed_pointers(context(builder)) || throw_typedpointererror()
     Instruction(API.LLVMBuildLoad(builder, PointerVal, Name))
 end
 
-function load!(builder::Builder, Ty::LLVMType, PointerVal::Value, Name::String="")
+function load!(builder::IRBuilder, Ty::LLVMType, PointerVal::Value, Name::String="")
     Instruction(API.LLVMBuildLoad2(builder, Ty, PointerVal, Name))
 end
 
-store!(builder::Builder, Val::Value, Ptr::Value) =
+store!(builder::IRBuilder, Val::Value, Ptr::Value) =
     Instruction(API.LLVMBuildStore(builder, Val, Ptr))
 
-fence!(builder::Builder, ordering::API.LLVMAtomicOrdering, singleThread::Core.Bool=false,
+fence!(builder::IRBuilder, ordering::API.LLVMAtomicOrdering, singleThread::Core.Bool=false,
        Name::String="") =
     Instruction(API.LLVMBuildFence(builder, ordering, convert(Bool, singleThread), Name))
 
-atomic_rmw!(builder::Builder, op::API.LLVMAtomicRMWBinOp, Ptr::Value, Val::Value,
+atomic_rmw!(builder::IRBuilder, op::API.LLVMAtomicRMWBinOp, Ptr::Value, Val::Value,
             ordering::API.LLVMAtomicOrdering, singleThread::Core.Bool) =
     Instruction(API.LLVMBuildAtomicRMW(builder, op, Ptr, Val, ordering,
                                        convert(Bool, singleThread)))
 
-atomic_cmpxchg!(builder::Builder, Ptr::Value, Cmp::Value, New::Value,
+atomic_cmpxchg!(builder::IRBuilder, Ptr::Value, Cmp::Value, New::Value,
                 SuccessOrdering::API.LLVMAtomicOrdering,
                 FailureOrdering::API.LLVMAtomicOrdering, SingleThread::Core.Bool) =
     Instruction(API.LLVMBuildAtomicCmpXchg(builder, Ptr, Cmp, New, SuccessOrdering,
                                            FailureOrdering, convert(Bool, SingleThread)))
 
-function gep!(builder::Builder, Pointer::Value, Indices::Vector{<:Value}, Name::String="")
+function gep!(builder::IRBuilder, Pointer::Value, Indices::Vector{<:Value}, Name::String="")
     supports_typed_pointers(context(builder)) || throw_typedpointererror()
     Value(API.LLVMBuildGEP(builder, Pointer, Indices, length(Indices), Name))
 end
 
-function gep!(builder::Builder, Ty::LLVMType, Pointer::Value, Indices::Vector{<:Value},
+function gep!(builder::IRBuilder, Ty::LLVMType, Pointer::Value, Indices::Vector{<:Value},
               Name::String="")
     return Value(API.LLVMBuildGEP2(builder, Ty, Pointer, Indices, length(Indices), Name))
 end
 
-function inbounds_gep!(builder::Builder, Pointer::Value, Indices::Vector{<:Value},
+function inbounds_gep!(builder::IRBuilder, Pointer::Value, Indices::Vector{<:Value},
                        Name::String="")
     supports_typed_pointers(context(builder)) || throw_typedpointererror()
     Value(API.LLVMBuildInBoundsGEP(builder, Pointer, Indices, length(Indices), Name))
 end
 
-function inbounds_gep!(builder::Builder, Ty::LLVMType, Pointer::Value,
+function inbounds_gep!(builder::IRBuilder, Ty::LLVMType, Pointer::Value,
                        Indices::Vector{<:Value}, Name::String="")
     Value(API.LLVMBuildInBoundsGEP2(builder, Ty, Pointer, Indices, length(Indices), Name))
 end
 
-function struct_gep!(builder::Builder, Pointer::Value, Idx, Name::String="")
+function struct_gep!(builder::IRBuilder, Pointer::Value, Idx, Name::String="")
     supports_typed_pointers(context(builder)) || throw_typedpointererror()
     Value(API.LLVMBuildStructGEP(builder, Pointer, Idx, Name))
 end
 
-function struct_gep!(builder::Builder, Ty::LLVMType, Pointer::Value, Idx, Name::String="")
+function struct_gep!(builder::IRBuilder, Ty::LLVMType, Pointer::Value, Idx, Name::String="")
     Value(API.LLVMBuildStructGEP2(builder, Ty, Pointer, Idx, Name))
 end
 
 # conversion operations
 
-trunc!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+trunc!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildTrunc(builder, Val, DestTy, Name))
 
-zext!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+zext!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildZExt(builder, Val, DestTy, Name))
 
-sext!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+sext!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildSExt(builder, Val, DestTy, Name))
 
-fptoui!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+fptoui!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildFPToUI(builder, Val, DestTy, Name))
 
-fptosi!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+fptosi!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildFPToSI(builder, Val, DestTy, Name))
 
-uitofp!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+uitofp!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildUIToFP(builder, Val, DestTy, Name))
 
-sitofp!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+sitofp!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildSIToFP(builder, Val, DestTy, Name))
 
-fptrunc!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+fptrunc!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildFPTrunc(builder, Val, DestTy, Name))
 
-fpext!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+fpext!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildFPExt(builder, Val, DestTy, Name))
 
-ptrtoint!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+ptrtoint!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildPtrToInt(builder, Val, DestTy, Name))
 
-inttoptr!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+inttoptr!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildIntToPtr(builder, Val, DestTy, Name))
 
-bitcast!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+bitcast!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildBitCast(builder, Val, DestTy, Name))
 
-addrspacecast!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+addrspacecast!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildAddrSpaceCast(builder, Val, DestTy, Name))
 
-zextorbitcast!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+zextorbitcast!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildZExtOrBitCast(builder, Val, DestTy, Name))
 
-sextorbitcast!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+sextorbitcast!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildSExtOrBitCast(builder, Val, DestTy, Name))
 
-truncorbitcast!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+truncorbitcast!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildTruncOrBitCast(builder, Val, DestTy, Name))
 
-cast!(builder::Builder, Op::API.LLVMOpcode, Val::Value, DestTy::LLVMType, Name::String="") =
+cast!(builder::IRBuilder, Op::API.LLVMOpcode, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildCast(builder, Op, Val, DestTy, Name))
 
 # XXX: make this error with opaque pointers?
-pointercast!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+pointercast!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildPointerCast(builder, Val, DestTy, Name))
 
-intcast!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+intcast!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildIntCast(builder, Val, DestTy, Name))
 
-fpcast!(builder::Builder, Val::Value, DestTy::LLVMType, Name::String="") =
+fpcast!(builder::IRBuilder, Val::Value, DestTy::LLVMType, Name::String="") =
     Value(API.LLVMBuildFPCast(builder, Val, DestTy, Name))
 
 
 # other operations
 
-icmp!(builder::Builder, Op::API.LLVMIntPredicate, LHS::Value, RHS::Value, Name::String="") =
+icmp!(builder::IRBuilder, Op::API.LLVMIntPredicate, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildICmp(builder, Op, LHS, RHS, Name))
 
-fcmp!(builder::Builder, Op::API.LLVMRealPredicate, LHS::Value, RHS::Value, Name::String="") =
+fcmp!(builder::IRBuilder, Op::API.LLVMRealPredicate, LHS::Value, RHS::Value, Name::String="") =
     Value(API.LLVMBuildFCmp(builder, Op, LHS, RHS, Name))
 
-phi!(builder::Builder, Ty::LLVMType, Name::String="") =
+phi!(builder::IRBuilder, Ty::LLVMType, Name::String="") =
     Instruction(API.LLVMBuildPhi(builder, Ty, Name))
 
-select!(builder::Builder, If::Value, Then::Value, Else::Value, Name::String="") =
+select!(builder::IRBuilder, If::Value, Then::Value, Else::Value, Name::String="") =
     Value(API.LLVMBuildSelect(builder, If, Then, Else, Name))
 
-function call!(builder::Builder, Fn::Value, Args::Vector{<:Value}=Value[], Name::String="")
+function call!(builder::IRBuilder, Fn::Value, Args::Vector{<:Value}=Value[], Name::String="")
     supports_typed_pointers(context(builder)) || throw_typedpointererror()
     Instruction(API.LLVMBuildCall(builder, Fn, Args, length(Args), Name))
 end
 
-function call!(builder::Builder, Ty::LLVMType, Fn::Value, Args::Vector{<:Value}=Value[],
+function call!(builder::IRBuilder, Ty::LLVMType, Fn::Value, Args::Vector{<:Value}=Value[],
                Name::String="")
     Instruction(API.LLVMBuildCall2(builder, Ty, Fn, Args, length(Args), Name))
 end
 
-call!(builder::Builder, Fn::Value, Args::Vector{<:Value},
+call!(builder::IRBuilder, Fn::Value, Args::Vector{<:Value},
       Bundles::Vector{OperandBundleDef}, Name::String="") =
     Instruction(API.LLVMBuildCallWithOpBundle(builder, Fn, Args, length(Args), Bundles,
                                               length(Bundles), Name))
 
 # convenience function that performs the OperandBundle(Iterator|Use)->Def conversion
-call!(builder::Builder, Fn::Value, Args::Vector{<:Value},
+call!(builder::IRBuilder, Fn::Value, Args::Vector{<:Value},
       Bundles, Name::String="") =
     Instruction(API.LLVMBuildCallWithOpBundle(builder, Fn, Args, length(Args),
                                               OperandBundleDef.(Bundles),
                                               length(Bundles), Name))
 
-va_arg!(builder::Builder, List::Value, Ty::LLVMType, Name::String="") =
+va_arg!(builder::IRBuilder, List::Value, Ty::LLVMType, Name::String="") =
     Instruction(API.LLVMBuildVAArg(builder, List, Ty, Name))
 
-landingpad!(builder::Builder, Ty::LLVMType, PersFn::Value, NumClauses::Integer,
+landingpad!(builder::IRBuilder, Ty::LLVMType, PersFn::Value, NumClauses::Integer,
             Name::String="") =
     Instruction(API.LLVMBuildLandingPad(builder, Ty, PersFn, NumClauses, Name))
 
-neg!(builder::Builder, V::Value, Name::String="") =
+neg!(builder::IRBuilder, V::Value, Name::String="") =
     Value(API.LLVMBuildNeg(builder, V, Name))
 
-nswneg!(builder::Builder, V::Value, Name::String="") =
+nswneg!(builder::IRBuilder, V::Value, Name::String="") =
     Value(API.LLVMBuildNSWNeg(builder, V, Name))
 
-nuwneg!(builder::Builder, V::Value, Name::String="") =
+nuwneg!(builder::IRBuilder, V::Value, Name::String="") =
     Value(API.LLVMBuildNUWNeg(builder, V, Name))
 
-fneg!(builder::Builder, V::Value, Name::String="") =
+fneg!(builder::IRBuilder, V::Value, Name::String="") =
     Value(API.LLVMBuildFNeg(builder, V, Name))
 
-not!(builder::Builder, V::Value, Name::String="") =
+not!(builder::IRBuilder, V::Value, Name::String="") =
     Value(API.LLVMBuildNot(builder, V, Name))
 
 
 # other build methods
 
-globalstring!(builder::Builder, Str::String, Name::String="") =
+globalstring!(builder::IRBuilder, Str::String, Name::String="") =
     Value(API.LLVMBuildGlobalString(builder, Str, Name))
 
-globalstring_ptr!(builder::Builder, Str::String, Name::String="") =
+globalstring_ptr!(builder::IRBuilder, Str::String, Name::String="") =
     Value(API.LLVMBuildGlobalStringPtr(builder, Str, Name))
 
-isnull!(builder::Builder, Val::Value, Name::String="") =
+isnull!(builder::IRBuilder, Val::Value, Name::String="") =
     Value(API.LLVMBuildIsNull(builder, Val, Name))
 
-isnotnull!(builder::Builder, Val::Value, Name::String="") =
+isnotnull!(builder::IRBuilder, Val::Value, Name::String="") =
     Value(API.LLVMBuildIsNotNull(builder, Val, Name))
 
-function ptrdiff!(builder::Builder, LHS::Value, RHS::Value, Name::String="")
+function ptrdiff!(builder::IRBuilder, LHS::Value, RHS::Value, Name::String="")
     supports_typed_pointers(context(builder)) || throw_typedpointererror()
     Value(API.LLVMBuildPtrDiff(builder, LHS, RHS, Name))
 end
 
-function ptrdiff!(builder::Builder, Ty::LLVMType, LHS::Value, RHS::Value, Name::String="")
+function ptrdiff!(builder::IRBuilder, Ty::LLVMType, LHS::Value, RHS::Value, Name::String="")
     Value(API.LLVMBuildPtrDiff2(builder, Ty, LHS, RHS, Name))
 end

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -1,6 +1,6 @@
 @testset "analysis" begin
 
-@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.Int32Type(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -13,7 +13,7 @@
     @test_throws LLVMException verify(fn)
 end
 
-@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 

--- a/test/bitcode.jl
+++ b/test/bitcode.jl
@@ -5,7 +5,7 @@
     @test_throws LLVMException parse(LLVM.Module, unsafe_wrap(Vector{UInt8}, invalid_bitcode); ctx)
 end
 
-@dispose ctx=Context() builder=Builder(ctx) source_mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) source_mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(source_mod, "SomeFunction", ft)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -204,7 +204,7 @@ end
 
 @testset "value" begin
 
-@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -240,7 +240,7 @@ end
 
 # usage
 
-@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx)])
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -1314,7 +1314,7 @@ end
 
 @testset "basic blocks" begin
 
-@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 
@@ -1372,7 +1372,7 @@ end
 
 @testset "instructions" begin
 
-@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
     @test isempty(parameters(fn))

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -57,7 +57,7 @@ function emit_sum(ctx::Context)
 
     entry = BasicBlock(sum, "entry"; ctx)
 
-    @dispose builder=Builder(ctx) begin
+    @dispose builder=IRBuilder(ctx) begin
         position!(builder, entry)
 
         tmp = add!(builder, parameters(sum)[1], parameters(sum)[2])
@@ -78,7 +78,7 @@ function emit_retint(ctx::Context, val)
 
     entry = BasicBlock(fn, "entry"; ctx)
 
-    @dispose builder=Builder(ctx) begin
+    @dispose builder=IRBuilder(ctx) begin
         position!(builder, entry)
 
         ret!(builder, ConstantInt(LLVM.Int32Type(ctx), val))
@@ -103,7 +103,7 @@ function emit_phi(ctx::Context)
     elsee = BasicBlock(fn, "else"; ctx)
     merge = BasicBlock(fn, "ifcont"; ctx)
 
-    @dispose builder=Builder(ctx) begin
+    @dispose builder=IRBuilder(ctx) begin
         position!(builder, entry)
 
         cond = LLVM.icmp!(builder, LLVM.API.LLVMIntSGT, parameters(fn)[1], parameters(fn)[2], "ifcond")

--- a/test/instructions.jl
+++ b/test/instructions.jl
@@ -1,6 +1,6 @@
 @testset "irbuilder" begin
 
-@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx), [LLVM.Int32Type(ctx), LLVM.Int32Type(ctx),
                                                 LLVM.FloatType(ctx), LLVM.FloatType(ctx),
                                                 LLVM.PointerType(LLVM.Int32Type(ctx)),
@@ -479,7 +479,7 @@ end
             @test sprint(io->print(io, bundle1)) == "\"unknown\"(i32 1, i64 2)"
 
             # use in a call
-            @dispose builder=Builder(ctx) begin
+            @dispose builder=IRBuilder(ctx) begin
                 position!(builder, inst)
                 inst = call!(builder, functions(mod)["x"], Value[], [bundle1])
 

--- a/test/instructions.jl
+++ b/test/instructions.jl
@@ -181,11 +181,10 @@
     freeinst = free!(builder, ptr1)
     @check_ir freeinst "tail call void @free"
 
+    loadinst = load!(builder, LLVM.Int32Type(ctx), ptr1)
     if supports_typed_pointers(ctx)
-        loadinst = load!(builder, ptr1)
         @check_ir loadinst "load i32, i32* %4"
     else
-        loadinst = load!(builder, LLVM.Int32Type(ctx), ptr1)
         @check_ir loadinst "load i32, ptr %4"
     end
     alignment!(loadinst, 4)
@@ -209,19 +208,17 @@
     fenceinst = fence!(builder, LLVM.API.LLVMAtomicOrderingNotAtomic)
     @check_ir fenceinst "fence"
 
+    gepinst = gep!(builder, LLVM.Int32Type(ctx), ptr1, [int1])
     if supports_typed_pointers(ctx)
-        gepinst = gep!(builder, ptr1, [int1])
         @check_ir gepinst "getelementptr i32, i32* %4, i32 %0"
     else
-        gepinst = gep!(builder, LLVM.Int32Type(ctx), ptr1, [int1])
         @check_ir gepinst "getelementptr i32, ptr %4, i32 %0"
     end
 
+    gepinst1 = inbounds_gep!(builder, LLVM.Int32Type(ctx), ptr1, [int1])
     if supports_typed_pointers(ctx)
-        gepinst1 = inbounds_gep!(builder, ptr1, [int1])
         @check_ir gepinst1 "getelementptr inbounds i32, i32* %4, i32 %0"
     else
-        gepinst1 = inbounds_gep!(builder, LLVM.Int32Type(ctx), ptr1, [int1])
         @check_ir gepinst1 "getelementptr inbounds i32, ptr %4, i32 %0"
     end
 
@@ -320,11 +317,7 @@
 
     trap = LLVM.Function(mod, "llvm.trap", LLVM.FunctionType(LLVM.VoidType(ctx)))
 
-    if supports_typed_pointers(ctx)
-        callinst = call!(builder, trap)
-    else
-        callinst = call!(builder, LLVM.FunctionType(LLVM.VoidType(ctx)), trap)
-    end
+    callinst = call!(builder, LLVM.FunctionType(LLVM.VoidType(ctx)), trap)
 
     @check_ir callinst "call void @llvm.trap()"
     @test called_value(callinst) == trap
@@ -367,11 +360,10 @@
 
     ptr1 = parameters(fn)[5]
     ptr2 = parameters(fn)[6]
+    ptrdiffinst = ptrdiff!(builder, LLVM.Int32Type(ctx), ptr1, ptr2)
     if supports_typed_pointers(ctx)
-        ptrdiffinst = ptrdiff!(builder, ptr1, ptr2)
         @check_ir ptrdiffinst r"sdiv exact i64 %.+, ptrtoint \(i32\* getelementptr \(i32, i32\* null, i32 1\) to i64\)"
-    elseif LLVM.version() >= v"14"   # XXX: backport, if we care
-        ptrdiffinst = ptrdiff!(builder, LLVM.Int32Type(ctx), ptr1, ptr2)
+    else
         @check_ir ptrdiffinst r"sdiv exact i64 %.+, ptrtoint \(ptr getelementptr \(i32, ptr null, i32 1\) to i64\)"
     end
 
@@ -479,9 +471,11 @@ end
             @test sprint(io->print(io, bundle1)) == "\"unknown\"(i32 1, i64 2)"
 
             # use in a call
+            f = functions(mod)["x"]
+            ft = function_type(f)
             @dispose builder=IRBuilder(ctx) begin
                 position!(builder, inst)
-                inst = call!(builder, functions(mod)["x"], Value[], [bundle1])
+                inst = call!(builder, ft, f, Value[], [bundle1])
 
                 bundles = operand_bundles(inst)
                 @test length(bundles) == 1
@@ -500,8 +494,8 @@ end
                 @test sprint(io->print(io, bundle3)) == "\"unknown\"(i32 1, i64 2)"
 
                 # creating a call should perform the necessary conversion automatically
-                call!(builder, functions(mod)["x"], Value[], operand_bundles(inst))
-                call!(builder, functions(mod)["x"], Value[], [bundle2])
+                call!(builder, ft, f, Value[], operand_bundles(inst))
+                call!(builder, ft, f, Value[], [bundle2])
             end
         end
     end

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -17,7 +17,7 @@ end
 
         f, ft = create_function(T_int, [T_int])
 
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(f, "entry"; ctx)
             position!(builder, entry)
 

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -6,16 +6,16 @@
 end
 
 @dispose ctx=Context() begin
-    let builder = Builder(ctx)
+    let builder = IRBuilder(ctx)
         dispose(builder)
     end
 
-    Builder(ctx) do builder
+    IRBuilder(ctx) do builder
     end
 end
 
 
-@dispose ctx=Context() builder=Builder(ctx) source_mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) source_mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(source_mod, "SomeFunction", ft)
 

--- a/test/linker.jl
+++ b/test/linker.jl
@@ -1,6 +1,6 @@
 @testset "linker" begin
 
-@dispose ctx=Context() builder=Builder(ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) begin
     mod1 = let
         mod = LLVM.Module("SomeModule"; ctx)
         ft = LLVM.FunctionType(LLVM.VoidType(ctx))

--- a/test/orc.jl
+++ b/test/orc.jl
@@ -21,7 +21,7 @@ end
         fname = mangle(orc, "wrapper")
         wrapper = LLVM.Function(mod, fname, ft)
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(wrapper, "entry"; ctx)
             position!(builder, entry)
 
@@ -73,7 +73,7 @@ end
         fname = mangle(orc, "wrapper")
         wrapper = LLVM.Function(mod, fname, ft)
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(wrapper, "entry"; ctx)
             position!(builder, entry)
 
@@ -128,7 +128,7 @@ end
         fname = mangle(orc, "wrapper")
         wrapper = LLVM.Function(mod, fname, ft)
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(wrapper, "entry"; ctx)
             position!(builder, entry)
 
@@ -171,7 +171,7 @@ end
         fname = mangle(orc, "wrapper")
         wrapper = LLVM.Function(mod, fname, ft)
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(wrapper, "entry"; ctx)
             position!(builder, entry)
 
@@ -214,7 +214,7 @@ end
         ft = LLVM.FunctionType(LLVM.VoidType(ctx))
         fn = LLVM.Function(mod, sym, ft)
 
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(fn, "entry"; ctx)
             position!(builder, entry)
             ret!(builder)
@@ -285,7 +285,7 @@ end
                 ft = LLVM.FunctionType(LLVM.VoidType(ctx))
                 fn = LLVM.Function(mod, sym, ft)
 
-                @dispose builder=Builder(ctx) begin
+                @dispose builder=IRBuilder(ctx) begin
                     entry = BasicBlock(fn, "entry"; ctx)
                     position!(builder, entry)
                     ret!(builder)

--- a/test/orcv2.jl
+++ b/test/orcv2.jl
@@ -68,7 +68,7 @@ end
             fname = "wrapper"
             wrapper = LLVM.Function(mod, fname, ft)
             # generate IR
-            @dispose builder=Builder(ctx) begin
+            @dispose builder=IRBuilder(ctx) begin
                 entry = BasicBlock(wrapper, "entry"; ctx)
                 position!(builder, entry)
 
@@ -110,7 +110,7 @@ end
             ft = LLVM.FunctionType(LLVM.VoidType(ctx))
             fn = LLVM.Function(mod, sym, ft)
 
-            @dispose builder=Builder(ctx) begin
+            @dispose builder=IRBuilder(ctx) begin
                 entry = BasicBlock(fn, "entry"; ctx)
                 position!(builder, entry)
                 ret!(builder)
@@ -144,7 +144,7 @@ end
             gv = LLVM.GlobalVariable(mod, LLVM.Int32Type(ctx), "gv")
             LLVM.extinit!(gv, true)
 
-            @dispose builder=Builder(ctx) begin
+            @dispose builder=IRBuilder(ctx) begin
                 entry = BasicBlock(fn, "entry"; ctx)
                 position!(builder, entry)
                 val = load!(builder, gv)
@@ -208,7 +208,7 @@ end
                 ft = LLVM.FunctionType(LLVM.VoidType(ctx))
                 fn = LLVM.Function(mod, sym, ft)
 
-                @dispose builder=Builder(ctx) begin
+                @dispose builder=IRBuilder(ctx) begin
                     entry = BasicBlock(fn, "entry"; ctx)
                     position!(builder, entry)
                     ret!(builder)
@@ -273,7 +273,7 @@ end
                     fn = LLVM.Function(mod, "foo", ft)
 
                     # generate IR
-                    @dispose builder=Builder(ctx) begin
+                    @dispose builder=IRBuilder(ctx) begin
                         entry = BasicBlock(fn, "entry"; ctx)
                         position!(builder, entry)
 

--- a/test/pass.jl
+++ b/test/pass.jl
@@ -1,6 +1,6 @@
 @testset "pass" begin
 
-@dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
+@dispose ctx=Context() builder=IRBuilder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
     ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     fn = LLVM.Function(mod, "SomeFunction", ft)
 

--- a/test/targetmachine.jl
+++ b/test/targetmachine.jl
@@ -19,7 +19,7 @@ end
     asm_verbosity!(tm, true)
 
     # emission
-    @dispose ctx=Context() builder=Builder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
+    @dispose ctx=Context() builder=IRBuilder(ctx) mod=LLVM.Module("SomeModule"; ctx) begin
         ft = LLVM.FunctionType(LLVM.VoidType(ctx))
         fn = LLVM.Function(mod, "SomeFunction", ft)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,7 +11,7 @@
         f = LLVM.Function(mod, "f", fun_type)
 
         # generate IR
-        @dispose builder=Builder(ctx) begin
+        @dispose builder=IRBuilder(ctx) begin
             entry = BasicBlock(f, "entry"; ctx)
             position!(builder, entry)
             ptr = const_inttoptr(


### PR DESCRIPTION
With https://github.com/maleadt/LLVM.jl/pull/152 introducing `DIBuilder`, we shouldn't have a generically-named `Builder`. Now that we're breaking things, let's rename this to `IRBuilder`.

I did add a deprecation to not make this breaking right away, as well as added deprecations for `llvmtype` and `llvmeltype`; no reason to make this release extra painful.