### PR TITLE
Restrict SetMetadata to MDNodes.

### DIFF
--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -197,7 +197,7 @@ function Base.getindex(md::InstructionMetadataDict, key)
     return Metadata(MetadataAsValue(objref))
   end
 
-Base.setindex!(md::InstructionMetadataDict, node::Metadata, key) =
+Base.setindex!(md::InstructionMetadataDict, node::MDNode, key) =
     API.LLVMSetMetadata(md.val, MDKind(key), Value(node))
 
 Base.delete!(md::InstructionMetadataDict, key) =


### PR DESCRIPTION
AFAIU only MDNodes are allowed: https://github.com/llvm/llvm-project/blob/d21e731c42d6b967e29dbe2edc16c1b86885df0d/llvm/lib/IR/Core.cpp#L1091-L1092

Before:

```
julia> metadata(inst)["foo"] = MDString("bar");
julia: /workspace/srcdir/llvm-project/llvm/lib/IR/Core.cpp:940: llvm::MDNode* extractMDNode(llvm::MetadataAsValue*): Assertion `(isa<MDNode>(MD) || isa<ConstantAsMetadata>(MD)) && "Expected a metadata node or a canonicalized constant"' failed.
```

After:

```
julia> metadata(inst)["foo"] = MDString("bar");
ERROR: MethodError: no method matching setindex!(::LLVM.InstructionMetadataDict, ::MDString, ::String)

Closest candidates are:
  setindex!(::AbstractDict, ::Any, ::Any, ::Any, ::Any...)
   @ Base abstractdict.jl:550
  setindex!(::LLVM.InstructionMetadataDict, ::MDNode, ::Any)
   @ LLVM ~/Julia/pkg/LLVM/src/core/metadata.jl:200
```