### PR TITLE
Strip whitespace when showing LLVM objects.

### DIFF
--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -36,9 +36,10 @@ function Metadata(ref::API.LLVMMetadataRef)
     return T(ref)
 end
 
-function Base.show(io::IO, md::Metadata)
-    output = unsafe_message(API.LLVMPrintMetadataToString(md))
-    print(io, output)
+Base.string(md::Metadata) = unsafe_message(API.LLVMPrintMetadataToString(md))
+
+function Base.show(io::IO, ::MIME"text/plain", md::Metadata)
+    print(io, strip(string(md)))
 end
 
 

--- a/src/core/module.jl
+++ b/src/core/module.jl
@@ -43,7 +43,7 @@ function Base.show(io::IO, mod::Module)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", mod::Module)
-    output = string(mod)
+    output = strip(string(mod))
     print(io, output)
 end
 

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -44,11 +44,11 @@ context(typ::LLVMType) = Context(API.LLVMGetTypeContext(typ))
 Base.string(typ::LLVMType) = unsafe_message(API.LLVMPrintTypeToString(typ))
 
 function Base.show(io::IO, ::MIME"text/plain", typ::LLVMType)
-    print(io, string(typ))
+    print(io, strip(string(typ)))
 end
 
 function Base.show(io::IO, typ::LLVMType)
-    print(io, typeof(typ), "(", string(typ), ")")
+    print(io, typeof(typ), "(", strip(string(typ)), ")")
 end
 
 Base.isempty(@nospecialize(T::LLVMType)) = false

--- a/src/core/value.jl
+++ b/src/core/value.jl
@@ -62,7 +62,7 @@ end
 
 # when more output is requested, render the value (which may print multiple lines)
 function Base.show(io::IO, ::MIME"text/plain", val::Value)
-    print(io, string(val))
+    print(io, strip(string(val)))
 end
 
 replace_uses!(old::Value, new::Value) = API.LLVMReplaceAllUsesWith(old, new)


### PR DESCRIPTION
LLVM's string representations often contain superfluous whitespace, which doesn't look nice in the REPL.

I originally wanted to do this in the `string` functions, but returning a `SubString` from there is unexpected and breaks things (such as the `llvmcall` embedding). Flattening to a String would incur copies everywhere, and doing pointer magic in `unsafe_message` can only skip leading whitespace without scanning the buffer twice for the terminating null.
So let's keep things simple and only strip when displaying.