### PR TITLE
Rework LLVM object display.

### DIFF
--- a/src/core/context.jl
+++ b/src/core/context.jl
@@ -33,6 +33,18 @@ else
     supports_typed_pointers(ctx::Context) = true
 end
 
+function Base.show(io::IO, ctx::Context)
+    @printf(io, "LLVM.Context(%p", ctx.ref)
+    if ctx == GlobalContext()
+        print(io, ", global instance")
+    end
+    if v"14" <= version() < v"17"
+        # migration to opaque pointers
+        print(io, ", ", supports_typed_pointers(ctx) ? "typed ptrs" : "opaque ptrs")
+    end
+    print(io, ")")
+end
+
 @noinline throw_typedpointererror() =
     error("""Typed pointers are not supported.
 

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -50,6 +50,12 @@ opcode(inst::Instruction) = API.LLVMGetInstructionOpcode(inst)
 predicate_int(inst::Instruction) = API.LLVMGetICmpPredicate(inst)
 predicate_real(inst::Instruction) = API.LLVMGetFCmpPredicate(inst)
 
+# strip unnecessary whitespace
+Base.show(io::IO, ::MIME"text/plain", inst::Instruction) = print(io, lstrip(string(inst)))
+
+# instructions are typically only a single line, so always display them in full
+Base.show(io::IO, inst::Instruction) = print(io, typeof(inst), "(", lstrip(string(inst)), ")")
+
 
 ## metadata iteration
 # TODO: doesn't actually iterate, since we can't list the available keys
@@ -250,13 +256,17 @@ function inputs(bundle::OperandBundleDef)
     return [Value(val) for val in vals]
 end
 
-function Base.show(io::IO, bundle::Union{OperandBundleUse,OperandBundleDef})
+function Base.string(bundle::Union{OperandBundleUse,OperandBundleDef})
     # mimic how bundles are rendered in LLVM IR
-    print(io, "\"", tag_name(bundle), "\"(")
-    join(io, inputs(bundle), ", ")
-    print(io, ")")
+    "\"$(tag_name(bundle))\"(" * join(string.(inputs(bundle)), ", ") * ")"
 end
 
+function Base.show(io::IO, ::MIME"text/plain", bundle::Union{OperandBundleUse,OperandBundleDef})
+    print(io, string(bundle))
+end
+
+Base.show(io::IO, bundle::Union{OperandBundleUse,OperandBundleDef}) =
+    print(io, typeof(bundle), "(", string(bundle), ")")
 
 
 ## terminators

--- a/src/core/module.jl
+++ b/src/core/module.jl
@@ -40,6 +40,10 @@ function Module(f::Core.Function, args...; kwargs...)
 end
 
 function Base.show(io::IO, mod::Module)
+    print(io, "LLVM.Module(\"", name(mod), "\")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", mod::Module)
     output = string(mod)
     print(io, output)
 end

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -42,9 +42,14 @@ issized(typ::LLVMType) =
     convert(Core.Bool, API.LLVMTypeIsSized(typ))
 context(typ::LLVMType) = Context(API.LLVMGetTypeContext(typ))
 
+Base.string(typ::LLVMType) = unsafe_message(API.LLVMPrintTypeToString(typ))
+
+function Base.show(io::IO, ::MIME"text/plain", typ::LLVMType)
+    print(io, string(typ))
+end
+
 function Base.show(io::IO, typ::LLVMType)
-    output = unsafe_message(API.LLVMPrintTypeToString(typ))
-    print(io, output)
+    print(io, typeof(typ), "(", string(typ), ")")
 end
 
 Base.isempty(@nospecialize(T::LLVMType)) = false

--- a/src/core/value.jl
+++ b/src/core/value.jl
@@ -49,9 +49,20 @@ Base.sizeof(val::Value) = sizeof(value_type(val))
 name(val::Value) = unsafe_string(API.LLVMGetValueName(val))
 name!(val::Value, name::String) = API.LLVMSetValueName(val, name)
 
+Base.string(val::Value) = unsafe_message(API.LLVMPrintValueToString(val))
+
+# by default, only print the value type and its name or address
 function Base.show(io::IO, val::Value)
-    output = unsafe_message(API.LLVMPrintValueToString(val))
-    print(io, output)
+    if !isempty(name(val))
+        @printf(io, "%s(\"%s\")", typeof(val), name(val))
+    else
+        @printf(io, "%s(%p)", typeof(val), val.ref)
+    end
+end
+
+# when more output is requested, render the value (which may print multiple lines)
+function Base.show(io::IO, ::MIME"text/plain", val::Value)
+    print(io, string(val))
 end
 
 replace_uses!(old::Value, new::Value) = API.LLVMReplaceAllUsesWith(old, new)

--- a/src/irbuilder.jl
+++ b/src/irbuilder.jl
@@ -26,6 +26,8 @@ function IRBuilder(f::Core.Function, args...; kwargs...)
     end
 end
 
+Base.show(io::IO, builder::IRBuilder) = @printf(io, "IRBuilder(%p)", builder.ref)
+
 Base.position(builder::IRBuilder) = BasicBlock(API.LLVMGetInsertBlock(builder))
 position!(builder::IRBuilder, inst::Instruction) =
     API.LLVMPositionBuilderBefore(builder, inst)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1026,7 +1026,7 @@ end
     show(devnull, mod)
 
     inline_asm!(mod, "nop")
-    @test occursin("module asm", sprint(io->show(io,mod)))
+    @test occursin("module asm", string(mod))
 
     dummyTriple = "SomeTriple"
     triple!(mod, dummyTriple)
@@ -1041,8 +1041,8 @@ end
     mod_flags = flags(mod)
     mod_flags["foobar", LLVM.API.LLVMModuleFlagBehaviorError] = md
 
-    @test occursin("!llvm.module.flags = !{!0}", sprint(io->show(io,mod)))
-    @test occursin(r"!0 = !\{i\d+ 1, !\"foobar\", i\d+ 42\}", sprint(io->show(io,mod)))
+    @test occursin("!llvm.module.flags = !{!0}", string(mod))
+    @test occursin(r"!0 = !\{i\d+ 1, !\"foobar\", i\d+ 42\}", string(mod))
 
     @test mod_flags["foobar"] == md
     @test_throws KeyError mod_flags["foobaz"]

--- a/test/instructions.jl
+++ b/test/instructions.jl
@@ -431,7 +431,7 @@ end
                 @test length(bundles) == 1
                 bundle = first(bundles)
                 @test LLVM.tag_name(bundle) == "deopt"
-                @test sprint(io->print(io, bundle)) == "\"deopt\"(i32 1, i64 2)"
+                @test string(bundle) == "\"deopt\"(i32 1, i64 2)"
 
                 inputs = LLVM.inputs(bundle)
                 @test length(inputs) == 2
@@ -444,15 +444,15 @@ end
                 let bundle = bundles[1]
                     inputs = LLVM.inputs(bundle)
                     @test length(inputs) == 0
-                    @test sprint(io->print(io, bundle)) == "\"deopt\"()"
+                    @test string(bundle) == "\"deopt\"()"
                 end
                 let bundle = bundles[2]
                     inputs = LLVM.inputs(bundle)
                     @test length(inputs) == 1
                     if supports_typed_pointers(ctx)
-                        @test sprint(io->print(io, bundle)) == "\"unknown\"(i8* null)"
+                        @test string(bundle) == "\"unknown\"(i8* null)"
                     else
-                        @test sprint(io->print(io, bundle)) == "\"unknown\"(ptr null)"
+                        @test string(bundle) == "\"unknown\"(ptr null)"
                     end
                 end
             end
@@ -469,7 +469,7 @@ end
             @test bundle1 isa OperandBundleDef
             @test LLVM.tag_name(bundle1) == "unknown"
             @test LLVM.inputs(bundle1) == inputs
-            @test sprint(io->print(io, bundle1)) == "\"unknown\"(i32 1, i64 2)"
+            @test string(bundle1) == "\"unknown\"(i32 1, i64 2)"
 
             # use in a call
             f = functions(mod)["x"]
@@ -485,14 +485,14 @@ end
                 @test bundle2 isa OperandBundleUse
                 @test LLVM.tag_name(bundle2) == "unknown"
                 @test LLVM.inputs(bundle2) == inputs
-                @test sprint(io->print(io, bundle2)) == "\"unknown\"(i32 1, i64 2)"
+                @test string(bundle2) == "\"unknown\"(i32 1, i64 2)"
 
                 # creating from a use
                 bundle3 = OperandBundleDef(bundle2)
                 @test bundle3 isa OperandBundleDef
                 @test LLVM.tag_name(bundle3) == "unknown"
                 @test LLVM.inputs(bundle3) == inputs
-                @test sprint(io->print(io, bundle3)) == "\"unknown\"(i32 1, i64 2)"
+                @test string(bundle3) == "\"unknown\"(i32 1, i64 2)"
 
                 # creating a call should perform the necessary conversion automatically
                 call!(builder, ft, f, Value[], operand_bundles(inst))


### PR DESCRIPTION
Some of the `LLVM*ToString` methods can generate verbose output, so restrict them to `text/plain` MIME output, and `string(...)` calls.