### PR TITLE
Unexport 'parent'.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LLVM"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "9.1.0"
+version = "9.1.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -1,5 +1,4 @@
-export Instruction, remove!, erase!, parent,
-       opcode
+export Instruction, remove!, erase!, opcode
 
 """
     Instruction


### PR DESCRIPTION
Wasn't exported before; clashes with `Base.parent`. Maybe we should just re-use the latter, but let's do the quick fix for now.