### PR TITLE
Disable instcombine fixpoint verification by default.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LLVM"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "9.3.0"
+version = "9.3.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/newpm.jl
+++ b/src/newpm.jl
@@ -566,7 +566,17 @@ end
 @function_pass "gvn-sink" GVNSinkPass
 @function_pass "helloworld" HelloWorldPass
 @function_pass "infer-address-spaces" InferAddressSpacesPass
-@function_pass "instcombine" InstCombinePass
+@function_pass "instcombine" InstCombinePass false
+function InstCombinePass(; kwargs...)
+    kwargs = Dict{Symbol, Any}(kwargs)
+    if version() >= v"18"
+        # XXX: LLVM "helpfully" enables fixpoint verification by default when using the C API
+        #      https://github.com/llvm/llvm-project/blob/3c3fb357a0ed4dbf640bdb6c61db2a430f7eb298/llvm/lib/Passes/PassBuilder.cpp#L1034-L1036
+        #      https://github.com/llvm/llvm-project/issues/92648
+        kwargs[:verify_fixpoint] = get(kwargs, :verify_fixpoint, false)
+    end
+    "instcombine" * kwargs_to_params(kwargs)
+end
 @function_pass "instcount" InstCountPass
 @function_pass "instsimplify" InstSimplifyPass
 @function_pass "invalidate<all>" InvalidateAllAnalysesPass


### PR DESCRIPTION
I missed in https://github.com/JuliaLLVM/LLVM.jl/pull/504 that this option is only enabled when using the C API, which is stupid. So it's definitely fine to toggle the setting by default.