### PR TITLE
Add `Colossus` to list of backends to initialise

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -21,7 +21,10 @@ export backends
 
 const libllvm_backends = [:AArch64, :AMDGPU, :ARC, :ARM, :AVR, :BPF, :Hexagon, :Lanai,
                           :MSP430, :Mips, :NVPTX, :PowerPC, :RISCV, :Sparc, :SystemZ,
-                          :VE, :WebAssembly, :X86, :XCore]
+                          :VE, :WebAssembly, :X86, :XCore,
+                          # Unofficial backends
+                          :Colossus,
+]
 const libllvm_components = [:Target, :TargetInfo, :TargetMC, :AsmPrinter, :AsmParser, :Disassembler]
 
 # discover supported back-ends and their components by looking at available symbols.


### PR DESCRIPTION
This PR adds support for the Colossus backend implemented in [Graphcore's LLVM fork](https://github.com/graphcore/llvm-project-fork).

This backend isn't officially in upstream LLVM, but it should be OK to keep it, if LLVM doesn't know it, it will simply skip it.