### PR TITLE
Replace (unsafe_)delete! with remove!/erase!, closer to upstream.

### DIFF
--- a/src/core/basicblock.jl
+++ b/src/core/basicblock.jl
@@ -1,4 +1,4 @@
-export BasicBlock, unsafe_delete!,
+export BasicBlock, remove!, erase!,
        terminator, name,
        move_before, move_after
 
@@ -20,9 +20,8 @@ BasicBlock(f::Function, name::String;) =
 BasicBlock(bb::BasicBlock, name::String) =
     BasicBlock(API.LLVMInsertBasicBlockInContext(context(bb), bb, name))
 
-unsafe_delete!(::Function, bb::BasicBlock) = API.LLVMDeleteBasicBlock(bb)
-Base.delete!(::Function, bb::BasicBlock) =
-    API.LLVMRemoveBasicBlockFromParent(bb)
+remove!(bb::BasicBlock) = API.LLVMRemoveBasicBlockFromParent(bb)
+erase!(bb::BasicBlock) = API.LLVMDeleteBasicBlock(bb)
 
 function parent(bb::BasicBlock)
     ref = API.LLVMGetBasicBlockParent(bb)

--- a/src/core/function.jl
+++ b/src/core/function.jl
@@ -1,4 +1,4 @@
-export unsafe_delete!,
+export erase!,
        personality, personality!,
        callconv, callconv!,
        gc, gc!,
@@ -14,7 +14,7 @@ function_type(Fn::Function) = FunctionType(API.LLVMGetFunctionType(Fn))
 
 Base.empty!(f::Function) = API.LLVMFunctionDeleteBody(f)
 
-unsafe_delete!(::Module, f::Function) = API.LLVMDeleteFunction(f)
+erase!(f::Function) = API.LLVMDeleteFunction(f)
 
 function personality(f::Function)
     has_personality = API.LLVMHasPersonalityFn(f) |> Bool

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -1,4 +1,4 @@
-export Instruction, unsafe_delete!,
+export Instruction, remove!, erase!, parent,
        opcode,
        predicate_int, predicate_real
 
@@ -35,10 +35,8 @@ end
 
 Base.copy(inst::Instruction) = Instruction(API.LLVMInstructionClone(inst))
 
-unsafe_delete!(::BasicBlock, inst::Instruction) =
-    API.LLVMInstructionEraseFromParent(inst)
-Base.delete!(::BasicBlock, inst::Instruction) =
-    API.LLVMInstructionRemoveFromParent(inst)
+remove!(inst::Instruction) = API.LLVMInstructionRemoveFromParent(inst)
+erase!(inst::Instruction) = API.LLVMInstructionEraseFromParent(inst)
 
 parent(inst::Instruction) =
     BasicBlock(API.LLVMGetInstructionParent(inst))

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -635,7 +635,7 @@ alignment!(val::AlignedValue, bytes::Integer) = API.LLVMSetAlignment(val, bytes)
 
 abstract type GlobalObject <: GlobalValue end
 
-export GlobalVariable, unsafe_delete!,
+export GlobalVariable, erase!,
        initializer, initializer!,
        isthreadlocal, threadlocal!,
        threadlocalmode, threadlocalmode!,
@@ -654,7 +654,7 @@ GlobalVariable(mod::Module, typ::LLVMType, name::String, addrspace::Integer) =
     GlobalVariable(API.LLVMAddGlobalInAddressSpace(mod, typ,
                                                    name, addrspace))
 
-unsafe_delete!(::Module, gv::GlobalVariable) = API.LLVMDeleteGlobal(gv)
+erase!(gv::GlobalVariable) = API.LLVMDeleteGlobal(gv)
 
 function initializer(gv::GlobalVariable)
     init = API.LLVMGetInitializer(gv)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -28,3 +28,8 @@ Base.@deprecate_binding ValueMetadataDict LLVM.InstructionMetadataDict
 
 @deprecate Module(mod::Module) copy(mod) false
 @deprecate Instruction(inst::Instruction) copy(inst) false
+
+@deprecate unsafe_delete!(::Module, gv::GlobalVariable) erase!(gv)
+@deprecate unsafe_delete!(::Module, f::Function) erase!(f)
+@deprecate unsafe_delete!(::Function, bb::BasicBlock) erase!(bb)
+@deprecate unsafe_delete!(::BasicBlock, inst::Instruction) erase!(inst)

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -831,16 +831,16 @@ end
     @test !haskey(globals(mod), "llvm.used")
     set_used!(mod, gv)
     @test haskey(globals(mod), "llvm.used")
-    unsafe_delete!(mod, globals(mod)["llvm.used"])
+    erase!(globals(mod)["llvm.used"])
 
     @test !haskey(globals(mod), "llvm.compiler.used")
     set_compiler_used!(mod, gv)
     @test haskey(globals(mod), "llvm.compiler.used")
-    unsafe_delete!(mod, globals(mod)["llvm.compiler.used"])
+    erase!(globals(mod)["llvm.compiler.used"])
 
     let gvars = globals(mod)
         @test gv in gvars
-        unsafe_delete!(mod, gv)
+        erase!(gv)
         @test isempty(gvars)
     end
 end
@@ -1181,7 +1181,7 @@ end
     @test personality(fn) == pers_fn
     personality!(fn, nothing)
     @test personality(fn) === nothing
-    unsafe_delete!(mod, pers_fn)
+    erase!(pers_fn)
 
     @test !isintrinsic(fn)
 
@@ -1195,7 +1195,7 @@ end
 
     let fns = functions(mod)
         @test fn in fns
-        unsafe_delete!(mod, fn)
+        erase!(fn)
         @test isempty(fns)
     end
 end
@@ -1417,7 +1417,7 @@ end
         @test collect(insts) == [brinst]
     end
 
-    unsafe_delete!(bb1, brinst)    # we'll be deleting bb2, so remove uses of it
+    erase!(brinst)    # we'll be deleting bb2, so remove uses of it
 
     # basic block iteration
     let bbs = blocks(fn)
@@ -1434,8 +1434,8 @@ end
 
         @test bb1 in bbs
         @test bb2 in bbs
-        delete!(fn, bb1)
-        unsafe_delete!(fn, bb2)
+        remove!(bb1)
+        erase!(bb2)
         @test isempty(bbs)
     end
 end
@@ -1539,12 +1539,12 @@ end
     end
 
     @test retinst in instructions(bb3)
-    delete!(bb3, retinst)
+    remove!(retinst)
     @test !(retinst in instructions(bb3))
     @test opcode(retinst) == LLVM.API.LLVMRet   # make sure retinst is still alive
 
     @test brinst in instructions(bb1)
-    unsafe_delete!(bb1, brinst)
+    erase!(brinst)
     @test !(brinst in instructions(bb1))
 end
 


### PR DESCRIPTION
These functions also don't have to take a `parent` argument, as `Base.delete!` does, making them more general (e.g., to erase unlinked instructions or blocks).