### PR TITLE
Add support for specifying the AA pipeline.

### DIFF
--- a/deps/LLVMExtra/CMakeLists.txt
+++ b/deps/LLVMExtra/CMakeLists.txt
@@ -1,9 +1,6 @@
-
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.13.4)
 
 SET(CMAKE_CXX_FLAGS "-Wall -fPIC -fno-rtti")
-cmake_policy(SET CMP0074 NEW)
-cmake_policy(SET CMP0077 NEW)
 
 project(LLVMExtra
 VERSION

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -254,6 +254,8 @@ void LLVMPassBuilderExtensionsRegisterFunctionPass(LLVMPassBuilderExtensionsRef 
                                                    const char *PassName,
                                                    LLVMJuliaFunctionPassCallback Callback,
                                                    void *Thunk);
+void LLVMPassBuilderExtensionsSetAAPipeline(LLVMPassBuilderExtensionsRef Extensions,
+                                            const char *AAPipeline);
 LLVMErrorRef LLVMRunJuliaPasses(LLVMModuleRef M, const char *Passes,
                                 LLVMTargetMachineRef TM, LLVMPassBuilderOptionsRef Options,
                                 LLVMPassBuilderExtensionsRef Extensions);

--- a/lib/15/libLLVM_extra.jl
+++ b/lib/15/libLLVM_extra.jl
@@ -377,6 +377,10 @@ function LLVMPassBuilderExtensionsRegisterFunctionPass(Options, PassName, Callba
     ccall((:LLVMPassBuilderExtensionsRegisterFunctionPass, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Cstring, LLVMJuliaFunctionPassCallback, Ptr{Cvoid}), Options, PassName, Callback, Thunk)
 end
 
+function LLVMPassBuilderExtensionsSetAAPipeline(Extensions, AAPipeline)
+    ccall((:LLVMPassBuilderExtensionsSetAAPipeline, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Cstring), Extensions, AAPipeline)
+end
+
 function LLVMRunJuliaPasses(M, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPasses, libLLVMExtra), LLVMErrorRef, (LLVMModuleRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), M, Passes, TM, Options, Extensions)
 end

--- a/lib/16/libLLVM_extra.jl
+++ b/lib/16/libLLVM_extra.jl
@@ -377,6 +377,10 @@ function LLVMPassBuilderExtensionsRegisterFunctionPass(Options, PassName, Callba
     ccall((:LLVMPassBuilderExtensionsRegisterFunctionPass, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Cstring, LLVMJuliaFunctionPassCallback, Ptr{Cvoid}), Options, PassName, Callback, Thunk)
 end
 
+function LLVMPassBuilderExtensionsSetAAPipeline(Extensions, AAPipeline)
+    ccall((:LLVMPassBuilderExtensionsSetAAPipeline, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Cstring), Extensions, AAPipeline)
+end
+
 function LLVMRunJuliaPasses(M, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPasses, libLLVMExtra), LLVMErrorRef, (LLVMModuleRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), M, Passes, TM, Options, Extensions)
 end

--- a/lib/17/libLLVM_extra.jl
+++ b/lib/17/libLLVM_extra.jl
@@ -337,6 +337,10 @@ function LLVMPassBuilderExtensionsRegisterFunctionPass(Options, PassName, Callba
     ccall((:LLVMPassBuilderExtensionsRegisterFunctionPass, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Cstring, LLVMJuliaFunctionPassCallback, Ptr{Cvoid}), Options, PassName, Callback, Thunk)
 end
 
+function LLVMPassBuilderExtensionsSetAAPipeline(Extensions, AAPipeline)
+    ccall((:LLVMPassBuilderExtensionsSetAAPipeline, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Cstring), Extensions, AAPipeline)
+end
+
 function LLVMRunJuliaPasses(M, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPasses, libLLVMExtra), LLVMErrorRef, (LLVMModuleRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), M, Passes, TM, Options, Extensions)
 end

--- a/lib/18/libLLVM_extra.jl
+++ b/lib/18/libLLVM_extra.jl
@@ -271,6 +271,10 @@ function LLVMPassBuilderExtensionsRegisterFunctionPass(Options, PassName, Callba
     ccall((:LLVMPassBuilderExtensionsRegisterFunctionPass, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Cstring, LLVMJuliaFunctionPassCallback, Ptr{Cvoid}), Options, PassName, Callback, Thunk)
 end
 
+function LLVMPassBuilderExtensionsSetAAPipeline(Extensions, AAPipeline)
+    ccall((:LLVMPassBuilderExtensionsSetAAPipeline, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Cstring), Extensions, AAPipeline)
+end
+
 function LLVMRunJuliaPasses(M, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPasses, libLLVMExtra), LLVMErrorRef, (LLVMModuleRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), M, Passes, TM, Options, Extensions)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
+IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Example:

```julia
@dispose ctx=Context() pb=NewPMPassBuilder() begin
    @dispose pb=NewPMPassBuilder(;debug_logging=true) mod=test_module() begin
        add!(pb, NewPMAAManager()) do aa
            add!(aa, "basic-aa")
        end
        add!(pb, "aa-eval")

        @test run!(pb, mod) === nothing
    end
end
```

Fixes https://github.com/maleadt/LLVM.jl/issues/436
x-ref https://discourse.llvm.org/t/newpm-c-api-questions/80598