### PR TITLE
Deprecate copy ctors in favor of Base.copy.

### DIFF
--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -33,8 +33,7 @@ function Instruction(ref::API.LLVMValueRef)
     return T(ref)
 end
 
-Instruction(inst::Instruction) =
-    Instruction(API.LLVMInstructionClone(inst))
+Base.copy(inst::Instruction) = Instruction(API.LLVMInstructionClone(inst))
 
 unsafe_delete!(::BasicBlock, inst::Instruction) =
     API.LLVMInstructionEraseFromParent(inst)

--- a/src/core/module.jl
+++ b/src/core/module.jl
@@ -24,8 +24,7 @@ end
 Module(name::String) =
     mark_alloc(Module(API.LLVMModuleCreateWithNameInContext(name, context())))
 
-Module(mod::Module) = mark_alloc(Module(API.LLVMCloneModule(mod)))
-Base.copy(mod::Module) = Module(mod)
+Base.copy(mod::Module) = mark_alloc(Module(API.LLVMCloneModule(mod)))
 
 dispose(mod::Module) = mark_dispose(API.LLVMDisposeModule, mod)
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -25,3 +25,6 @@ Base.@deprecate_binding ValueMetadataDict LLVM.InstructionMetadataDict
                            SyncScope(syncscope)), false)
 
 @deprecate Base.size(vectyp::VectorType) length(vectyp) false
+
+@deprecate Module(mod::Module) copy(mod) false
+@deprecate Instruction(inst::Instruction) copy(inst) false


### PR DESCRIPTION
Copy-constructors aren't a common thing in Julia (even in Base some are no-ops, others copy), so let's be explicit.