### PR TITLE
Preserve integer index type for pointerref/pointerset.

### DIFF
--- a/src/interop/pointer.jl
+++ b/src/interop/pointer.jl
@@ -6,18 +6,18 @@ export @typed_ccall
 
 using Core: LLVMPtr
 
-@generated function pointerref(ptr::LLVMPtr{T,A}, i::Integer, ::Val{align}) where {T,A,align}
+@generated function pointerref(ptr::LLVMPtr{T,A}, i::I, ::Val{align}) where {T,A,I,align}
     sizeof(T) == 0 && return T.instance
     @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T; ctx)
 
-        T_int = convert(LLVMType, Int; ctx)
+        T_idx = convert(LLVMType, I; ctx)
         T_ptr = convert(LLVMType, ptr; ctx)
 
         T_typed_ptr = LLVM.PointerType(eltyp, A)
 
         # create a function
-        param_types = [T_ptr, T_int]
+        param_types = [T_ptr, T_idx]
         llvm_f, _ = create_function(eltyp, param_types)
 
         # generate IR
@@ -39,22 +39,22 @@ using Core: LLVMPtr
             ret!(builder, ld)
         end
 
-        call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, Int}, :ptr, :(Int(i-one(i))))
+        call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, I}, :ptr, :(i-one(I)))
     end
 end
 
-@generated function pointerset(ptr::LLVMPtr{T,A}, x::T, i::Integer, ::Val{align}) where {T,A,align}
+@generated function pointerset(ptr::LLVMPtr{T,A}, x::T, i::I, ::Val{align}) where {T,A,I,align}
     sizeof(T) == 0 && return
     @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T; ctx)
 
-        T_int = convert(LLVMType, Int; ctx)
+        T_idx = convert(LLVMType, I; ctx)
         T_ptr = convert(LLVMType, ptr; ctx)
 
         T_typed_ptr = LLVM.PointerType(eltyp, A)
 
         # create a function
-        param_types = [T_ptr, eltyp, T_int]
+        param_types = [T_ptr, eltyp, T_idx]
         llvm_f, _ = create_function(LLVM.VoidType(ctx), param_types)
 
         # generate IR
@@ -77,8 +77,8 @@ end
             ret!(builder)
         end
 
-        call_function(llvm_f, Cvoid, Tuple{LLVMPtr{T,A}, T, Int},
-                      :ptr, :(convert(T,x)), :(Int(i-one(i))))
+        call_function(llvm_f, Cvoid, Tuple{LLVMPtr{T,A}, T, I},
+                      :ptr, :(convert(T,x)), :(i-one(I)))
     end
 end
 


### PR DESCRIPTION
For https://github.com/JuliaGPU/CUDA.jl/pull/1895

Interestingly, we do still get an `i64`. With a simple CUDA `vadd` kernel, the unoptimized LLVM IR is:

