### PR TITLE
LLVMPtr: Implement arithmetic without using Base.add_ptr to avoid addrspacecasts

### DIFF
--- a/test/interop_tests.jl
+++ b/test/interop_tests.jl
@@ -242,6 +242,12 @@ using Core: LLVMPtr
     @test b - 1 == a
     @test d - 1 == c
     @test f - 1 == e
+
+    # ensure pointer arithmetic doesn't perform addrspacecasts
+    ir = sprint(io->code_llvm(io, +, Tuple{typeof(e), Int}; optimize=false, dump_module=true))
+    @test !occursin(r"addrspacecast", ir)
+    ir = sprint(io->code_llvm(io, -, Tuple{typeof(e), Int}; optimize=false, dump_module=true))
+    @test !occursin(r"addrspacecast", ir)
 end
 
 @testset "unsafe_load" begin


### PR DESCRIPTION
Fixes https://github.com/maleadt/LLVM.jl/issues/386, towards fixing https://github.com/JuliaGPU/Metal.jl/issues/282