### PR TITLE
Fix Julia JIT integration on Windows x86_64

### DIFF
--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -1032,7 +1032,11 @@ end
     show(devnull, mod)
 
     inline_asm!(mod, "nop")
-    @test occursin("module asm", string(mod))
+    @test split(inline_asm(mod)) == ["nop"]
+    inline_asm!(mod, "nop")
+    @test split(inline_asm(mod)) == ["nop", "nop"]
+    inline_asm!(mod, "nop"; overwrite=true)
+    @test split(inline_asm(mod)) == ["nop"]
 
     dummyTriple = "SomeTriple"
     triple!(mod, dummyTriple)


### PR DESCRIPTION
Julia's JIT expects certain symbols to be present in the generated code, https://github.com/JuliaLang/julia/blob/f24364a4821f85410a27a236173c4e6bbb08e568/src/debuginfo.cpp#L287-L315, generated by https://github.com/JuliaLang/julia/blob/f24364a4821f85410a27a236173c4e6bbb08e568/src/jitlayers.cpp#L2152-L2172. Since this seems Julia-specific, add those symbols automatically when adding IR to a Julia JIT instance.

Fixes https://github.com/maleadt/LLVM.jl/issues/393

@gbaraldi: Since you wrote the Julia JIT integration in https://github.com/maleadt/LLVM.jl/pull/346, care to review?