### PR TITLE
Reject non-power-of-2 alignment in pointerref/pointerset

### DIFF
--- a/src/interop/pointer.jl
+++ b/src/interop/pointer.jl
@@ -8,6 +8,7 @@ using Core: LLVMPtr
 
 @inline @generated function pointerref(ptr::LLVMPtr{T,A}, i::I, ::Val{align}) where {T,A,I,align}
     sizeof(T) == 0 && return T.instance
+    ispow2(align) || return :(error("pointerref: alignment must be a power of 2, got $($align)"))
     @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T)
 
@@ -45,6 +46,7 @@ end
 
 @inline @generated function pointerset(ptr::LLVMPtr{T,A}, x::T, i::I, ::Val{align}) where {T,A,I,align}
     sizeof(T) == 0 && return
+    ispow2(align) || return :(error("pointerset: alignment must be a power of 2, got $($align)"))
     @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T)
 

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -315,6 +315,10 @@ end
     else
         @test contains(ir, r"load i64, ptr %.+?, align 4")
     end
+
+    # alignment must be a power of 2 (LLVM requirement)
+    @test_throws "power of 2" unsafe_load(ptr, 1, Val(3))
+    @test_throws "power of 2" unsafe_store!(ptr, Int64(0), 1, Val(6))
 end
 
 @testset "reinterpret with addrspacecast" begin


### PR DESCRIPTION
LLVM requires alignment on load/store instructions to be a power of 2 (enforced by the Align class constructor). Passing non-power-of-2 values produces invalid IR that gets silently miscompiled, e.g. causing misaligned vectorized loads that crash on GPU.

x-ref https://github.com/JuliaGPU/CUDA.jl/issues/2963