### PR TITLE
Extend iteration interface

### DIFF
--- a/src/core/function.jl
+++ b/src/core/function.jl
@@ -104,7 +104,17 @@ function Base.iterate(iter::FunctionParameterSet, state=API.LLVMGetFirstParam(it
     state == C_NULL ? nothing : (Argument(state), API.LLVMGetNextParam(state))
 end
 
-Base.last(iter::FunctionParameterSet) = Argument(API.LLVMGetLastParam(iter.f))
+function Base.first(iter::FunctionParameterSet)
+    ref = API.LLVMGetFirstParam(iter.f)
+    ref == C_NULL && throw(BoundsError(iter))
+    Argument(ref)
+end
+
+function Base.last(iter::FunctionParameterSet)
+    ref = API.LLVMGetLastParam(iter.f)
+    ref == C_NULL && throw(BoundsError(iter))
+    Argument(ref)
+end
 
 # NOTE: optimized `collect`
 function Base.collect(iter::FunctionParameterSet)
@@ -115,7 +125,7 @@ end
 
 # basic block iteration
 
-export blocks
+export blocks, prevblock, nextblock
 
 struct FunctionBlockSet <: AbstractVector{BasicBlock}
     f::Function
@@ -133,6 +143,7 @@ function Base.first(iter::FunctionBlockSet)
     ref == C_NULL && throw(BoundsError(iter))
     BasicBlock(ref)
 end
+
 function Base.last(iter::FunctionBlockSet)
     ref = API.LLVMGetLastBasicBlock(iter.f)
     ref == C_NULL && throw(BoundsError(iter))
@@ -141,6 +152,18 @@ end
 
 function Base.iterate(iter::FunctionBlockSet, state=API.LLVMGetFirstBasicBlock(iter.f))
     state == C_NULL ? nothing : (BasicBlock(state), API.LLVMGetNextBasicBlock(state))
+end
+
+function prevblock(bb::BasicBlock)
+    ref = API.LLVMGetPreviousBasicBlock(bb)
+    ref == C_NULL && return nothing
+    BasicBlock(ref)
+end
+
+function nextblock(bb::BasicBlock)
+    ref = API.LLVMGetNextBasicBlock(bb)
+    ref == C_NULL && return nothing
+    BasicBlock(ref)
 end
 
 # provide a random access interface by maintaining a cache of blocks

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -275,7 +275,7 @@ Base.setindex!(iter::TerminatorSuccessorSet, bb::BasicBlock, i::Int) =
 
 # incoming iteration
 
-export PhiIncomingSet
+export incoming
 
 struct PhiIncomingSet <: AbstractVector{Tuple{Value,BasicBlock}}
     phi::Instruction

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -219,39 +219,6 @@ function Base.getindex(iter::OperandBundleInputIterator, i::Int)
     Value(API.LLVMGetOperandBundleArgAtIndex(iter.bundle, i-1))
 end
 
-# @checked mutable struct OperandBundleDef
-#     ref::API.LLVMOperandBundleDefRef
-# end
-# Base.unsafe_convert(::Type{API.LLVMOperandBundleDefRef}, bundle::OperandBundleDef) =
-#     bundle.ref
-
-# function tag_name(bundle::OperandBundleDef)
-#     len = Ref{Cuint}()
-#     data = API.LLVMGetOperandBundleDefTag(bundle, len)
-#     unsafe_string(convert(Ptr{Int8}, data), len[])
-# end
-
-# function OperandBundleDef(bundle_use::OperandBundle)
-#     bundle_def = OperandBundleDef(API.LLVMOperandBundleDefFromUse(bundle_use))
-#     finalizer(bundle_def) do obj
-#         API.LLVMDisposeOperandBundleDef(obj)
-#     end
-# end
-
-# function OperandBundleDef(tag::String, inputs::Vector{<:Value}=Value[])
-#     bundle = OperandBundleDef(API.LLVMCreateOperandBundleDef(tag, inputs, length(inputs)))
-#     finalizer(bundle) do obj
-#         API.LLVMDisposeOperandBundleDef(obj)
-#     end
-# end
-
-# function inputs(bundle::OperandBundleDef)
-#     nvals = API.LLVMGetOperandBundleDefNumInputs(bundle)
-#     vals = Vector{API.LLVMValueRef}(undef, nvals)
-#     API.LLVMGetOperandBundleDefInputs(bundle, vals)
-#     return [Value(val) for val in vals]
-# end
-
 function Base.string(bundle::OperandBundle)
     # mimic how bundles are rendered in LLVM IR
     "\"$(tag(bundle))\"(" * join(string.(inputs(bundle)), ", ") * ")"

--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -329,8 +329,17 @@ function Base.iterate(iter::ModuleMetadataIterator, state=API.LLVMGetFirstNamedM
     end
 end
 
-Base.last(iter::ModuleMetadataIterator) =
-    NamedMDNode(iter.mod, API.LLVMGetLastNamedMetadata(iter.mod))
+function Base.first(iter::ModuleMetadataIterator)
+    ref = API.LLVMGetFirstNamedMetadata(iter.mod)
+    ref == C_NULL && throw(BoundsError(iter))
+    NamedMDNode(iter.mod, ref)
+end
+
+function Base.last(iter::ModuleMetadataIterator)
+    ref = API.LLVMGetLastNamedMetadata(iter.mod)
+    ref == C_NULL && throw(BoundsError(iter))
+    NamedMDNode(iter.mod, ref)
+end
 
 Base.isempty(iter::ModuleMetadataIterator) =
     API.LLVMGetLastNamedMetadata(iter.mod) == C_NULL

--- a/test/execution_tests.jl
+++ b/test/execution_tests.jl
@@ -114,16 +114,16 @@ function emit_phi()
         br!(builder, merge)
 
         position!(builder, elsee)
-        elsecg = sub!(builder, LLVM.parameters(fn)[2], LLVM.ConstantInt(LLVM.Int32Type(), 5))
+        elsecg = sub!(builder, parameters(fn)[2], LLVM.ConstantInt(LLVM.Int32Type(), 5))
         br!(builder, merge)
 
         position!(builder, merge)
         phi = phi!(builder, LLVM.Int32Type(), "iftmp")
 
-        append!(LLVM.incoming(phi), [(thencg, then), (elsecg, elsee)])
+        append!(incoming(phi), [(thencg, then), (elsecg, elsee)])
 
-        @test length(LLVM.incoming(phi)) == 2
-        @test_throws BoundsError LLVM.incoming(phi)[3]
+        @test length(incoming(phi)) == 2
+        @test_throws BoundsError incoming(phi)[3]
 
         ret!(builder, phi)
     end

--- a/test/newpm_tests.jl
+++ b/test/newpm_tests.jl
@@ -70,7 +70,7 @@ end
         end
 
         # target machines
-        host_triple = LLVM.triple()
+        host_triple = triple()
         host_t = Target(triple=host_triple)
         @dispose tm=TargetMachine(host_t, host_triple) mod=test_module() begin
             @test run!(NoOpModulePass(), mod, tm) === nothing


### PR DESCRIPTION
This PR exposes functionality to move to the previous/next instruction/block/function by means of `prevXXX`/`nextXXX` functions (inspired by `prevfloat`/`nextfloat` and `prevind`/`nextind`). Not particularly idiomatic, but I couldn't immediately find another common iterator abstraction to implement this kind of operation...