### PR TITLE
NFC clean-ups.

### DIFF
--- a/src/core/basicblock.jl
+++ b/src/core/basicblock.jl
@@ -43,6 +43,7 @@ move_before(bb::BasicBlock, pos::BasicBlock) =
 move_after(bb::BasicBlock, pos::BasicBlock) =
     API.LLVMMoveBasicBlockAfter(bb, pos)
 
+
 ## instruction iteration
 
 export instructions, previnst, nextinst
@@ -88,7 +89,6 @@ function nextinst(inst::Instruction)
     ref == C_NULL && return nothing
     Instruction(ref)
 end
-
 
 
 ## cfg-like operations

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -159,7 +159,7 @@ else
 end
 
 addrspace(ptrtyp::PointerType) =
-    API.LLVMGetPointerAddressSpace(ptrtyp)
+    Int(API.LLVMGetPointerAddressSpace(ptrtyp))
 
 
 ## array types
@@ -189,7 +189,7 @@ function VectorType(eltyp::LLVMType, count)
     return VectorType(API.LLVMVectorType(eltyp, count))
 end
 
-Base.size(vectyp::VectorType) = API.LLVMGetVectorSize(vectyp)
+Base.length(vectyp::VectorType) = Int(API.LLVMGetVectorSize(vectyp))
 
 
 ## structure types

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -23,3 +23,5 @@ Base.@deprecate_binding ValueMetadataDict LLVM.InstructionMetadataDict
                            FailureOrdering::API.LLVMAtomicOrdering, syncscope::String),
            atomic_cmpxchg!(builder, Ptr, Cmp, New, SuccessOrdering, FailureOrdering,
                            SyncScope(syncscope)), false)
+
+@deprecate Base.size(vectyp::VectorType) length(vectyp) false

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -130,7 +130,7 @@ end
     @test eltype(vectyp) == eltyp
     @test context(vectyp) == context(eltyp)
 
-    @test size(vectyp) == 2
+    @test length(vectyp) == 2
 end
 
 # structure


### PR DESCRIPTION
- tighten some functions to avoid assertions
- return human-readable ints from length etc methods
- switch from size to length for vector types.