### PR TITLE
Update Bfloat16s.jl compat bound.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
 BFloat16sExt = "BFloat16s"
 
 [compat]
-BFloat16s = "0.4"
+BFloat16s = "0.4, 0.5"
 CEnum = "0.2, 0.3, 0.4, 0.5"
 LLVMExtra_jll = "=0.0.29"
 Libdl = "1.8"


### PR DESCRIPTION
Not sure why CompatHelper.jl didn't do this...

@DilumAluthge do you know? LLVM.jl had the following BFloat16s.jl-related entries in Project.toml: https://github.com/maleadt/LLVM.jl/blob/5a34b05e1797b9fd6b4254d91874bd7e8816a20b/Project.toml#L14-L21

BFloat16s.jl 0.5 has been released for a while, yet CompatHelper.jl on here doesn't even mention the package in its logs: https://github.com/maleadt/LLVM.jl/actions/runs/8547271848/job/23419132957. We are using the latest CompatHelper.jl, v3.10.0.