### PR TITLE
Fix constructing a ThreadSafeModule from a Module in a different Ctx.

### DIFF
--- a/test/orc_tests.jl
+++ b/test/orc_tests.jl
@@ -24,6 +24,22 @@ end
             true
         end
     end
+
+    @dispose ctx=Context() ts_ctx=ThreadSafeContext() begin
+        src_mod = LLVM.Module("SomeModule")
+        ts_mod = ThreadSafeModule(src_mod)
+        ts_mod() do copied_mod
+            # XXX: this is a very specific test to check the current implementation of the
+            #      ThreadSafeModule constructor, which currently copies the source module
+            #      from its context into the thread safe one. This is questionable; maybe
+            #      it should create a ThreadSafeModule in a ThreadSafeContext matching the
+            #      source context. However, that would result in a TSMod that doesn't match
+            #      the currently-active ts_context()...
+            @test context(copied_mod) != context(src_mod)
+            @test context(copied_mod) == context(ts_context())
+        end
+        dispose(ts_mod)
+    end
 end
 
 @testset "JITDylib" begin


### PR DESCRIPTION
In https://github.com/maleadt/LLVM.jl/pull/459, I added a simple assertion to make sure the module passed to `LLVMOrcCreateNewThreadSafeModule` resides in the same context as the thread-safe context passed to the API, because the `ThreadSafeModule` ctor called by the C API simply creates a new object without copying:
- https://github.com/llvm/llvm-project/blob/36c210bb340cfdc68d314dd188e18c0bf017b999/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp#L748-L753
- https://llvm.org/doxygen/classllvm_1_1orc_1_1ThreadSafeModule.html#aad76bc6379e9faa0a0b2e360817bbc37

This tripped up Enzyme:

```
ABI & Calling convention: Error During Test at /home/runner/work/LLVM.jl/LLVM.jl/downstream/test/abi.jl:4
  Got exception outside of a @test
  AssertionError: context(mod) == context(ts_context())
  Stacktrace:
    [1] LLVM.ThreadSafeModule(mod::LLVM.Module)
      @ LLVM ~/work/LLVM.jl/LLVM.jl/src/executionengine/ts_module.jl:87
    [2] #3
      @ ~/work/LLVM.jl/LLVM.jl/downstream/src/compiler/orcv2.jl:168 [inlined]
    [3] LLVM.ThreadSafeContext(f::Enzyme.Compiler.JIT.var"#3#4"{LLVM.MemoryBuffer}; kwargs::@Kwargs{})
      @ LLVM ~/work/LLVM.jl/LLVM.jl/src/executionengine/ts_module.jl:33
    [4] ThreadSafeContext
      @ ~/work/LLVM.jl/LLVM.jl/src/executionengine/ts_module.jl:30 [inlined]
    [5] move_to_threadsafe
      @ ~/work/LLVM.jl/LLVM.jl/downstream/src/compiler/orcv2.jl:166 [inlined]
    [6] add!(mod::LLVM.Module)
      @ Enzyme.Compiler.JIT ~/work/LLVM.jl/LLVM.jl/downstream/src/compiler/orcv2.jl:265
    [7] _link(job::CompilerJob{Enzyme.Compiler.EnzymeTarget, Enzyme.Compiler.EnzymeCompilerParams}, ::Tuple{LLVM.Module, String, Nothing, DataType})
      @ Enzyme.Compiler ~/work/LLVM.jl/LLVM.jl/downstream/src/compiler.jl:7212
    [8] cached_compilation
      @ ~/work/LLVM.jl/LLVM.jl/downstream/src/compiler.jl:7283 [inlined]
    [9] thunkbase(ctx::LLVM.Context, mi::Core.MethodInstance, ::Val{0x0000000000007b15}, ::Type{Const{var"#f#26"}}, ::Type{Const}, tt::Type{Tuple{Const{Nothing}}}, ::Val{Enzyme.API.DEM_ReverseModeCombined}, ::Val{1}, ::Val{(false, false)}, ::Val{false}, ::Val{false}, ::Type{FFIABI}, ::Val{true})
      @ Enzyme.Compiler ~/work/LLVM.jl/LLVM.jl/downstream/src/compiler.jl:7355
   [10] #s2080#19052
      @ ~/work/LLVM.jl/LLVM.jl/downstream/src/compiler.jl:7407 [inlined]
   [11] var"#s2080#19052"(FA::Any, A::Any, TT::Any, Mode::Any, ModifiedBetween::Any, width::Any, ReturnPrimal::Any, ShadowInit::Any, World::Any, ABI::Any, ErrIfFuncWritten::Any, ::Any, ::Type, ::Type, ::Type, tt::Any, ::Type, ::Type, ::Type, ::Type, ::Type, ::Type, ::Any)
      @ Enzyme.Compiler ./none:0
   [12] (::Core.GeneratedFunctionStub)(::UInt64, ::LineNumberNode, ::Any, ::Vararg{Any})
      @ Core ./boot.jl:602
   [13] autodiff
      @ ~/work/LLVM.jl/LLVM.jl/downstream/src/Enzyme.jl:315 [inlined]
   [14] autodiff(mode::ReverseMode{false, FFIABI, false, false}, f::var"#f#26", ::Type{Const}, args::Const{Nothing})
      @ Enzyme ~/work/LLVM.jl/LLVM.jl/downstream/src/Enzyme.jl:332
   [15] macro expansion
      @ ~/work/LLVM.jl/LLVM.jl/downstream/test/abi.jl:9 [inlined]
   [16] macro expansion
      @ /opt/hostedtoolcache/julia/1.10.5/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:1577 [inlined]
   [17] top-level scope
      @ ~/work/LLVM.jl/LLVM.jl/downstream/test/abi.jl:6
   [18] include(fname::String)
      @ Base.MainInclude ./client.jl:489
   [19] top-level scope
      @ ~/work/LLVM.jl/LLVM.jl/downstream/test/runtests.jl:85
   [20] include(fname::String)
      @ Base.MainInclude ./client.jl:489
   [21] top-level scope
      @ none:6
   [22] eval
      @ ./boot.jl:385 [inlined]
   [23] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:291
   [24] _start()
      @ Base ./client.jl:552
```

So it looks like Enzyme is doing Very Broken Things. The ORC manual, https://llvm.org/docs/ORCv2.html#how-to-use-threadsafemodule-and-threadsafecontext, discusses another convenience method that should probably be used here: https://llvm.org/doxygen/classllvm_1_1orc_1_1ThreadSafeModule.html#a59b16a2ba2778523a92d88a10d000e9d

> For this reason a convenience constructor for ThreadSafeModule is provided that implicitly constructs a new ThreadSafeContext value from a std::unique_ptr<LLVMContext>:

However, that currently isn't exposed by the C API. So for now, round-trip through a MemoryBuffer to make sure the contexts match.

cc @wsmoses @vchuravy 