```llvm
; PTX CompilerJob of MethodInstance for vadd(::CuDeviceMatrix{Float32, 1, Int32}, ::CuDeviceMatrix{Float32, 1, Int32}, ::CuDeviceMatrix{Float32, 1, Int32}) for sm_86
define ptx_kernel void @_Z4vadd13CuDeviceArrayI7Float32Li2ELi1E5Int32ES_IS0_Li2ELi1ES1_ES_IS0_Li2ELi1ES1_E({ i8 addrspace(1)*, i32, [2 x i32], i32 } %0, { i8 addrspace(1)*, i32, [2 x i32], i32 } %1, { i8 addrspace(1)*, i32, [2 x i32], i32 } %2) local_unnamed_addr #1 {
conversion:
  %3 = alloca { i8 addrspace(1)*, i32, [2 x i32], i32 }, align 8
  store { i8 addrspace(1)*, i32, [2 x i32], i32 } %0, { i8 addrspace(1)*, i32, [2 x i32], i32 }* %3, align 8
  %4 = alloca { i8 addrspace(1)*, i32, [2 x i32], i32 }, align 8
  store { i8 addrspace(1)*, i32, [2 x i32], i32 } %1, { i8 addrspace(1)*, i32, [2 x i32], i32 }* %4, align 8
  %5 = alloca { i8 addrspace(1)*, i32, [2 x i32], i32 }, align 8
  store { i8 addrspace(1)*, i32, [2 x i32], i32 } %2, { i8 addrspace(1)*, i32, [2 x i32], i32 }* %5, align 8
  br label %top

top:                                              ; preds = %conversion
  %6 = alloca [1 x i32], align 4
  %7 = alloca [1 x i32], align 4
  %8 = alloca [1 x i32], align 4
  %9 = call {}*** @julia.get_pgcstack()
  %10 = bitcast {}*** %9 to {}**
  %current_task = getelementptr inbounds {}*, {}** %10, i64 -12
  %11 = bitcast {}** %current_task to i64*
  %world_age = getelementptr inbounds i64, i64* %11, i64 13
  %12 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
  %13 = add i32 %12, 1
  %14 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.y()
  %15 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.z()
  %16 = sub i32 %13, 1
  %17 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
  %18 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.y()
  %19 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.z()
  %20 = mul i32 %16, %17
  %21 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
  %22 = add i32 %21, 1
  %23 = call i32 @llvm.nvvm.read.ptx.sreg.tid.y()
  %24 = call i32 @llvm.nvvm.read.ptx.sreg.tid.z()
  %25 = add i32 %20, %22
  br label %L48

L48:                                              ; preds = %top
  %26 = getelementptr inbounds { i8 addrspace(1)*, i32, [2 x i32], i32 }, { i8 addrspace(1)*, i32, [2 x i32], i32 }* %3, i32 0, i32 0
  %27 = sub i32 %25, 1
  %28 = load i8 addrspace(1)*, i8 addrspace(1)** %26, align 8
  %29 = bitcast i8 addrspace(1)* %28 to float addrspace(1)*
  %30 = getelementptr inbounds float, float addrspace(1)* %29, i32 %27
  %31 = load float, float addrspace(1)* %30, align 4
  br label %L54

L54:                                              ; preds = %L48
  br label %L55

L55:                                              ; preds = %L54
  br label %L70

L70:                                              ; preds = %L55
  %32 = getelementptr inbounds { i8 addrspace(1)*, i32, [2 x i32], i32 }, { i8 addrspace(1)*, i32, [2 x i32], i32 }* %4, i32 0, i32 0
  %33 = sub i32 %25, 1
  %34 = load i8 addrspace(1)*, i8 addrspace(1)** %32, align 8
  %35 = bitcast i8 addrspace(1)* %34 to float addrspace(1)*
  %36 = getelementptr inbounds float, float addrspace(1)* %35, i32 %33
  %37 = load float, float addrspace(1)* %36, align 4
  br label %L76

L76:                                              ; preds = %L70
  br label %L77

L77:                                              ; preds = %L76
  %38 = fadd float %31, %37
  br label %L93

L93:                                              ; preds = %L77
  %39 = getelementptr inbounds { i8 addrspace(1)*, i32, [2 x i32], i32 }, { i8 addrspace(1)*, i32, [2 x i32], i32 }* %5, i32 0, i32 0
  %40 = sub i32 %25, 1
  %41 = load i8 addrspace(1)*, i8 addrspace(1)** %39, align 8
  %42 = bitcast i8 addrspace(1)* %41 to float addrspace(1)*
  %43 = getelementptr inbounds float, float addrspace(1)* %42, i32 %40
  store float %38, float addrspace(1)* %43, align 4
  br label %L99

L99:                                              ; preds = %L93
  br label %L100

L100:                                             ; preds = %L99
  ret void
}
```

i.e. no `i64`. However, after optimization:

```llvm
; PTX CompilerJob of MethodInstance for vadd(::CuDeviceMatrix{Float32, 1, Int32}, ::CuDeviceMatrix{Float32, 1, Int32}, ::CuDeviceMatrix{Float32, 1, Int32}) for sm_86
define ptx_kernel void @_Z4vadd13CuDeviceArrayI7Float32Li2ELi1E5Int32ES_IS0_Li2ELi1ES1_ES_IS0_Li2ELi1ES1_E([1 x i64] %state, { i8 addrspace(1)*, i32, [2 x i32], i32 } %0, { i8 addrspace(1)*, i32, [2 x i32], i32 } %1, { i8 addrspace(1)*, i32, [2 x i32], i32 } %2) local_unnamed_addr #1 {
conversion:
  %.fca.0.extract11 = extractvalue { i8 addrspace(1)*, i32, [2 x i32], i32 } %0, 0
  %.fca.0.extract1 = extractvalue { i8 addrspace(1)*, i32, [2 x i32], i32 } %1, 0
  %.fca.0.extract = extractvalue { i8 addrspace(1)*, i32, [2 x i32], i32 } %2, 0
  %3 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
  %4 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
  %5 = mul i32 %4, %3
  %6 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
  %7 = add i32 %5, %6
  %8 = bitcast i8 addrspace(1)* %.fca.0.extract11 to float addrspace(1)*
  %9 = sext i32 %7 to i64
  %10 = getelementptr inbounds float, float addrspace(1)* %8, i64 %9
  %11 = load float, float addrspace(1)* %10, align 4
  %12 = bitcast i8 addrspace(1)* %.fca.0.extract1 to float addrspace(1)*
  %13 = getelementptr inbounds float, float addrspace(1)* %12, i64 %9
  %14 = load float, float addrspace(1)* %13, align 4
  %15 = fadd float %11, %14
  %16 = bitcast i8 addrspace(1)* %.fca.0.extract to float addrspace(1)*
  %17 = getelementptr inbounds float, float addrspace(1)* %16, i64 %9
  store float %15, float addrspace(1)* %17, align 4
  ret void
}
```

So optimization sneaks in an `i64` GEP? Which is too bad, as it means the compiled PTX code still contains some 64-bit instructions.