### PR TITLE
NewPM: Warn early when using invalid empty pass lists.

### DIFF
--- a/src/newpm.jl
+++ b/src/newpm.jl
@@ -55,6 +55,10 @@ Base.string(pm::NewPMPassManager) = "$(pm.type)($(join(pm.passes, ",")))"
 
 function add!(f::Base.Callable, parent::AbstractPassManager, nested::AbstractPassManager)
     f(nested)
+    if isempty(nested.passes)
+        # LLVM errors when doing `module()` etc, so catch this early
+        error("Cannot add an empty pass manager; did you forget to add passes?")
+    end
     add!(parent, nested)
 end
 


### PR DESCRIPTION
Otherwise, when submitting an empty pass manager (see e.g. https://github.com/JuliaGPU/GPUCompiler.jl/commit/6c3c8f67c642f19fefdcb1443c4e1b34668a97b0 for a real-life example) you get an inscrutable error (`LLVM ERROR: Unknown function pass ''`).