### PR TITLE
LLVM 17 enablement.

### DIFF
--- a/examples/Kaleidoscope/run.jl
+++ b/examples/Kaleidoscope/run.jl
@@ -16,13 +16,30 @@ function generate_IR(str)
 end
 
 function optimize!(mod::LLVM.Module)
-    LLVM.@dispose pass_manager=LLVM.ModulePassManager() begin
-        LLVM.instruction_combining!(pass_manager)
-        LLVM.reassociate!(pass_manager)
-        LLVM.gvn!(pass_manager)
-        LLVM.cfgsimplification!(pass_manager)
-        LLVM.promote_memory_to_register!(pass_manager)
-        LLVM.run!(pass_manager, mod)
+    if LLVM.has_newpm()
+        host_triple = Sys.MACHINE # LLVM.triple() might be wrong (see LLVM.jl#108)
+        host_t = LLVM.Target(triple=host_triple)
+        LLVM.@dispose tm=LLVM.TargetMachine(host_t, host_triple) pb=LLVM.PassBuilder(tm) begin
+            LLVM.NewPMModulePassManager(pb) do mpm
+                LLVM.add!(mpm, LLVM.NewPMFunctionPassManager) do fpm
+                    LLVM.add!(fpm, LLVM.InstCombinePass())
+                    LLVM.add!(fpm, LLVM.ReassociatePass())
+                    LLVM.add!(fpm, LLVM.GVNPass())
+                    LLVM.add!(fpm, LLVM.SimplifyCFGPass())
+                    LLVM.add!(fpm, LLVM.PromotePass())
+                end
+                LLVM.run!(mpm, mod, tm)
+            end
+        end
+    else
+        LLVM.@dispose pass_manager=LLVM.ModulePassManager() begin
+            LLVM.instruction_combining!(pass_manager)
+            LLVM.reassociate!(pass_manager)
+            LLVM.gvn!(pass_manager)
+            LLVM.cfgsimplification!(pass_manager)
+            LLVM.promote_memory_to_register!(pass_manager)
+            LLVM.run!(pass_manager, mod)
+        end
     end
     return mod
 end

--- a/src/LLVM.jl
+++ b/src/LLVM.jl
@@ -40,9 +40,9 @@ let
     if version().major < 13
         error("LLVM.jl only supports LLVM 13 and later.")
     end
-    dir = if version().major > 16
-        @warn "LLVM.jl has not been tested with LLVM versions newer than 16."
-        joinpath(@__DIR__, "..", "lib", "16")
+    dir = if version().major > 17
+        @warn "LLVM.jl has not been tested with LLVM versions newer than 17."
+        joinpath(@__DIR__, "..", "lib", "17")
     else
         joinpath(@__DIR__, "..", "lib", string(version().major))
     end
@@ -55,12 +55,15 @@ include(joinpath(@__DIR__, "..", "lib", "libLLVM_julia.jl"))
 
 end # module API
 
+has_oldpm() = LLVM.version() < v"17"
 has_newpm() = LLVM.version() >= v"15"
 has_julia_ojit() = VERSION >= v"1.10.0-DEV.1395"
 
 # LLVM API wrappers
 include("support.jl")
-include("passregistry.jl")
+if LLVM.version() < v"17"
+    include("passregistry.jl")
+end
 include("init.jl")
 include("core.jl")
 include("linker.jl")
@@ -76,7 +79,9 @@ include("targetmachine.jl")
 include("datalayout.jl")
 include("ir.jl")
 include("bitcode.jl")
-include("transform.jl")
+if has_oldpm()
+    include("transform.jl")
+end
 include("debuginfo.jl")
 include("dibuilder.jl")
 include("jitevents.jl")

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -355,7 +355,7 @@ export ConstantExpr,
        const_sext, const_zext, const_fptrunc, const_fpext, const_uitofp, const_sitofp,
        const_fptoui, const_fptosi, const_ptrtoint, const_inttoptr, const_bitcast,
        const_addrspacecast, const_zextorbitcast, const_sextorbitcast, const_truncorbitcast,
-       const_pointercast, const_intcast, const_fpcast, const_select, const_shufflevector
+       const_pointercast, const_intcast, const_fpcast, const_shufflevector
 
 @checked struct ConstantExpr <: Constant
     ref::API.LLVMValueRef
@@ -492,9 +492,6 @@ const_intcast(val::Constant, ToType::LLVMType, isSigned::Bool) =
 const_fpcast(val::Constant, ToType::LLVMType) =
     Value(API.LLVMConstFPCast(val, ToType))
 
-const_select(cond::Constant, if_true::Value, if_false::Value) =
-    Value(API.LLVMConstSelect(cond, if_true, if_false))
-
 const_extractelement(vector::Constant, index::Constant) =
     Value(API.LLVMConstExtractElement(vector ,index))
 
@@ -541,6 +538,15 @@ const_fsub(lhs::Constant, rhs::Constant) =
 
 const_fmul(lhs::Constant, rhs::Constant) =
     Value(API.LLVMConstFMul(lhs, rhs))
