### PR TITLE
Improve API for setting pointer mode

### DIFF
--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -185,6 +185,8 @@ void LLVMReplaceMDNodeOperandWith(LLVMMetadataRef MD, unsigned I, LLVMMetadataRe
 
 #if LLVM_VERSION_MAJOR >= 13
 LLVMBool LLVMContextSupportsTypedPointers(LLVMContextRef C);
+#endif
+#if LLVM_VERSION_MAJOR >= 15
 LLVMBool LLVMContextHasSetOpaquePointersValue(LLVMContextRef C);
 #endif
 

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -185,6 +185,7 @@ void LLVMReplaceMDNodeOperandWith(LLVMMetadataRef MD, unsigned I, LLVMMetadataRe
 
 #if LLVM_VERSION_MAJOR >= 13
 LLVMBool LLVMContextSupportsTypedPointers(LLVMContextRef C);
+LLVMBool LLVMContextHasSetOpaquePointersValue(LLVMContextRef C);
 #endif
 
 // constant data

--- a/deps/LLVMExtra/lib/llvm-api.cpp
+++ b/deps/LLVMExtra/lib/llvm-api.cpp
@@ -618,6 +618,8 @@ void LLVMReplaceMDNodeOperandWith(LLVMMetadataRef MD, unsigned I, LLVMMetadataRe
 LLVMBool LLVMContextSupportsTypedPointers(LLVMContextRef C) {
   return unwrap(C)->supportsTypedPointers();
 }
+#endif
+#if LLVM_VERSION_MAJOR >= 15
 LLVMBool LLVMContextHasSetOpaquePointersValue(LLVMContextRef C) {
   return unwrap(C)->hasSetOpaquePointersValue();
 }

--- a/deps/LLVMExtra/lib/llvm-api.cpp
+++ b/deps/LLVMExtra/lib/llvm-api.cpp
@@ -618,6 +618,9 @@ void LLVMReplaceMDNodeOperandWith(LLVMMetadataRef MD, unsigned I, LLVMMetadataRe
 LLVMBool LLVMContextSupportsTypedPointers(LLVMContextRef C) {
   return unwrap(C)->supportsTypedPointers();
 }
+LLVMBool LLVMContextHasSetOpaquePointersValue(LLVMContextRef C) {
+  return unwrap(C)->hasSetOpaquePointersValue();
+}
 #endif
 
 LLVMValueRef LLVMConstDataArray(LLVMTypeRef ElementTy, const void *Data, unsigned NumElements) {

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -452,10 +452,12 @@ function LLVMPostDominatorTreeInstructionDominates(Tree, InstA, InstB)
     ccall((:LLVMPostDominatorTreeInstructionDominates, libLLVMExtra), LLVMBool, (LLVMPostDominatorTreeRef, LLVMValueRef, LLVMValueRef), Tree, InstA, InstB)
 end
 
-if version() > v"12"
+if version() >= v"13"
 function LLVMContextSupportsTypedPointers(Ctx)
     ccall((:LLVMContextSupportsTypedPointers, libLLVMExtra), LLVMBool, (LLVMContextRef,), Ctx)
 end
+end
+if version() >= v"15"
 function LLVMContextHasSetOpaquePointersValue(Ctx)
     ccall((:LLVMContextHasSetOpaquePointersValue, libLLVMExtra), LLVMBool, (LLVMContextRef,), Ctx)
 end

--- a/lib/libLLVM_extra.jl
+++ b/lib/libLLVM_extra.jl
@@ -456,6 +456,9 @@ if version() > v"12"
 function LLVMContextSupportsTypedPointers(Ctx)
     ccall((:LLVMContextSupportsTypedPointers, libLLVMExtra), LLVMBool, (LLVMContextRef,), Ctx)
 end
+function LLVMContextHasSetOpaquePointersValue(Ctx)
+    ccall((:LLVMContextHasSetOpaquePointersValue, libLLVMExtra), LLVMBool, (LLVMContextRef,), Ctx)
+end
 end
 
 function LLVMConstDataArray(ElementTy, Data, NumElements)

--- a/src/core/context.jl
+++ b/src/core/context.jl
@@ -74,8 +74,8 @@ if version() >= v"13"
 
     function unsafe_opaque_pointers!(ctx::Context, enable::Core.Bool)
         @static if version() >= v"15"
-            if has_set_opaque_pointers_value(ctx)
-                error("Opaque pointers value has already been set!")
+            if has_set_opaque_pointers_value(ctx) && typed_pointers(ctx) != !enable
+                error("Cannot $(enable ? "enable" : "disable") opaque pointers, as the context has already been configured to use $(typed_pointers(ctx) ? "typed" : "opaque") pointers")
             end
         end
         API.LLVMContextSetOpaquePointers(ctx, enable)
@@ -103,19 +103,6 @@ function opaque_pointers!(ctx::Context, opaque_pointers)
     end
 
     @static if v"13" <= version() < v"17"
-        # the opaque pointer setting can only be set once
-        @static if version() >= v"15"
-            # on LLVM 15, we can check whether the context has been configured already
-            if has_set_opaque_pointers_value(ctx)
-                return
-            end
-        else
-            # we also know that Julia used to set this value to `false` by default
-            if VERSION < v"1.11-"
-                return
-            end
-        end
-
         unsafe_opaque_pointers!(ctx, opaque_pointers)
     end
 end

--- a/src/executionengine/ts_module.jl
+++ b/src/executionengine/ts_module.jl
@@ -5,12 +5,7 @@ Base.unsafe_convert(::Type{API.LLVMOrcThreadSafeContextRef}, ctx::ThreadSafeCont
 
 function ThreadSafeContext(; opaque_pointers=false)
     ts_ctx = ThreadSafeContext(API.LLVMOrcCreateNewThreadSafeContext())
-    @static if v"13" <= version() < v"17"
-        ctx = context(ts_ctx)
-        if opaque_pointers !== nothing && !has_set_opaque_pointers_value(ctx)
-            opaque_pointers!(ctx, opaque_pointers)
-        end
-    end
+    opaque_pointers!(context(ts_ctx), opaque_pointers)
     activate(ts_ctx)
     ts_ctx
 end

--- a/src/executionengine/ts_module.jl
+++ b/src/executionengine/ts_module.jl
@@ -3,9 +3,11 @@
 end
 Base.unsafe_convert(::Type{API.LLVMOrcThreadSafeContextRef}, ctx::ThreadSafeContext) = ctx.ref
 
-function ThreadSafeContext(; opaque_pointers=false)
+function ThreadSafeContext(; opaque_pointers=nothing)
     ts_ctx = ThreadSafeContext(API.LLVMOrcCreateNewThreadSafeContext())
-    opaque_pointers!(context(ts_ctx), opaque_pointers)
+    if opaque_pointers !== nothing
+        opaque_pointers!(context(ts_ctx), opaque_pointers)
+    end
     activate(ts_ctx)
     ts_ctx
 end


### PR DESCRIPTION
Adds an `opaque_pointers` kwarg to the `Context` and `ThreadSafeContext` constructors, while checking that the flag hasn't been set already. This relies on https://github.com/JuliaLang/julia/pull/51840, which makes it so that Julia doesn't default to setting this flag (preventing us from changing the setting).