### PR TITLE
Add back a convenience function for calling with operand bundles.

### DIFF
--- a/src/irbuilder.jl
+++ b/src/irbuilder.jl
@@ -412,6 +412,11 @@ function call!(builder::IRBuilder, Ty::LLVMType, Fn::Value, Args::Vector{<:Value
                                                     length(Bundles), Name))
 end
 
+# convenience function to be able to call `call!` with an `operand_bundles(call)` argument
+call!(builder::IRBuilder, Ty::LLVMType, Fn::Value, Args::Vector{<:Value},
+      Bundles::OperandBundleIterator, Name::String="") =
+    call!(builder, Ty, Fn, Args, collect(Bundles), Name)
+
 va_arg!(builder::IRBuilder, List::Value, Ty::LLVMType, Name::String="") =
     Instruction(API.LLVMBuildVAArg(builder, List, Ty, Name))
 

--- a/test/instructions_tests.jl
+++ b/test/instructions_tests.jl
@@ -526,6 +526,9 @@ end
                 bundles = operand_bundles(inst)
                 @test length(bundles) == 1
 
+                # test the ability to directly forward `operand_bundles`
+                inst2 = call!(builder, ft, f, Value[], bundles)
+
                 bundle2 = bundles[1]
                 @test bundle2 isa OperandBundle
                 @test LLVM.tag(bundle2) == "unknown"


### PR DESCRIPTION
Used by GPUCompiler.jl: https://github.com/JuliaGPU/GPUCompiler.jl/blob/b71344189c86531cb61fe630cf512b3a0b6558a8/src/metal.jl#L533-L535