### PR TITLE
Fix reference to `dispose` in `@dispose` macro

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -88,7 +88,7 @@ macro dispose(ex...)
     for res in reverse(resources)
         Meta.isexpr(res, :(=)) ||
             error("Resource arguments to LLVM.@dispose should be assignments")
-        push!(cleanup.args, :(LLVM.dispose($(res.args[1]))))
+        push!(cleanup.args, :($dispose($(res.args[1]))))
     end
 
     ex = quote


### PR DESCRIPTION
I'm refactoring the MLIR bindings in Reactant.jl (which will be backported to MLIR.jl) to be more like the LLVM.jl API design.

In this process of API convergence, we are reusing `dispose`, `activate`, `deactivate`, ... and the `@dispose` macro. Unfortunately, the macro crashes when it's called in a module where LLVM.jl has not been explicitly imported.

This PR fixes the reference to the `LLVM.dispose` method in `@dispose`.