### PR TITLE
MDString: deprecate string in favor of convert.

### DIFF
--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -83,7 +83,7 @@ Metadata(val::Value) = Metadata(API.LLVMValueAsMetadata(val))
 Base.convert(T::Type{<:Metadata}, val::Value) = Metadata(val)::T
 
 
-## values
+## strings
 
 export MDString
 
@@ -95,7 +95,7 @@ register(MDString, API.LLVMMDStringMetadataKind)
 MDString(val::String) =
     MDString(API.LLVMMDStringInContext2(context(), val, length(val)))
 
-function Base.string(md::MDString)
+function Base.convert(::Type{String}, md::MDString)
     len = Ref{Cuint}()
     ptr = API.LLVMGetMDString2(md, len)
     return unsafe_string(convert(Ptr{Int8}, ptr), len[])

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -33,3 +33,9 @@ Base.@deprecate_binding ValueMetadataDict LLVM.InstructionMetadataDict
 @deprecate unsafe_delete!(::Module, f::Function) erase!(f)
 @deprecate unsafe_delete!(::Function, bb::BasicBlock) erase!(bb)
 @deprecate unsafe_delete!(::BasicBlock, inst::Instruction) erase!(inst)
+
+@deprecate Base.string(md::MDString) convert(String, md) false
+function Base.show(io::IO, ::MIME"text/plain", md::MDString)
+    str = @invoke string(md::Metadata)
+    print(io, strip(str))
+end

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -870,7 +870,7 @@ end
 
 @dispose ctx=Context() begin
     str = MDString("foo")
-    @test string(str) == "foo"
+    @test convert(String, str) == "foo"
 
     # wrap as Value
     val = Value(str)


### PR DESCRIPTION
`string` methods are supposed to mimic printing to I/O, while here we're extracting the underlying string (`!{"foo"}` vs `"foo"`). It was also silly to have this behave differently with different Metadata subtypes.