+
+end
+
+if version() < v"17"
+
+export const_select
+
+const_select(cond::Constant, if_true::Value, if_false::Value) =
+    Value(API.LLVMConstSelect(cond, if_true, if_false))
 
 end
 

--- a/src/init.jl
+++ b/src/init.jl
@@ -4,17 +4,19 @@ export ismultithreaded
 
 ismultithreaded() = API.LLVMIsMultithreaded() |> Bool
 
-const subsystems = [:Core, :TransformUtils, :ScalarOpts, :Vectorization, :InstCombine,
-                    :IPO, :Analysis, :IPA, :CodeGen, :Target]
-if LLVM.version() < v"16"
-    append!(subsystems, [:ObjCARCOpts, :Instrumentation])
-end
-for subsystem in subsystems
-    jl_fname = Symbol(:Initialize, subsystem)
-    api_fname = Symbol(:LLVM, jl_fname)
-    @eval begin
-        export $jl_fname
-        $jl_fname(R::PassRegistry) = API.$api_fname(R)
+if LLVM.version() < v"17"
+    const subsystems = [:Core, :TransformUtils, :ScalarOpts, :Vectorization, :InstCombine,
+                        :IPO, :Analysis, :IPA, :CodeGen, :Target]
+    if LLVM.version() < v"16"
+        append!(subsystems, [:ObjCARCOpts, :Instrumentation])
+    end
+    for subsystem in subsystems
+        jl_fname = Symbol(:Initialize, subsystem)
+        api_fname = Symbol(:LLVM, jl_fname)
+        @eval begin
+            export $jl_fname
+            $jl_fname(R::PassRegistry) = API.$api_fname(R)
+        end
     end
 end
 

--- a/src/newpm/passes.jl
+++ b/src/newpm/passes.jl
@@ -379,7 +379,9 @@ is_function_pass(::Type{InvalidateAllAnalysesPass}) = true
 @function_pass "print<cost-model>" CostModelPrinterPass
 @function_pass "print<cycles>" CycleInfoPrinterPass
 @function_pass "print<da>" DependenceAnalysisPrinterPass
+if LLVM.version() < v"17"
 @function_pass "print<divergence>" DivergenceAnalysisPrinterPass
+end
 @function_pass "print<domtree>" DominatorTreePrinterPass
 @function_pass "print<postdomtree>" PostDominatorTreePrinterPass
 @function_pass "print<delinearization>" DelinearizationPrinterPass

--- a/test/essential_tests.jl
+++ b/test/essential_tests.jl
@@ -1,5 +1,6 @@
 @testitem "essentials" begin
 
+if LLVM.version() < v"17"
 @testset "pass registry" begin
     passreg = GlobalPassRegistry()
 
@@ -20,11 +21,12 @@
     InitializeIPA(passreg)
     InitializeCodeGen(passreg)
     InitializeTarget(passreg)
-
-    InitializeNativeTarget()
-    InitializeAllTargetInfos()
-    InitializeAllTargetMCs()
-    InitializeNativeAsmPrinter()
 end
+end
+
+InitializeNativeTarget()
+InitializeAllTargetInfos()
+InitializeAllTargetMCs()
+InitializeNativeAsmPrinter()
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,5 +44,9 @@ runtests(LLVM; worker_init_expr, nworkers=min(Sys.CPU_THREADS,4), nworker_thread
         LLVM.has_newpm() || return false
     end
 
+    if ti.name == "transform"
+        LLVM.has_oldpm() || return false
+    end
+
     true
 end


### PR DESCRIPTION
Remaining issue: ORC is broken on LLVM 17

```
❯ jl +nightly --project examples/sum_orc.jl
ERROR: LoadError: LLVM error: Symbols not found: [ llvm_orc_registerEHFrameSectionWrapper ]
Stacktrace:
 [1] macro expansion
   @ ~/Julia/pkg/LLVM/src/executionengine/utils.jl:32 [inlined]
 [2] LLJIT(builder::LLJITBuilder)
   @ LLVM ~/Julia/pkg/LLVM/src/executionengine/lljit.jl:38
 [3] #LLJIT#66
   @ ~/Julia/pkg/LLVM/src/executionengine/lljit.jl:59 [inlined]
 [4] top-level scope
   @ ~/Julia/pkg/LLVM/examples/sum_orc.jl:45
 [5] include
   @ ./Base.jl:559 [inlined]
 [6] exec_options(opts::Base.JLOptions)
   @ Base ./client.jl:325
 [7] _start()
   @ Base ./client.jl:533
in expression starting at /home/tim/Julia/pkg/LLVM/examples/sum_orc.jl:45
```

Looks like ORC now expects certain LLVM symbols to be globally visible: https://github.com/llvm/llvm-project/issues/74671. This basically requires a change in how Julia links against LLVM, re-exporting those symbols. The alternatives aren't viable (see https://github.com/apache/arrow/issues/39695#issuecomment-1912186637). I agree with https://github.com/llvm/llvm-project/issues/74671#issuecomment-1845616965 that this is a bad design decision on LLVM's side.