### PR TITLE
Remove PassRegistry wrappers.

### DIFF
--- a/src/LLVM.jl
+++ b/src/LLVM.jl
@@ -65,9 +65,6 @@ include("debug.jl")
 
 # LLVM API wrappers
 include("support.jl")
-if LLVM.version() < v"17"
-    include("passregistry.jl")
-end
 include("init.jl")
 include("core.jl")
 include("linker.jl")

--- a/src/passregistry.jl
+++ b/src/passregistry.jl
@@ -1,9 +1,0 @@
-@checked struct PassRegistry
-    ref::API.LLVMPassRegistryRef
-end
-
-Base.unsafe_convert(::Type{API.LLVMPassRegistryRef}, pr::PassRegistry) = pr.ref
-
-export GlobalPassRegistry
-
-GlobalPassRegistry() = PassRegistry(API.LLVMGetGlobalPassRegistry())

--- a/test/essential_tests.jl
+++ b/test/essential_tests.jl
@@ -1,32 +1,8 @@
 @testitem "essentials" begin
 
-if LLVM.version() < v"17"
-@testset "pass registry" begin
-    passreg = GlobalPassRegistry()
-
-    @test version() isa VersionNumber
-    @test ismultithreaded() isa Bool
-
-    InitializeCore(passreg)
-    InitializeTransformUtils(passreg)
-    InitializeScalarOpts(passreg)
-    if LLVM.version() < v"16"
-        InitializeObjCARCOpts(passreg)
-        InitializeInstrumentation(passreg)
-    end
-    InitializeVectorization(passreg)
-    InitializeInstCombine(passreg)
-    InitializeIPO(passreg)
-    InitializeAnalysis(passreg)
-    InitializeIPA(passreg)
-    InitializeCodeGen(passreg)
-    InitializeTarget(passreg)
-end
-end
-
-InitializeNativeTarget()
-InitializeAllTargetInfos()
-InitializeAllTargetMCs()
-InitializeNativeAsmPrinter()
+@test InitializeNativeTarget() === nothing
+@test InitializeAllTargetInfos() === nothing
+@test InitializeAllTargetMCs() === nothing
+@test InitializeNativeAsmPrinter() === nothing
 
 end

--- a/test/support_tests.jl
+++ b/test/support_tests.jl
@@ -29,8 +29,8 @@ code = """
 
 end
 
-@testset "memcheck" begin
 if LLVM.memcheck_enabled
+@testset "memcheck" begin
     # use after dispose
     let (; out, err) =
         execute_code("""buf = LLVM.MemoryBuffer(UInt8[])


### PR DESCRIPTION
They are unused, unneeded, and removed from LLVM 17+.