### PR TITLE
Remove support for global contexts.

### DIFF
--- a/src/LLVM.jl
+++ b/src/LLVM.jl
@@ -131,7 +131,6 @@ function __init__()
     end
 
     _install_handlers()
-    _install_handlers(GlobalContext())
     atexit(report_leaks)
 end
 

--- a/src/core/context.jl
+++ b/src/core/context.jl
@@ -1,6 +1,6 @@
 # Contexts are execution states for the core LLVM IR system.
 
-export Context, dispose, GlobalContext
+export Context, dispose
 
 @checked struct Context
     ref::API.LLVMContextRef
@@ -32,13 +32,8 @@ function Context(f::Core.Function; kwargs...)
     end
 end
 
-GlobalContext() = Context(API.LLVMGetGlobalContext())
-
 function Base.show(io::IO, ctx::Context)
     @printf(io, "LLVM.Context(%p", ctx.ref)
-    if ctx == GlobalContext()
-        print(io, ", global instance")
-    end
     if v"14" <= version() < v"17"
         # migration to opaque pointers
         print(io, ", ", supports_typed_pointers(ctx) ? "typed ptrs" : "opaque ptrs")

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -21,7 +21,12 @@ end
 
 let
     ctx = Context()
-    @assert ctx != GlobalContext()
+    @test context() == ctx
+    let ctx2 = Context()
+        @test context() == ctx2
+        @test ctx !== ctx2
+        dispose(ctx2)
+    end
     @test context() == ctx
     dispose(ctx)
     @test context(; throw_error=false) === nothing


### PR DESCRIPTION
Has been removed from upstream for ages: https://reviews.llvm.org/D19094