### PR TITLE
Re-enable ORC testing.

### DIFF
--- a/examples/sum_orc.jl
+++ b/examples/sum_orc.jl
@@ -4,13 +4,6 @@ using Test
 
 using LLVM
 
-if LLVM.version() >= v"17" && Sys.islinux()
-
-# maleadt/LLVM.jl#405
-@error "ORC is broken on Linux with LLVM >= 17"
-
-else
-
 if length(ARGS) == 2
     x, y = parse.([Int32], ARGS[1:2])
 else
@@ -68,5 +61,3 @@ end
 @test call_sum(x, y) == x + y
 LLVM.dispose(jit)
 LLVM.dispose(tm)
-
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,12 +41,5 @@ runtests(LLVM; worker_init_expr, nworkers=min(Sys.CPU_THREADS,4), nworker_thread
         LLVM.has_oldpm() || return false
     end
 
-    if ti.name == "orc"
-        if LLVM.version() >= v"17" && Sys.islinux()
-            # maleadt/LLVM.jl#405
-            return false
-        end
-    end
-
     true
 end


### PR DESCRIPTION
Looks like this got fixed on LLVM 18.

Closes https://github.com/maleadt/LLVM.jl/issues/405