### PR TITLE
Make it possible to run NewPM pipeline with a custom TTI

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -70,7 +70,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           path-type: inherit
-          install: mingw-w64-x86_64-gcc
+          install: make mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake
         if: runner.os == 'Windows'
 
       - name: Build libLLVMExtra

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -18,6 +18,7 @@ jobs:
   binary_test:
     name: Julia ${{ matrix.version }} ${{ matrix.llvm_args }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.11'
+          version: '1.12'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -268,9 +268,9 @@ LLVMErrorRef LLVMRunJuliaPassesOnFunction(LLVMValueRef F, const char *Passes,
 // the pass builder. Pass `NULL` to revert to the default TTI (derived from
 // the `TargetMachine`, if any).
 //
-// Callback fields come in `(fnptr, userdata)` pairs. `userdata` is threaded
-// back to the callback on each invocation; the caller must keep the pointee
-// alive for the duration of each `LLVMRunJuliaPasses` call.
+// A single `UserData` pointer is threaded back to every callback; the caller
+// must keep the pointee alive for the duration of each `LLVMRunJuliaPasses`
+// call.
 
 // Callback signatures.
 
@@ -316,7 +316,7 @@ typedef LLVMBool (*LLVMTTICollectFlatAddressOperandsFn)(
 // POD options struct. "Unset" sentinels:
 //  - unsigned fields: ~0u
 //  - int32_t   tri-state bool fields: -1 (0 = false, 1 = true)
-//  - callback fields: NULL (the paired UserData is then ignored)
+//  - callback fields: NULL
 typedef struct {
   // The address space LLVM should treat as "flat" / generic. Required for
   // InferAddressSpacesPass and for folding addrspacecasts.
@@ -331,25 +331,18 @@ typedef struct {
   int32_t IsSingleThreaded;
 
   LLVMTTIASPairPredicateFn IsNoopAddrSpaceCast;
-  void *IsNoopAddrSpaceCastUD;
   LLVMTTIASPairPredicateFn IsValidAddrSpaceCast;
-  void *IsValidAddrSpaceCastUD;
   LLVMTTIASPairPredicateFn AddrSpacesMayAlias;
-  void *AddrSpacesMayAliasUD;
   LLVMTTIASPredicateFn CanHaveGlobalInitializerInAS;
-  void *CanHaveGlobalInitializerInASUD;
   LLVMTTIValuePredicateFn IsSourceOfDivergence;
-  void *IsSourceOfDivergenceUD;
   LLVMTTIValuePredicateFn IsAlwaysUniform;
-  void *IsAlwaysUniformUD;
   LLVMTTIGetAssumedAddressSpaceFn GetAssumedAddressSpace;
-  void *GetAssumedAddressSpaceUD;
   LLVMTTIGetPredicatedAddressSpaceFn GetPredicatedAddressSpace;
-  void *GetPredicatedAddressSpaceUD;
   LLVMTTIRewriteIntrinsicFn RewriteIntrinsicWithAS;
-  void *RewriteIntrinsicWithASUD;
   LLVMTTICollectFlatAddressOperandsFn CollectFlatAddressOperands;
-  void *CollectFlatAddressOperandsUD;
+
+  // Threaded back to every callback as its last argument.
+  void *UserData;
 } LLVMTTIOptions;
 
 // Attach a custom TTI to the pass builder. Copies `*Options` into internal

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -263,14 +263,12 @@ LLVMErrorRef LLVMRunJuliaPassesOnFunction(LLVMValueRef F, const char *Passes,
 // divergence). That disables TTI-sensitive passes like InferAddressSpaces and
 // UniformityAnalysis.
 //
-// Populate an `LLVMTTIOptions` struct and call
-// `LLVMPassBuilderExtensionsSetTTI` to attach a minimal, data-driven TTI to
-// the pass builder. Pass `NULL` to revert to the default TTI (derived from
-// the `TargetMachine`, if any).
-//
-// A single `UserData` pointer is threaded back to every callback; the caller
-// must keep the pointee alive for the duration of each `LLVMRunJuliaPasses`
-// call.
+// Create an options handle with `LLVMCreateTTIOptions`, populate it through
+// the `LLVMTTIOptionsSet*` setters, and attach it with
+// `LLVMPassBuilderExtensionsSetTTI`. Unset fields fall back to the
+// `TargetTransformInfoImplBase` behavior. Each callback is paired with its
+// own `UserData` pointer (LLVM C-API convention); the caller must keep any
+// pointee alive for the duration of each `LLVMRunJuliaPasses` call.
 
 // Callback signatures.
 
@@ -313,43 +311,56 @@ typedef LLVMBool (*LLVMTTICollectFlatAddressOperandsFn)(
     unsigned IID, int *OutOps, unsigned MaxCount, unsigned *OutCount,
     void *UserData);
 
-// POD options struct. "Unset" sentinels:
-//  - unsigned fields: ~0u
-//  - int32_t   tri-state bool fields: -1 (0 = false, 1 = true)
-//  - callback fields: NULL
-typedef struct {
-  // The address space LLVM should treat as "flat" / generic. Required for
-  // InferAddressSpacesPass and for folding addrspacecasts.
-  unsigned FlatAddressSpace;
+// Opaque options handle; allocate with LLVMCreateTTIOptions, free with
+// LLVMDisposeTTIOptions.
+typedef struct LLVMOpaqueTTIOptions *LLVMTTIOptionsRef;
 
-  // Declare that this target can produce divergent control flow. Enables
-  // divergence-aware variants in SimplifyCFG, the loop passes, etc.
-  int32_t HasBranchDivergence;
+LLVMTTIOptionsRef LLVMCreateTTIOptions(void);
+void LLVMDisposeTTIOptions(LLVMTTIOptionsRef Options);
 
-  // Declare that the target is single-threaded. A few passes use this to skip
-  // transformations that only matter in the presence of concurrent execution.
-  int32_t IsSingleThreaded;
+// Field setters. Unset fields fall back to TargetTransformInfoImplBase
+// behavior. Each callback setter takes a `(Callback, UserData)` pair; the
+// user data is threaded back to that callback on every invocation.
+void LLVMTTIOptionsSetFlatAddressSpace(LLVMTTIOptionsRef Options, unsigned AS);
+void LLVMTTIOptionsSetHasBranchDivergence(LLVMTTIOptionsRef Options,
+                                          LLVMBool Value);
+void LLVMTTIOptionsSetIsSingleThreaded(LLVMTTIOptionsRef Options,
+                                       LLVMBool Value);
+void LLVMTTIOptionsSetIsNoopAddrSpaceCast(LLVMTTIOptionsRef Options,
+                                          LLVMTTIASPairPredicateFn Callback,
+                                          void *UserData);
+void LLVMTTIOptionsSetIsValidAddrSpaceCast(LLVMTTIOptionsRef Options,
+                                           LLVMTTIASPairPredicateFn Callback,
+                                           void *UserData);
+void LLVMTTIOptionsSetAddrSpacesMayAlias(LLVMTTIOptionsRef Options,
+                                         LLVMTTIASPairPredicateFn Callback,
+                                         void *UserData);
+void LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(
+    LLVMTTIOptionsRef Options, LLVMTTIASPredicateFn Callback, void *UserData);
+void LLVMTTIOptionsSetIsSourceOfDivergence(LLVMTTIOptionsRef Options,
+                                           LLVMTTIValuePredicateFn Callback,
+                                           void *UserData);
+void LLVMTTIOptionsSetIsAlwaysUniform(LLVMTTIOptionsRef Options,
+                                      LLVMTTIValuePredicateFn Callback,
+                                      void *UserData);
+void LLVMTTIOptionsSetGetAssumedAddressSpace(
+    LLVMTTIOptionsRef Options, LLVMTTIGetAssumedAddressSpaceFn Callback,
+    void *UserData);
+void LLVMTTIOptionsSetGetPredicatedAddressSpace(
+    LLVMTTIOptionsRef Options, LLVMTTIGetPredicatedAddressSpaceFn Callback,
+    void *UserData);
+void LLVMTTIOptionsSetRewriteIntrinsicWithAS(LLVMTTIOptionsRef Options,
+                                             LLVMTTIRewriteIntrinsicFn Callback,
+                                             void *UserData);
+void LLVMTTIOptionsSetCollectFlatAddressOperands(
+    LLVMTTIOptionsRef Options, LLVMTTICollectFlatAddressOperandsFn Callback,
+    void *UserData);
 
-  LLVMTTIASPairPredicateFn IsNoopAddrSpaceCast;
-  LLVMTTIASPairPredicateFn IsValidAddrSpaceCast;
-  LLVMTTIASPairPredicateFn AddrSpacesMayAlias;
-  LLVMTTIASPredicateFn CanHaveGlobalInitializerInAS;
-  LLVMTTIValuePredicateFn IsSourceOfDivergence;
-  LLVMTTIValuePredicateFn IsAlwaysUniform;
-  LLVMTTIGetAssumedAddressSpaceFn GetAssumedAddressSpace;
-  LLVMTTIGetPredicatedAddressSpaceFn GetPredicatedAddressSpace;
-  LLVMTTIRewriteIntrinsicFn RewriteIntrinsicWithAS;
-  LLVMTTICollectFlatAddressOperandsFn CollectFlatAddressOperands;
-
-  // Threaded back to every callback as its last argument.
-  void *UserData;
-} LLVMTTIOptions;
-
-// Attach a custom TTI to the pass builder. Copies `*Options` into internal
-// state. Pass `NULL` to revert to the default TTI.
-void LLVMPassBuilderExtensionsSetTTI(
-    LLVMPassBuilderExtensionsRef Extensions,
-    const LLVMTTIOptions *Options);
+// Attach a custom TTI to the pass builder. Copies the options into internal
+// state; the caller retains ownership of the handle. Pass `NULL` to revert
+// to the default TTI.
+void LLVMPassBuilderExtensionsSetTTI(LLVMPassBuilderExtensionsRef Extensions,
+                                     LLVMTTIOptionsRef Options);
 
 // More DataLayout queries
 unsigned LLVMGlobalsAddressSpace(LLVMTargetDataRef TD);

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -255,6 +255,109 @@ LLVMErrorRef LLVMRunJuliaPassesOnFunction(LLVMValueRef F, const char *Passes,
                                           LLVMPassBuilderOptionsRef Options,
                                           LLVMPassBuilderExtensionsRef Extensions);
 
+// Custom TargetTransformInfo
+//
+// Pipelines that don't have a TargetMachine (e.g. out-of-tree backends invoked
+// through a CLI) normally see the baseline `TargetTransformInfoImplBase`, which
+// reports conservative defaults (e.g. no flat address space, no branch
+// divergence). That disables TTI-sensitive passes like InferAddressSpaces and
+// UniformityAnalysis.
+//
+// Populate an `LLVMTTIOptions` struct and call
+// `LLVMPassBuilderExtensionsSetTTI` to attach a minimal, data-driven TTI to
+// the pass builder. Pass `NULL` to revert to the default TTI (derived from
+// the `TargetMachine`, if any).
+//
+// Callback fields come in `(fnptr, userdata)` pairs. `userdata` is threaded
+// back to the callback on each invocation; the caller must keep the pointee
+// alive for the duration of each `LLVMRunJuliaPasses` call.
+
+// Callback signatures.
+
+// Predicate over an (FromAS, ToAS) pair. Used by isNoopAddrSpaceCast,
+// isValidAddrSpaceCast, addrspacesMayAlias.
+typedef LLVMBool (*LLVMTTIASPairPredicateFn)(unsigned FromAS, unsigned ToAS,
+                                             void *UserData);
+
+// Predicate over a single AS. Used by
+// canHaveNonUndefGlobalInitializerInAddressSpace.
+typedef LLVMBool (*LLVMTTIASPredicateFn)(unsigned AS, void *UserData);
+
+// Predicate over a single Value. Used by isSourceOfDivergence, isAlwaysUniform.
+typedef LLVMBool (*LLVMTTIValuePredicateFn)(LLVMValueRef V, void *UserData);
+
+// Returns the inferred AS for a Value, or ~0u if no inference is made.
+typedef unsigned (*LLVMTTIGetAssumedAddressSpaceFn)(LLVMValueRef V,
+                                                    void *UserData);
+
+// Returns the inferred AS for a Value guarded by a predicate. Writes the
+// predicate value to `*OutPredicate` (or leaves it null if none), and returns
+// the AS (or ~0u if no inference is made).
+typedef unsigned (*LLVMTTIGetPredicatedAddressSpaceFn)(
+    LLVMValueRef V, LLVMValueRef *OutPredicate, void *UserData);
+
+// Rewrites an intrinsic call `II` after its operand `OldV` has been replaced
+// by `NewV` (in a different address space). Returns the rewritten Value, or
+// null if no rewrite is needed.
+typedef LLVMValueRef (*LLVMTTIRewriteIntrinsicFn)(LLVMValueRef II,
+                                                  LLVMValueRef OldV,
+                                                  LLVMValueRef NewV,
+                                                  void *UserData);
+
+// Reports which operand indices of an intrinsic call are flat-AS pointer
+// operands. The callback writes up to `MaxCount` indices into `OutOps`, stores
+// the number written in `*OutCount`, and returns true if any operands were
+// reported. If the target needs to report more than `MaxCount` operands
+// (currently 32), the excess is silently truncated.
+typedef LLVMBool (*LLVMTTICollectFlatAddressOperandsFn)(
+    unsigned IID, int *OutOps, unsigned MaxCount, unsigned *OutCount,
+    void *UserData);
+
+// POD options struct. "Unset" sentinels:
+//  - unsigned fields: ~0u
+//  - int32_t   tri-state bool fields: -1 (0 = false, 1 = true)
+//  - callback fields: NULL (the paired UserData is then ignored)
+typedef struct {
+  // The address space LLVM should treat as "flat" / generic. Required for
+  // InferAddressSpacesPass and for folding addrspacecasts.
+  unsigned FlatAddressSpace;
+
+  // Declare that this target can produce divergent control flow. Enables
+  // divergence-aware variants in SimplifyCFG, the loop passes, etc.
+  int32_t HasBranchDivergence;
+
+  // Declare that the target is single-threaded. A few passes use this to skip
+  // transformations that only matter in the presence of concurrent execution.
+  int32_t IsSingleThreaded;
+
+  LLVMTTIASPairPredicateFn IsNoopAddrSpaceCast;
+  void *IsNoopAddrSpaceCastUD;
+  LLVMTTIASPairPredicateFn IsValidAddrSpaceCast;
+  void *IsValidAddrSpaceCastUD;
+  LLVMTTIASPairPredicateFn AddrSpacesMayAlias;
+  void *AddrSpacesMayAliasUD;
+  LLVMTTIASPredicateFn CanHaveGlobalInitializerInAS;
+  void *CanHaveGlobalInitializerInASUD;
+  LLVMTTIValuePredicateFn IsSourceOfDivergence;
+  void *IsSourceOfDivergenceUD;
+  LLVMTTIValuePredicateFn IsAlwaysUniform;
+  void *IsAlwaysUniformUD;
+  LLVMTTIGetAssumedAddressSpaceFn GetAssumedAddressSpace;
+  void *GetAssumedAddressSpaceUD;
+  LLVMTTIGetPredicatedAddressSpaceFn GetPredicatedAddressSpace;
+  void *GetPredicatedAddressSpaceUD;
+  LLVMTTIRewriteIntrinsicFn RewriteIntrinsicWithAS;
+  void *RewriteIntrinsicWithASUD;
+  LLVMTTICollectFlatAddressOperandsFn CollectFlatAddressOperands;
+  void *CollectFlatAddressOperandsUD;
+} LLVMTTIOptions;
+
+// Attach a custom TTI to the pass builder. Copies `*Options` into internal
+// state. Pass `NULL` to revert to the default TTI.
+void LLVMPassBuilderExtensionsSetTTI(
+    LLVMPassBuilderExtensionsRef Extensions,
+    const LLVMTTIOptions *Options);
+
 // More DataLayout queries
 unsigned LLVMGlobalsAddressSpace(LLVMTargetDataRef TD);
 

--- a/deps/LLVMExtra/lib/NewPM.cpp
+++ b/deps/LLVMExtra/lib/NewPM.cpp
@@ -42,6 +42,17 @@ public:
     return BaseT::isNoopAddrSpaceCast(FromAS, ToAS);
   }
 
+  bool canHaveNonUndefGlobalInitializerInAddressSpace(unsigned AS) const {
+    if (Opts.CanHaveGlobalInitializerInAS)
+      return Opts.CanHaveGlobalInitializerInAS(
+                 AS, Opts.CanHaveGlobalInitializerInASUD) != 0;
+    return BaseT::canHaveNonUndefGlobalInitializerInAddressSpace(AS);
+  }
+
+  // `isValidAddrSpaceCast` and `addrspacesMayAlias` were added in LLVM 17.
+  // On earlier versions the pass framework doesn't query them, so we skip
+  // providing the override entirely.
+#if LLVM_VERSION_MAJOR >= 17
   bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
     if (Opts.IsValidAddrSpaceCast)
       return Opts.IsValidAddrSpaceCast(FromAS, ToAS,
@@ -55,23 +66,28 @@ public:
                                      Opts.AddrSpacesMayAliasUD) != 0;
     return BaseT::addrspacesMayAlias(AS0, AS1);
   }
+#endif
 
-  bool canHaveNonUndefGlobalInitializerInAddressSpace(unsigned AS) const {
-    if (Opts.CanHaveGlobalInitializerInAS)
-      return Opts.CanHaveGlobalInitializerInAS(
-                 AS, Opts.CanHaveGlobalInitializerInASUD) != 0;
-    return BaseT::canHaveNonUndefGlobalInitializerInAddressSpace(AS);
-  }
-
+  // `hasBranchDivergence` grew a `Function*` parameter in LLVM 17.
+#if LLVM_VERSION_MAJOR >= 17
   bool hasBranchDivergence(const Function *F = nullptr) const {
     if (Opts.HasBranchDivergence < 0) return BaseT::hasBranchDivergence(F);
     return Opts.HasBranchDivergence != 0;
   }
+#else
+  bool hasBranchDivergence() const {
+    if (Opts.HasBranchDivergence < 0) return BaseT::hasBranchDivergence();
+    return Opts.HasBranchDivergence != 0;
+  }
+#endif
 
+  // `isSingleThreaded` was added to the CRTP base in LLVM 16.
+#if LLVM_VERSION_MAJOR >= 16
   bool isSingleThreaded() const {
     if (Opts.IsSingleThreaded < 0) return BaseT::isSingleThreaded();
     return Opts.IsSingleThreaded != 0;
   }
+#endif
 
   bool isSourceOfDivergence(const Value *V) const {
     if (Opts.IsSourceOfDivergence)

--- a/deps/LLVMExtra/lib/NewPM.cpp
+++ b/deps/LLVMExtra/lib/NewPM.cpp
@@ -13,10 +13,40 @@
 
 using namespace llvm;
 
+// Backing struct for the opaque `LLVMTTIOptionsRef` handle. Fields left at
+// their defaults below cause `CustomTargetTransformInfo` to fall back to the
+// `TargetTransformInfoImplCRTPBase` behavior. Each callback is paired with
+// its own UserData (LLVM C-API convention).
+struct LLVMTTIOptions {
+  unsigned FlatAddressSpace = ~0u;
+  int32_t HasBranchDivergence = -1;
+  int32_t IsSingleThreaded = -1;
+  LLVMTTIASPairPredicateFn IsNoopAddrSpaceCast = nullptr;
+  void *IsNoopAddrSpaceCastUD = nullptr;
+  LLVMTTIASPairPredicateFn IsValidAddrSpaceCast = nullptr;
+  void *IsValidAddrSpaceCastUD = nullptr;
+  LLVMTTIASPairPredicateFn AddrSpacesMayAlias = nullptr;
+  void *AddrSpacesMayAliasUD = nullptr;
+  LLVMTTIASPredicateFn CanHaveGlobalInitializerInAS = nullptr;
+  void *CanHaveGlobalInitializerInASUD = nullptr;
+  LLVMTTIValuePredicateFn IsSourceOfDivergence = nullptr;
+  void *IsSourceOfDivergenceUD = nullptr;
+  LLVMTTIValuePredicateFn IsAlwaysUniform = nullptr;
+  void *IsAlwaysUniformUD = nullptr;
+  LLVMTTIGetAssumedAddressSpaceFn GetAssumedAddressSpace = nullptr;
+  void *GetAssumedAddressSpaceUD = nullptr;
+  LLVMTTIGetPredicatedAddressSpaceFn GetPredicatedAddressSpace = nullptr;
+  void *GetPredicatedAddressSpaceUD = nullptr;
+  LLVMTTIRewriteIntrinsicFn RewriteIntrinsicWithAS = nullptr;
+  void *RewriteIntrinsicWithASUD = nullptr;
+  LLVMTTICollectFlatAddressOperandsFn CollectFlatAddressOperands = nullptr;
+  void *CollectFlatAddressOperandsUD = nullptr;
+};
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(LLVMTTIOptions, LLVMTTIOptionsRef)
+
 // Minimal TargetTransformInfo for pipelines that don't have a TargetMachine.
-// Wraps an `LLVMTTIOptions` POD struct (see LLVMExtra.h) and falls back
-// to the default `TargetTransformInfoImplCRTPBase` behavior for any field
-// left at its sentinel value.
+// Wraps an `LLVMTTIOptions` value and falls back to the default
+// `TargetTransformInfoImplCRTPBase` behavior for any field left unset.
 namespace {
 
 // Fixed-size scratch buffer for CollectFlatAddressOperands. More than enough
@@ -37,13 +67,15 @@ public:
 
   bool isNoopAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
     if (Opts.IsNoopAddrSpaceCast)
-      return Opts.IsNoopAddrSpaceCast(FromAS, ToAS, Opts.UserData) != 0;
+      return Opts.IsNoopAddrSpaceCast(FromAS, ToAS,
+                                      Opts.IsNoopAddrSpaceCastUD) != 0;
     return BaseT::isNoopAddrSpaceCast(FromAS, ToAS);
   }
 
   bool canHaveNonUndefGlobalInitializerInAddressSpace(unsigned AS) const {
     if (Opts.CanHaveGlobalInitializerInAS)
-      return Opts.CanHaveGlobalInitializerInAS(AS, Opts.UserData) != 0;
+      return Opts.CanHaveGlobalInitializerInAS(
+                 AS, Opts.CanHaveGlobalInitializerInASUD) != 0;
     return BaseT::canHaveNonUndefGlobalInitializerInAddressSpace(AS);
   }
 
@@ -53,13 +85,15 @@ public:
 #if LLVM_VERSION_MAJOR >= 17
   bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
     if (Opts.IsValidAddrSpaceCast)
-      return Opts.IsValidAddrSpaceCast(FromAS, ToAS, Opts.UserData) != 0;
+      return Opts.IsValidAddrSpaceCast(FromAS, ToAS,
+                                       Opts.IsValidAddrSpaceCastUD) != 0;
     return BaseT::isValidAddrSpaceCast(FromAS, ToAS);
   }
 
   bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const {
     if (Opts.AddrSpacesMayAlias)
-      return Opts.AddrSpacesMayAlias(AS0, AS1, Opts.UserData) != 0;
+      return Opts.AddrSpacesMayAlias(AS0, AS1,
+                                     Opts.AddrSpacesMayAliasUD) != 0;
     return BaseT::addrspacesMayAlias(AS0, AS1);
   }
 #endif
@@ -87,19 +121,21 @@ public:
 
   bool isSourceOfDivergence(const Value *V) const {
     if (Opts.IsSourceOfDivergence)
-      return Opts.IsSourceOfDivergence(wrap(V), Opts.UserData) != 0;
+      return Opts.IsSourceOfDivergence(wrap(V),
+                                       Opts.IsSourceOfDivergenceUD) != 0;
     return BaseT::isSourceOfDivergence(V);
   }
 
   bool isAlwaysUniform(const Value *V) const {
     if (Opts.IsAlwaysUniform)
-      return Opts.IsAlwaysUniform(wrap(V), Opts.UserData) != 0;
+      return Opts.IsAlwaysUniform(wrap(V), Opts.IsAlwaysUniformUD) != 0;
     return BaseT::isAlwaysUniform(V);
   }
 
   unsigned getAssumedAddrSpace(const Value *V) const {
     if (Opts.GetAssumedAddressSpace)
-      return Opts.GetAssumedAddressSpace(wrap(V), Opts.UserData);
+      return Opts.GetAssumedAddressSpace(wrap(V),
+                                         Opts.GetAssumedAddressSpaceUD);
     return BaseT::getAssumedAddrSpace(V);
   }
 
@@ -107,8 +143,8 @@ public:
   getPredicatedAddrSpace(const Value *V) const {
     if (Opts.GetPredicatedAddressSpace) {
       LLVMValueRef Predicate = nullptr;
-      unsigned AS = Opts.GetPredicatedAddressSpace(wrap(V), &Predicate,
-                                                   Opts.UserData);
+      unsigned AS = Opts.GetPredicatedAddressSpace(
+          wrap(V), &Predicate, Opts.GetPredicatedAddressSpaceUD);
       return {unwrap(Predicate), AS};
     }
     return BaseT::getPredicatedAddrSpace(V);
@@ -119,7 +155,7 @@ public:
     if (Opts.RewriteIntrinsicWithAS) {
       LLVMValueRef Result = Opts.RewriteIntrinsicWithAS(
           wrap(static_cast<Value *>(II)), wrap(OldV), wrap(NewV),
-          Opts.UserData);
+          Opts.RewriteIntrinsicWithASUD);
       return unwrap(Result);
     }
     return BaseT::rewriteIntrinsicWithAddressSpace(II, OldV, NewV);
@@ -132,7 +168,8 @@ public:
       unsigned Count = 0;
       LLVMBool Any = Opts.CollectFlatAddressOperands(
           static_cast<unsigned>(IID), Buf,
-          CollectFlatAddressOperandsBufSize, &Count, Opts.UserData);
+          CollectFlatAddressOperandsBufSize, &Count,
+          Opts.CollectFlatAddressOperandsUD);
       if (!Any)
         return false;
       if (Count > CollectFlatAddressOperandsBufSize)
@@ -288,12 +325,90 @@ void LLVMPassBuilderExtensionsSetAAPipeline(LLVMPassBuilderExtensionsRef Extensi
 
 // Custom TargetTransformInfo
 
-void LLVMPassBuilderExtensionsSetTTI(
-    LLVMPassBuilderExtensionsRef Extensions,
-    const LLVMTTIOptions *Options) {
+LLVMTTIOptionsRef LLVMCreateTTIOptions() {
+  return wrap(new LLVMTTIOptions());
+}
+
+void LLVMDisposeTTIOptions(LLVMTTIOptionsRef Options) {
+  delete unwrap(Options);
+}
+
+void LLVMTTIOptionsSetFlatAddressSpace(LLVMTTIOptionsRef Options, unsigned AS) {
+  unwrap(Options)->FlatAddressSpace = AS;
+}
+void LLVMTTIOptionsSetHasBranchDivergence(LLVMTTIOptionsRef Options,
+                                          LLVMBool Value) {
+  unwrap(Options)->HasBranchDivergence = Value ? 1 : 0;
+}
+void LLVMTTIOptionsSetIsSingleThreaded(LLVMTTIOptionsRef Options,
+                                       LLVMBool Value) {
+  unwrap(Options)->IsSingleThreaded = Value ? 1 : 0;
+}
+void LLVMTTIOptionsSetIsNoopAddrSpaceCast(LLVMTTIOptionsRef Options,
+                                          LLVMTTIASPairPredicateFn Callback,
+                                          void *UserData) {
+  unwrap(Options)->IsNoopAddrSpaceCast = Callback;
+  unwrap(Options)->IsNoopAddrSpaceCastUD = UserData;
+}
+void LLVMTTIOptionsSetIsValidAddrSpaceCast(LLVMTTIOptionsRef Options,
+                                           LLVMTTIASPairPredicateFn Callback,
+                                           void *UserData) {
+  unwrap(Options)->IsValidAddrSpaceCast = Callback;
+  unwrap(Options)->IsValidAddrSpaceCastUD = UserData;
+}
+void LLVMTTIOptionsSetAddrSpacesMayAlias(LLVMTTIOptionsRef Options,
+                                         LLVMTTIASPairPredicateFn Callback,
+                                         void *UserData) {
+  unwrap(Options)->AddrSpacesMayAlias = Callback;
+  unwrap(Options)->AddrSpacesMayAliasUD = UserData;
+}
+void LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(
+    LLVMTTIOptionsRef Options, LLVMTTIASPredicateFn Callback, void *UserData) {
+  unwrap(Options)->CanHaveGlobalInitializerInAS = Callback;
+  unwrap(Options)->CanHaveGlobalInitializerInASUD = UserData;
+}
+void LLVMTTIOptionsSetIsSourceOfDivergence(LLVMTTIOptionsRef Options,
+                                           LLVMTTIValuePredicateFn Callback,
+                                           void *UserData) {
+  unwrap(Options)->IsSourceOfDivergence = Callback;
+  unwrap(Options)->IsSourceOfDivergenceUD = UserData;
+}
+void LLVMTTIOptionsSetIsAlwaysUniform(LLVMTTIOptionsRef Options,
+                                      LLVMTTIValuePredicateFn Callback,
+                                      void *UserData) {
+  unwrap(Options)->IsAlwaysUniform = Callback;
+  unwrap(Options)->IsAlwaysUniformUD = UserData;
+}
+void LLVMTTIOptionsSetGetAssumedAddressSpace(
+    LLVMTTIOptionsRef Options, LLVMTTIGetAssumedAddressSpaceFn Callback,
+    void *UserData) {
+  unwrap(Options)->GetAssumedAddressSpace = Callback;
+  unwrap(Options)->GetAssumedAddressSpaceUD = UserData;
+}
+void LLVMTTIOptionsSetGetPredicatedAddressSpace(
+    LLVMTTIOptionsRef Options, LLVMTTIGetPredicatedAddressSpaceFn Callback,
+    void *UserData) {
+  unwrap(Options)->GetPredicatedAddressSpace = Callback;
+  unwrap(Options)->GetPredicatedAddressSpaceUD = UserData;
+}
+void LLVMTTIOptionsSetRewriteIntrinsicWithAS(LLVMTTIOptionsRef Options,
+                                             LLVMTTIRewriteIntrinsicFn Callback,
+                                             void *UserData) {
+  unwrap(Options)->RewriteIntrinsicWithAS = Callback;
+  unwrap(Options)->RewriteIntrinsicWithASUD = UserData;
+}
+void LLVMTTIOptionsSetCollectFlatAddressOperands(
+    LLVMTTIOptionsRef Options, LLVMTTICollectFlatAddressOperandsFn Callback,
+    void *UserData) {
+  unwrap(Options)->CollectFlatAddressOperands = Callback;
+  unwrap(Options)->CollectFlatAddressOperandsUD = UserData;
+}
+
+void LLVMPassBuilderExtensionsSetTTI(LLVMPassBuilderExtensionsRef Extensions,
+                                     LLVMTTIOptionsRef Options) {
   LLVMPassBuilderExtensions *PassExts = unwrap(Extensions);
   if (Options)
-    PassExts->TTI = *Options;
+    PassExts->TTI = *unwrap(Options);
   else
     PassExts->TTI.reset();
 }

--- a/deps/LLVMExtra/lib/NewPM.cpp
+++ b/deps/LLVMExtra/lib/NewPM.cpp
@@ -37,15 +37,13 @@ public:
 
   bool isNoopAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
     if (Opts.IsNoopAddrSpaceCast)
-      return Opts.IsNoopAddrSpaceCast(FromAS, ToAS,
-                                      Opts.IsNoopAddrSpaceCastUD) != 0;
+      return Opts.IsNoopAddrSpaceCast(FromAS, ToAS, Opts.UserData) != 0;
     return BaseT::isNoopAddrSpaceCast(FromAS, ToAS);
   }
 
   bool canHaveNonUndefGlobalInitializerInAddressSpace(unsigned AS) const {
     if (Opts.CanHaveGlobalInitializerInAS)
-      return Opts.CanHaveGlobalInitializerInAS(
-                 AS, Opts.CanHaveGlobalInitializerInASUD) != 0;
+      return Opts.CanHaveGlobalInitializerInAS(AS, Opts.UserData) != 0;
     return BaseT::canHaveNonUndefGlobalInitializerInAddressSpace(AS);
   }
 
@@ -55,15 +53,13 @@ public:
 #if LLVM_VERSION_MAJOR >= 17
   bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
     if (Opts.IsValidAddrSpaceCast)
-      return Opts.IsValidAddrSpaceCast(FromAS, ToAS,
-                                       Opts.IsValidAddrSpaceCastUD) != 0;
+      return Opts.IsValidAddrSpaceCast(FromAS, ToAS, Opts.UserData) != 0;
     return BaseT::isValidAddrSpaceCast(FromAS, ToAS);
   }
 
   bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const {
     if (Opts.AddrSpacesMayAlias)
-      return Opts.AddrSpacesMayAlias(AS0, AS1,
-                                     Opts.AddrSpacesMayAliasUD) != 0;
+      return Opts.AddrSpacesMayAlias(AS0, AS1, Opts.UserData) != 0;
     return BaseT::addrspacesMayAlias(AS0, AS1);
   }
 #endif
@@ -91,21 +87,19 @@ public:
 
   bool isSourceOfDivergence(const Value *V) const {
     if (Opts.IsSourceOfDivergence)
-      return Opts.IsSourceOfDivergence(
-                 wrap(V), Opts.IsSourceOfDivergenceUD) != 0;
+      return Opts.IsSourceOfDivergence(wrap(V), Opts.UserData) != 0;
     return BaseT::isSourceOfDivergence(V);
   }
 
   bool isAlwaysUniform(const Value *V) const {
     if (Opts.IsAlwaysUniform)
-      return Opts.IsAlwaysUniform(wrap(V), Opts.IsAlwaysUniformUD) != 0;
+      return Opts.IsAlwaysUniform(wrap(V), Opts.UserData) != 0;
     return BaseT::isAlwaysUniform(V);
   }
 
   unsigned getAssumedAddrSpace(const Value *V) const {
     if (Opts.GetAssumedAddressSpace)
-      return Opts.GetAssumedAddressSpace(wrap(V),
-                                         Opts.GetAssumedAddressSpaceUD);
+      return Opts.GetAssumedAddressSpace(wrap(V), Opts.UserData);
     return BaseT::getAssumedAddrSpace(V);
   }
 
@@ -113,8 +107,8 @@ public:
   getPredicatedAddrSpace(const Value *V) const {
     if (Opts.GetPredicatedAddressSpace) {
       LLVMValueRef Predicate = nullptr;
-      unsigned AS = Opts.GetPredicatedAddressSpace(
-          wrap(V), &Predicate, Opts.GetPredicatedAddressSpaceUD);
+      unsigned AS = Opts.GetPredicatedAddressSpace(wrap(V), &Predicate,
+                                                   Opts.UserData);
       return {unwrap(Predicate), AS};
     }
     return BaseT::getPredicatedAddrSpace(V);
@@ -125,7 +119,7 @@ public:
     if (Opts.RewriteIntrinsicWithAS) {
       LLVMValueRef Result = Opts.RewriteIntrinsicWithAS(
           wrap(static_cast<Value *>(II)), wrap(OldV), wrap(NewV),
-          Opts.RewriteIntrinsicWithASUD);
+          Opts.UserData);
       return unwrap(Result);
     }
     return BaseT::rewriteIntrinsicWithAddressSpace(II, OldV, NewV);
@@ -138,8 +132,7 @@ public:
       unsigned Count = 0;
       LLVMBool Any = Opts.CollectFlatAddressOperands(
           static_cast<unsigned>(IID), Buf,
-          CollectFlatAddressOperandsBufSize, &Count,
-          Opts.CollectFlatAddressOperandsUD);
+          CollectFlatAddressOperandsBufSize, &Count, Opts.UserData);
       if (!Any)
         return false;
       if (Count > CollectFlatAddressOperandsBufSize)

--- a/deps/LLVMExtra/lib/NewPM.cpp
+++ b/deps/LLVMExtra/lib/NewPM.cpp
@@ -13,14 +13,14 @@
 
 using namespace llvm;
 
-// Backing struct for the opaque `LLVMTTIOptionsRef` handle. Fields left at
-// their defaults below cause `CustomTargetTransformInfo` to fall back to the
-// `TargetTransformInfoImplCRTPBase` behavior. Each callback is paired with
-// its own UserData (LLVM C-API convention).
+// Backing struct for the opaque `LLVMTTIOptionsRef` handle. Unset scalar
+// fields are `std::nullopt`; unset callbacks are `nullptr`. In both cases
+// `CustomTargetTransformInfo` falls back to `TargetTransformInfoImplCRTPBase`.
+// Each callback is paired with its own UserData (LLVM C-API convention).
 struct LLVMTTIOptions {
-  unsigned FlatAddressSpace = ~0u;
-  int32_t HasBranchDivergence = -1;
-  int32_t IsSingleThreaded = -1;
+  std::optional<unsigned> FlatAddressSpace;
+  std::optional<bool> HasBranchDivergence;
+  std::optional<bool> IsSingleThreaded;
   LLVMTTIASPairPredicateFn IsNoopAddrSpaceCast = nullptr;
   void *IsNoopAddrSpaceCastUD = nullptr;
   LLVMTTIASPairPredicateFn IsValidAddrSpaceCast = nullptr;
@@ -63,7 +63,10 @@ public:
   CustomTargetTransformInfo(const DataLayout &DL, LLVMTTIOptions Opts)
       : BaseT(DL), Opts(Opts) {}
 
-  unsigned getFlatAddressSpace() const { return Opts.FlatAddressSpace; }
+  unsigned getFlatAddressSpace() const {
+    if (Opts.FlatAddressSpace) return *Opts.FlatAddressSpace;
+    return BaseT::getFlatAddressSpace();
+  }
 
   bool isNoopAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
     if (Opts.IsNoopAddrSpaceCast)
@@ -101,21 +104,21 @@ public:
   // `hasBranchDivergence` grew a `Function*` parameter in LLVM 17.
 #if LLVM_VERSION_MAJOR >= 17
   bool hasBranchDivergence(const Function *F = nullptr) const {
-    if (Opts.HasBranchDivergence < 0) return BaseT::hasBranchDivergence(F);
-    return Opts.HasBranchDivergence != 0;
+    if (Opts.HasBranchDivergence) return *Opts.HasBranchDivergence;
+    return BaseT::hasBranchDivergence(F);
   }
 #else
   bool hasBranchDivergence() const {
-    if (Opts.HasBranchDivergence < 0) return BaseT::hasBranchDivergence();
-    return Opts.HasBranchDivergence != 0;
+    if (Opts.HasBranchDivergence) return *Opts.HasBranchDivergence;
+    return BaseT::hasBranchDivergence();
   }
 #endif
 
   // `isSingleThreaded` was added to the CRTP base in LLVM 16.
 #if LLVM_VERSION_MAJOR >= 16
   bool isSingleThreaded() const {
-    if (Opts.IsSingleThreaded < 0) return BaseT::isSingleThreaded();
-    return Opts.IsSingleThreaded != 0;
+    if (Opts.IsSingleThreaded) return *Opts.IsSingleThreaded;
+    return BaseT::isSingleThreaded();
   }
 #endif
 
@@ -338,11 +341,11 @@ void LLVMTTIOptionsSetFlatAddressSpace(LLVMTTIOptionsRef Options, unsigned AS) {
 }
 void LLVMTTIOptionsSetHasBranchDivergence(LLVMTTIOptionsRef Options,
                                           LLVMBool Value) {
-  unwrap(Options)->HasBranchDivergence = Value ? 1 : 0;
+  unwrap(Options)->HasBranchDivergence = (Value != 0);
 }
 void LLVMTTIOptionsSetIsSingleThreaded(LLVMTTIOptionsRef Options,
                                        LLVMBool Value) {
-  unwrap(Options)->IsSingleThreaded = Value ? 1 : 0;
+  unwrap(Options)->IsSingleThreaded = (Value != 0);
 }
 void LLVMTTIOptionsSetIsNoopAddrSpaceCast(LLVMTTIOptionsRef Options,
                                           LLVMTTIASPairPredicateFn Callback,

--- a/deps/LLVMExtra/lib/NewPM.cpp
+++ b/deps/LLVMExtra/lib/NewPM.cpp
@@ -16,7 +16,6 @@ using namespace llvm;
 // Backing struct for the opaque `LLVMTTIOptionsRef` handle. Unset scalar
 // fields are `std::nullopt`; unset callbacks are `nullptr`. In both cases
 // `CustomTargetTransformInfo` falls back to `TargetTransformInfoImplCRTPBase`.
-// Each callback is paired with its own UserData (LLVM C-API convention).
 struct LLVMTTIOptions {
   std::optional<unsigned> FlatAddressSpace;
   std::optional<bool> HasBranchDivergence;
@@ -82,9 +81,6 @@ public:
     return BaseT::canHaveNonUndefGlobalInitializerInAddressSpace(AS);
   }
 
-  // `isValidAddrSpaceCast` and `addrspacesMayAlias` were added in LLVM 17.
-  // On earlier versions the pass framework doesn't query them, so we skip
-  // providing the override entirely.
 #if LLVM_VERSION_MAJOR >= 17
   bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
     if (Opts.IsValidAddrSpaceCast)

--- a/deps/LLVMExtra/lib/NewPM.cpp
+++ b/deps/LLVMExtra/lib/NewPM.cpp
@@ -1,13 +1,143 @@
 #include "LLVMExtra.h"
 
 #include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/Analysis/TargetTransformInfoImpl.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Passes/StandardInstrumentations.h>
 #include <llvm/Support/CBindingWrapping.h>
 
+#include <optional>
+
 using namespace llvm;
+
+// Minimal TargetTransformInfo for pipelines that don't have a TargetMachine.
+// Wraps an `LLVMTTIOptions` POD struct (see LLVMExtra.h) and falls back
+// to the default `TargetTransformInfoImplCRTPBase` behavior for any field
+// left at its sentinel value.
+namespace {
+
+// Fixed-size scratch buffer for CollectFlatAddressOperands. More than enough
+// for any real intrinsic (pointer operand counts are tiny). If a caller
+// produces more, the tail is silently dropped — callbacks know the buffer
+// size in advance and can clamp themselves.
+constexpr unsigned CollectFlatAddressOperandsBufSize = 32;
+
+class CustomTargetTransformInfo final
+    : public TargetTransformInfoImplCRTPBase<CustomTargetTransformInfo> {
+  typedef TargetTransformInfoImplCRTPBase<CustomTargetTransformInfo> BaseT;
+
+public:
+  CustomTargetTransformInfo(const DataLayout &DL, LLVMTTIOptions Opts)
+      : BaseT(DL), Opts(Opts) {}
+
+  unsigned getFlatAddressSpace() const { return Opts.FlatAddressSpace; }
+
+  bool isNoopAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
+    if (Opts.IsNoopAddrSpaceCast)
+      return Opts.IsNoopAddrSpaceCast(FromAS, ToAS,
+                                      Opts.IsNoopAddrSpaceCastUD) != 0;
+    return BaseT::isNoopAddrSpaceCast(FromAS, ToAS);
+  }
+
+  bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const {
+    if (Opts.IsValidAddrSpaceCast)
+      return Opts.IsValidAddrSpaceCast(FromAS, ToAS,
+                                       Opts.IsValidAddrSpaceCastUD) != 0;
+    return BaseT::isValidAddrSpaceCast(FromAS, ToAS);
+  }
+
+  bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const {
+    if (Opts.AddrSpacesMayAlias)
+      return Opts.AddrSpacesMayAlias(AS0, AS1,
+                                     Opts.AddrSpacesMayAliasUD) != 0;
+    return BaseT::addrspacesMayAlias(AS0, AS1);
+  }
+
+  bool canHaveNonUndefGlobalInitializerInAddressSpace(unsigned AS) const {
+    if (Opts.CanHaveGlobalInitializerInAS)
+      return Opts.CanHaveGlobalInitializerInAS(
+                 AS, Opts.CanHaveGlobalInitializerInASUD) != 0;
+    return BaseT::canHaveNonUndefGlobalInitializerInAddressSpace(AS);
+  }
+
+  bool hasBranchDivergence(const Function *F = nullptr) const {
+    if (Opts.HasBranchDivergence < 0) return BaseT::hasBranchDivergence(F);
+    return Opts.HasBranchDivergence != 0;
+  }
+
+  bool isSingleThreaded() const {
+    if (Opts.IsSingleThreaded < 0) return BaseT::isSingleThreaded();
+    return Opts.IsSingleThreaded != 0;
+  }
+
+  bool isSourceOfDivergence(const Value *V) const {
+    if (Opts.IsSourceOfDivergence)
+      return Opts.IsSourceOfDivergence(
+                 wrap(V), Opts.IsSourceOfDivergenceUD) != 0;
+    return BaseT::isSourceOfDivergence(V);
+  }
+
+  bool isAlwaysUniform(const Value *V) const {
+    if (Opts.IsAlwaysUniform)
+      return Opts.IsAlwaysUniform(wrap(V), Opts.IsAlwaysUniformUD) != 0;
+    return BaseT::isAlwaysUniform(V);
+  }
+
+  unsigned getAssumedAddrSpace(const Value *V) const {
+    if (Opts.GetAssumedAddressSpace)
+      return Opts.GetAssumedAddressSpace(wrap(V),
+                                         Opts.GetAssumedAddressSpaceUD);
+    return BaseT::getAssumedAddrSpace(V);
+  }
+
+  std::pair<const Value *, unsigned>
+  getPredicatedAddrSpace(const Value *V) const {
+    if (Opts.GetPredicatedAddressSpace) {
+      LLVMValueRef Predicate = nullptr;
+      unsigned AS = Opts.GetPredicatedAddressSpace(
+          wrap(V), &Predicate, Opts.GetPredicatedAddressSpaceUD);
+      return {unwrap(Predicate), AS};
+    }
+    return BaseT::getPredicatedAddrSpace(V);
+  }
+
+  Value *rewriteIntrinsicWithAddressSpace(IntrinsicInst *II, Value *OldV,
+                                          Value *NewV) const {
+    if (Opts.RewriteIntrinsicWithAS) {
+      LLVMValueRef Result = Opts.RewriteIntrinsicWithAS(
+          wrap(static_cast<Value *>(II)), wrap(OldV), wrap(NewV),
+          Opts.RewriteIntrinsicWithASUD);
+      return unwrap(Result);
+    }
+    return BaseT::rewriteIntrinsicWithAddressSpace(II, OldV, NewV);
+  }
+
+  bool collectFlatAddressOperands(SmallVectorImpl<int> &OpIndexes,
+                                  Intrinsic::ID IID) const {
+    if (Opts.CollectFlatAddressOperands) {
+      int Buf[CollectFlatAddressOperandsBufSize];
+      unsigned Count = 0;
+      LLVMBool Any = Opts.CollectFlatAddressOperands(
+          static_cast<unsigned>(IID), Buf,
+          CollectFlatAddressOperandsBufSize, &Count,
+          Opts.CollectFlatAddressOperandsUD);
+      if (!Any)
+        return false;
+      if (Count > CollectFlatAddressOperandsBufSize)
+        Count = CollectFlatAddressOperandsBufSize;
+      OpIndexes.append(Buf, Buf + Count);
+      return Count > 0;
+    }
+    return BaseT::collectFlatAddressOperands(OpIndexes, IID);
+  }
+
+private:
+  LLVMTTIOptions Opts;
+};
+} // namespace
 
 static TargetMachine *unwrap(LLVMTargetMachineRef P) {
   return reinterpret_cast<TargetMachine *>(P);
@@ -51,6 +181,10 @@ public:
   // A pipeline describing the alias analysis passes to run.
   const char *AAPipeline;
 #endif
+
+  // If set, passes requesting TargetTransformInfo will see this custom TTI
+  // instead of the default one derived from the (possibly-missing) TargetMachine.
+  std::optional<LLVMTTIOptions> TTI;
 };
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(LLVMPassBuilderExtensions, LLVMPassBuilderExtensionsRef)
 } // namespace llvm
@@ -143,6 +277,18 @@ void LLVMPassBuilderExtensionsSetAAPipeline(LLVMPassBuilderExtensionsRef Extensi
 }
 #endif
 
+// Custom TargetTransformInfo
+
+void LLVMPassBuilderExtensionsSetTTI(
+    LLVMPassBuilderExtensionsRef Extensions,
+    const LLVMTTIOptions *Options) {
+  LLVMPassBuilderExtensions *PassExts = unwrap(Extensions);
+  if (Options)
+    PassExts->TTI = *Options;
+  else
+    PassExts->TTI.reset();
+}
+
 
 // Vendored API entrypoint
 
@@ -170,6 +316,19 @@ static LLVMErrorRef runJuliaPasses(Module *Mod, Function *Fun, const char *Passe
   FunctionAnalysisManager FAM;
   CGSCCAnalysisManager CGAM;
   ModuleAnalysisManager MAM;
+
+  // If a custom TTI was requested, register it with FAM *before*
+  // PB.registerFunctionAnalyses, so our TargetIRAnalysis wins over the default
+  // one (which would otherwise be derived from the TargetMachine, if any).
+  if (PassExts->TTI) {
+    auto Opts = *PassExts->TTI;
+    FAM.registerPass([Opts] {
+      return TargetIRAnalysis([Opts](const Function &F) {
+        return TargetTransformInfo(
+            CustomTargetTransformInfo(F.getParent()->getDataLayout(), Opts));
+      });
+    });
+  }
   const char *AAPipeline =
 #if LLVM_VERSION_MAJOR >= 20
     PassOpts->AAPipeline;

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-CMake_jll = "3f4e10e2-61f2-5801-8945-23b9d642d0e6"
 Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 LLVMExtra_jll = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -8,7 +8,10 @@ if haskey(ENV, "GITHUB_ACTIONS")
     println("::warning ::Using a locally-built LLVMExtra; A bump of LLVMExtra_jll will be required before releasing LLVM.jl.")
 end
 
-using Pkg, Scratch, Preferences, Libdl, CMake_jll
+using Pkg, Scratch, Preferences, Libdl
+
+cmake_path = Sys.which("cmake")
+cmake_path === nothing && error("cmake not found on PATH; please install it (e.g. `pacman -S mingw-w64-x86_64-cmake` inside msys2 on Windows)")
 
 LLVM = Base.UUID("929cbde3-209d-540e-8aea-75f648917ca0")
 
@@ -46,16 +49,14 @@ end
 LLVM_DIR = joinpath(LLVM.artifact_dir, "lib", "cmake", "llvm")
 
 # build and install
-@info "Building" source_dir scratch_dir build_dir LLVM_DIR
-cmake() do cmake_path
-    config_opts = `-DLLVM_ROOT=$(LLVM_DIR) -DCMAKE_INSTALL_PREFIX=$(scratch_dir)`
-    if Sys.iswindows()
-        # prevent picking up MSVC
-        config_opts = `$config_opts -G "MSYS Makefiles"`
-    end
-    run(`$cmake_path $config_opts -B$(build_dir) -S$(source_dir)`)
-    run(`$cmake_path --build $(build_dir) --target install`)
+@info "Building" source_dir scratch_dir build_dir LLVM_DIR cmake_path
+config_opts = `-DLLVM_ROOT=$(LLVM_DIR) -DCMAKE_INSTALL_PREFIX=$(scratch_dir)`
+if Sys.iswindows()
+    # prevent picking up MSVC
+    config_opts = `$config_opts -G "MSYS Makefiles"`
 end
+run(`$cmake_path $config_opts -B$(build_dir) -S$(source_dir)`)
+run(`$cmake_path --build $(build_dir) --target install`)
 
 # discover built libraries
 built_libs = filter(readdir(joinpath(scratch_dir, "lib"))) do file

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.1"
+julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "0ee821a899049e2419189cebe54163f3555e63ef"
+project_hash = "0527455a66c610cde7dc994e5b098fcf0a61ddf6"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
@@ -26,11 +26,21 @@ version = "1.11.0"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
 
+[[deps.CEnum]]
+git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.5.0"
+
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "bce6804e5e6044c6daab27bb533d1295e4a2e759"
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.6"
+version = "0.7.8"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -38,10 +48,9 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 version = "1.11.0"
 
 [[deps.DocStringExtensions]]
-deps = ["LibGit2"]
-git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.9.3"
+version = "0.9.5"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
@@ -52,29 +61,35 @@ version = "1.7.0"
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "1c6317308b9dc757616f0b5cb379db10494443a7"
+git-tree-sha1 = "27af30de8b5445644e8ffe3bcb0d72049c089cf1"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.6.2+0"
+version = "2.7.3+0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 version = "1.11.0"
 
 [[deps.Git]]
-deps = ["Git_jll"]
-git-tree-sha1 = "04eff47b1354d702c3a85e8ab23d539bb7d5957e"
+deps = ["Git_LFS_jll", "Git_jll", "JLLWrappers", "OpenSSH_jll"]
+git-tree-sha1 = "824a1890086880696fc908fe12a17bcf61738bd8"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
-version = "1.3.1"
+version = "1.5.0"
+
+[[deps.Git_LFS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "bb8471f313ed941f299aa53d32a94ab3bee08844"
+uuid = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
+version = "3.7.0+0"
 
 [[deps.Git_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "ea372033d09e4552a04fd38361cd019f9003f4f4"
+git-tree-sha1 = "0dd4cfb426924210c8f42742751cbde74b27bfa3"
 uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
-version = "2.46.2+0"
+version = "2.54.0+0"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
@@ -89,9 +104,9 @@ version = "1.11.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "be3dc50a92e5a386872a493a10050136d4703f9b"
+git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.6.1"
+version = "1.7.1"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -99,10 +114,38 @@ git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.4"
 
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.LLVM]]
+deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Preferences", "Printf", "Unicode"]
+path = "/Users/tim/Julia/pkg/LLVM"
+uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
+version = "9.4.6"
+
+    [deps.LLVM.extensions]
+    BFloat16sExt = "BFloat16s"
+
+    [deps.LLVM.weakdeps]
+    BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
+
+[[deps.LLVMExtra_jll]]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
+git-tree-sha1 = "8e76807afb59ebb833e9b131ebf1a8c006510f33"
+uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
+version = "0.0.38+0"
+
 [[deps.LazilyInitializedFields]]
-git-tree-sha1 = "8f7f3cabab0fd1800699663533b6d5cb3fc0e612"
+git-tree-sha1 = "0f2da712350b020bc3957f269c9caad516383ee0"
 uuid = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
-version = "1.2.2"
+version = "1.3.0"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -110,24 +153,24 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.6.0+0"
+version = "8.15.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.7.2+0"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -135,29 +178,24 @@ version = "1.11.0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "f9557a255370125b405568f9767d6d195822a175"
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.17.0+0"
+version = "1.18.0+0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 version = "1.11.0"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
 
 [[deps.MarkdownAST]]
 deps = ["AbstractTrees", "Markdown"]
-git-tree-sha1 = "465a70f0fc7d443a00dcdc3267a497397b8a3899"
+git-tree-sha1 = "93c718d892e73931841089cdc0e982d6dd9cc87b"
 uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
-version = "0.1.2"
-
-[[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.6+0"
+version = "0.1.3"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -165,33 +203,38 @@ version = "1.11.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.12.12"
+version = "2025.11.4"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
+
+[[deps.OpenSSH_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+git-tree-sha1 = "57baa4b81a24c2910afbb6d853aa0685e4312bf7"
+uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
+version = "10.3.1+0"
 
 [[deps.OpenSSL_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "7493f61f55a6cce7325f197443aa80d32554ba10"
+deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.15+1"
+version = "3.5.4+0"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.42.0+1"
+version = "10.44.0+1"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
+git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.1"
+version = "2.8.3"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.11.0"
+version = "1.12.1"
 weakdeps = ["REPL"]
 
     [deps.Pkg.extensions]
@@ -199,15 +242,15 @@ weakdeps = ["REPL"]
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.2.1"
+version = "1.3.3"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.3"
+version = "1.5.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -215,7 +258,7 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 version = "1.11.0"
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
 
@@ -278,14 +321,14 @@ version = "1.11.0"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+1"
+version = "1.3.1+2"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.59.0+0"
+version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.7.0+0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 
 [compat]
 Documenter = "1.7"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,7 +48,8 @@ function main()
         doctest = true,
         doctestfilters = [
             r"0x[0-9a-f]+",     # pointer values
-            r"@julia_\w+_\d+"   # function names in generated code
+            r"@julia_\w+_\d+",  # function names in generated code
+            r"(?s)\nStacktrace:.*",  # stack traces (path- and version-dependent)
         ]
     )
 

--- a/docs/src/lib/transforms.md
+++ b/docs/src/lib/transforms.md
@@ -26,6 +26,26 @@ LLVM.NewPMCustomPass
 register!
 ```
 
+## Custom target info
+
+```@docs
+AbstractTargetTransformInfo
+target_transform_info!
+LLVM.flat_address_space
+LLVM.has_branch_divergence
+LLVM.is_single_threaded
+LLVM.is_noop_addr_space_cast
+LLVM.is_valid_addr_space_cast
+LLVM.addrspaces_may_alias
+LLVM.can_have_non_undef_global_initializer_in_address_space
+LLVM.is_source_of_divergence
+LLVM.is_always_uniform
+LLVM.get_assumed_addr_space
+LLVM.get_predicated_addr_space
+LLVM.rewrite_intrinsic_with_address_space
+LLVM.collect_flat_address_operands
+```
+
 ## IR cloning
 
 ```@docs

--- a/docs/src/man/essentials.md
+++ b/docs/src/man/essentials.md
@@ -61,7 +61,7 @@ To create a new LLVM context, use the `Context()` constructor:
 
 ```jldoctest
 julia> ctx = Context()
-LLVM.Context(0x0000600003d18980, typed ptrs)
+LLVM.Context(0x0000600001f95470)
 
 julia> dispose(ctx) # see next section
 ```
@@ -79,7 +79,7 @@ ERROR: No LLVM context is active
 julia> ctx = Context();
 
 julia> context()
-LLVM.Context(0x0000600000ae1470, typed ptrs)
+LLVM.Context(0x0000600001fa07e0)
 ```
 
 Although the context is automatically managed by LLVM.jl, it is still important to keep
@@ -88,7 +88,7 @@ context:
 
 ```jldoctest
 julia> ctx = Context()
-LLVM.Context(0x000060000007c4b0, typed ptrs)
+LLVM.Context(0x0000600001fb8fb0)
 
 julia> dispose(ctx)
 

--- a/docs/src/man/execution.md
+++ b/docs/src/man/execution.md
@@ -104,7 +104,7 @@ when using them. On the Julia side, they are created much like regular contexts:
 
 ```jldoctest
 julia> ts_ctx = ThreadSafeContext()
-ThreadSafeContext(Ptr{LLVM.API.LLVMOrcOpaqueThreadSafeContext} @0x00006000035fb8a0)
+ThreadSafeContext(Ptr{LLVM.API.LLVMOrcOpaqueThreadSafeContext}(0x0000600001fac180))
 
 julia> dispose(ts_ctx)
 ```
@@ -142,7 +142,7 @@ much like a regular module:
 
 ```jldoctest
 julia> ts_mod = ThreadSafeModule("SomeModule")
-ThreadSafeModule(Ptr{LLVM.API.LLVMOrcOpaqueThreadSafeModule} @0x00006000037fb640)
+ThreadSafeModule(Ptr{LLVM.API.LLVMOrcOpaqueThreadSafeModule}(0x0000600001d893a0))
 
 julia> dispose(ts_mod)
 ```

--- a/docs/src/man/functions.md
+++ b/docs/src/man/functions.md
@@ -43,7 +43,7 @@ name and signature will be treated as such:
 julia> mod = LLVM.Module("SomeModule");
 
 julia> f = LLVM.Function(mod, "llvm.trap", LLVM.FunctionType(LLVM.VoidType()))
-; Function Attrs: cold noreturn nounwind
+; Function Attrs: cold noreturn nounwind memory(inaccessiblemem: write)
 declare void @llvm.trap() #0
 
 julia> isintrinsic(f)
@@ -62,7 +62,7 @@ overloaded name is correct:
 julia> mod = LLVM.Module("SomeModule");
 
 julia> intr = LLVM.Intrinsic("llvm.abs")
-Intrinsic(1): overloaded intrinsic
+Intrinsic(5): overloaded intrinsic
 
 julia> isoverloaded(intr)
 true
@@ -108,13 +108,13 @@ Different kinds of attributes are supported:
 
 ```jldoctest
 julia> EnumAttribute("nounwind")
-EnumAttribute 36=0
+EnumAttribute 38=0
 
 julia> StringAttribute("frame-pointer", "none")
 StringAttribute frame-pointer=none
 
 julia> TypeAttribute("byval", LLVM.Int32Type())
-TypeAttribute 70=LLVM.IntegerType(i32)
+TypeAttribute 74=LLVM.IntegerType(i32)
 ```
 
 

--- a/docs/src/man/interop.md
+++ b/docs/src/man/interop.md
@@ -39,7 +39,7 @@ julia> isboxed(String)
 true
 
 julia> convert(LLVMType, String; allow_boxed=true)
-{} addrspace(10)*
+ptr addrspace(10)
 ```
 
 Another useful query is `isghosttype`, which returns whether a type is a ghost type, i.e.,

--- a/docs/src/man/transforms.md
+++ b/docs/src/man/transforms.md
@@ -132,6 +132,60 @@ Hello, World!
 ```
 
 
+## Custom target info
+
+Some analyses and passes consult LLVM's `TargetTransformInfo` (TTI) to decide
+whether they can do anything useful — `InferAddressSpacesPass` wants to know
+the flat address space, `UniformityAnalysis` wants to know which values are
+divergent, and so on.
+
+Most users don't need to think about this. In-tree back-ends (host CPU, NVPTX,
+AMDGPU) carry their own TTI through a `TargetMachine`, and passing that
+machine to `run!(pb, mod, tm)` is enough — the machine provides everything
+these passes need.
+
+The `AbstractTargetTransformInfo` interface is for the cases where that isn't
+enough:
+
+- **Out-of-tree back-ends** whose TTI isn't linked into the `libLLVM` that
+  Julia loads (e.g. Metal). Pipelines targeting them have no `TargetMachine`
+  to derive TTI from, so the baseline TTI takes over and TTI-sensitive passes
+  silently no-op.
+- **Tooling / analysis flows** that run passes without any target at all.
+- **Per-query overrides on top of a real `TargetMachine`**: a custom TTI
+  attached via `target_transform_info!` takes precedence over the
+  machine-derived one, useful for forcing a particular knob while leaving
+  everything else alone.
+
+Subtype `AbstractTargetTransformInfo` and override only the queries you care
+about; every other query falls back to a default matching LLVM's
+`TargetTransformInfoImplBase`. Attach the instance to a `NewPMPassBuilder`
+with `target_transform_info!`:
+
+```julia
+using LLVM
+
+struct MyTTI <: AbstractTargetTransformInfo end
+LLVM.flat_address_space(::MyTTI) = UInt(0)
+LLVM.is_noop_addr_space_cast(::MyTTI, from::Unsigned, to::Unsigned) =
+    from == 0 || to == 0
+
+@dispose pb=NewPMPassBuilder() begin
+    target_transform_info!(pb, MyTTI())
+    add!(pb, NewPMFunctionPassManager()) do fpm
+        add!(fpm, InferAddressSpacesPass())
+    end
+    run!(pb, mod)
+end
+```
+
+Pass `nothing` to `target_transform_info!` to revert to LLVM's native TTI
+(the `TargetMachine`-derived one if you supply a machine to `run!`, otherwise
+the conservative baseline).
+
+See the API reference for the full list of overridable queries.
+
+
 ## IR cloning
 
 Somewhat distinct from IR passes, it is also possible to clone bits of the IR. This can be

--- a/docs/src/man/types.md
+++ b/docs/src/man/types.md
@@ -92,13 +92,13 @@ they can be opaque or have an element type that can be queried using the `eltype
 
 ```jldoctest
 julia> supports_typed_pointers()
-true
+false
 
 julia> ty = LLVM.PointerType(LLVM.Int1Type())
-i1*
+ptr
 
 julia> eltype(ty)
-i1
+ERROR: Taking the type of an opaque pointer is illegal
 ```
 
 ```julia-repl
@@ -117,7 +117,7 @@ using the `addrspace` function:
 
 ```jldoctest
 julia> ty = LLVM.PointerType(LLVM.Int1Type(), 1)
-i1 addrspace(1)*
+ptr addrspace(1)
 
 julia> addrspace(ty)
 1

--- a/docs/src/man/values.md
+++ b/docs/src/man/values.md
@@ -59,7 +59,7 @@ that take a single type as argument:
 
 ```jldoctest
 julia> PointerNull(LLVM.PointerType(LLVM.Int1Type()))
-i1* null
+ptr null
 
 julia> UndefValue(LLVM.Int1Type())
 i1 undef
@@ -167,7 +167,7 @@ julia> const_neg(ConstantInt(1))
 i64 -1
 
 julia> const_inttoptr(ConstantInt(42), LLVM.PointerType(LLVM.Int1Type()))
-i1* inttoptr (i64 42 to i1*)
+ptr inttoptr (i64 42 to ptr)
 ```
 
 For the exact list of supported constant expressions, refer to the LLVM documentation.
@@ -183,7 +183,7 @@ a boolean indicating whether the assembly has side effects:
 
 ```jldoctest
 julia> InlineAsm(LLVM.FunctionType(LLVM.VoidType()), "nop", "", false)
-void ()* asm "nop", ""
+ptr asm "nop", ""
 ```
 
 For more details on inline assembly, particularly the format of the constraints string,
@@ -239,7 +239,7 @@ julia> c2 = const_inttoptr(c1, LLVM.PointerType(LLVM.Int1Type()));
 julia> use = only(uses(c1));
 
 julia> user(use)
-i1* inttoptr (i64 42 to i1*)
+ptr inttoptr (i64 42 to ptr)
 
 julia> value(use)
 i64 42

--- a/lib/15/libLLVM.jl
+++ b/lib/15/libLLVM.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const IS_LIBC_MUSL = occursin("musl", Base.MACHINE)
 
@@ -840,11 +840,11 @@ end
 end
 
 """
-    ##Ctag#230
+    ##Ctag#277
 
 Attribute index are either LLVMAttributeReturnIndex, LLVMAttributeFunctionIndex or a parameter number from 1 to N.
 """
-@cenum var"##Ctag#230"::Int32 begin
+@cenum var"##Ctag#277"::Int32 begin
     LLVMAttributeReturnIndex = 0
     LLVMAttributeFunctionIndex = -1
 end
@@ -3350,6 +3350,14 @@ function LLVMGetAggregateElement(C, Idx)
     ccall((:LLVMGetAggregateElement, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, Idx)
 end
 
+"""
+    LLVMGetElementAsConstant(C, idx)
+
+Get an element at specified index as a constant.
+
+# See also
+ConstantDataSequential::getElementAsConstant()
+"""
 function LLVMGetElementAsConstant(C, idx)
     ccall((:LLVMGetElementAsConstant, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, idx)
 end
@@ -3886,6 +3894,18 @@ function LLVMSetExternallyInitialized(GlobalVar, IsExtInit)
     ccall((:LLVMSetExternallyInitialized, libllvm), Cvoid, (LLVMValueRef, LLVMBool), GlobalVar, IsExtInit)
 end
 
+"""
+    LLVMAddAlias(M, Ty, Aliasee, Name)
+
+` LLVMCoreValueConstantGlobalAlias Global Aliases`
+
+This group contains function that operate on global alias values.
+
+@{
+
+# See also
+llvm::GlobalAlias
+"""
 function LLVMAddAlias(M, Ty, Aliasee, Name)
     ccall((:LLVMAddAlias, libllvm), LLVMValueRef, (LLVMModuleRef, LLVMTypeRef, LLVMValueRef, Cstring), M, Ty, Aliasee, Name)
 end
@@ -6534,11 +6554,11 @@ The amount of debug information to emit.
 end
 
 """
-    ##Ctag#231
+    ##Ctag#278
 
 The kind of metadata nodes.
 """
-@cenum var"##Ctag#231"::UInt32 begin
+@cenum var"##Ctag#278"::UInt32 begin
     LLVMMDStringMetadataKind = 0
     LLVMConstantAsMetadataMetadataKind = 1
     LLVMLocalAsMetadataMetadataKind = 2

--- a/lib/15/libLLVM_extra.jl
+++ b/lib/15/libLLVM_extra.jl
@@ -1,4 +1,9 @@
-using CEnum
+using CEnum: CEnum, @cenum
+
+# no prototype is found for this function at LLVMExtra.h:16:6, please use with caution
+function dummy()
+    ccall((:dummy, libLLVMExtra), Cvoid, ())
+end
 
 function LLVMExtraInitializeNativeTarget()
     ccall((:LLVMExtraInitializeNativeTarget, libLLVMExtra), LLVMBool, ())
@@ -399,6 +404,57 @@ end
 
 function LLVMRunJuliaPassesOnFunction(F, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPassesOnFunction, libLLVMExtra), LLVMErrorRef, (LLVMValueRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), F, Passes, TM, Options, Extensions)
+end
+
+# typedef LLVMBool ( * LLVMTTIASPairPredicateFn ) ( unsigned FromAS , unsigned ToAS , void * UserData )
+const LLVMTTIASPairPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIASPredicateFn ) ( unsigned AS , void * UserData )
+const LLVMTTIASPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIValuePredicateFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIValuePredicateFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetAssumedAddressSpaceFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIGetAssumedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetPredicatedAddressSpaceFn ) ( LLVMValueRef V , LLVMValueRef * OutPredicate , void * UserData )
+const LLVMTTIGetPredicatedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef LLVMValueRef ( * LLVMTTIRewriteIntrinsicFn ) ( LLVMValueRef II , LLVMValueRef OldV , LLVMValueRef NewV , void * UserData )
+const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
+const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
+
+struct LLVMTTIOptions
+    FlatAddressSpace::Cuint
+    HasBranchDivergence::Int32
+    IsSingleThreaded::Int32
+    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
+    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsValidAddrSpaceCastUD::Ptr{Cvoid}
+    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
+    AddrSpacesMayAliasUD::Ptr{Cvoid}
+    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
+    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
+    IsSourceOfDivergence::LLVMTTIValuePredicateFn
+    IsSourceOfDivergenceUD::Ptr{Cvoid}
+    IsAlwaysUniform::LLVMTTIValuePredicateFn
+    IsAlwaysUniformUD::Ptr{Cvoid}
+    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
+    GetAssumedAddressSpaceUD::Ptr{Cvoid}
+    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
+    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
+    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
+    RewriteIntrinsicWithASUD::Ptr{Cvoid}
+    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
+    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+end
+
+function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/15/libLLVM_extra.jl
+++ b/lib/15/libLLVM_extra.jl
@@ -427,25 +427,72 @@ const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
 # typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
 const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
 
-struct LLVMTTIOptions
-    FlatAddressSpace::Cuint
-    HasBranchDivergence::Int32
-    IsSingleThreaded::Int32
-    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsAlwaysUniform::LLVMTTIValuePredicateFn
-    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    UserData::Ptr{Cvoid}
+mutable struct LLVMOpaqueTTIOptions end
+
+const LLVMTTIOptionsRef = Ptr{LLVMOpaqueTTIOptions}
+
+function LLVMCreateTTIOptions()
+    ccall((:LLVMCreateTTIOptions, libLLVMExtra), LLVMTTIOptionsRef, ())
+end
+
+function LLVMDisposeTTIOptions(Options)
+    ccall((:LLVMDisposeTTIOptions, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef,), Options)
+end
+
+function LLVMTTIOptionsSetFlatAddressSpace(Options, AS)
+    ccall((:LLVMTTIOptionsSetFlatAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, Cuint), Options, AS)
+end
+
+function LLVMTTIOptionsSetHasBranchDivergence(Options, Value)
+    ccall((:LLVMTTIOptionsSetHasBranchDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsSingleThreaded(Options, Value)
+    ccall((:LLVMTTIOptionsSetIsSingleThreaded, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsNoopAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsNoopAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsValidAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsValidAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetAddrSpacesMayAlias(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetAddrSpacesMayAlias, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCanHaveGlobalInitializerInAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsSourceOfDivergence(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsSourceOfDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsAlwaysUniform(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsAlwaysUniform, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetAssumedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetAssumedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetAssumedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetPredicatedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetPredicatedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetPredicatedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetRewriteIntrinsicWithAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetRewriteIntrinsicWithAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIRewriteIntrinsicFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCollectFlatAddressOperands(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCollectFlatAddressOperands, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTICollectFlatAddressOperandsFn, Ptr{Cvoid}), Options, Callback, UserData)
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
-    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, LLVMTTIOptionsRef), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/15/libLLVM_extra.jl
+++ b/lib/15/libLLVM_extra.jl
@@ -432,25 +432,16 @@ struct LLVMTTIOptions
     HasBranchDivergence::Int32
     IsSingleThreaded::Int32
     IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
     IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCastUD::Ptr{Cvoid}
     AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAliasUD::Ptr{Cvoid}
     CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
     IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsSourceOfDivergenceUD::Ptr{Cvoid}
     IsAlwaysUniform::LLVMTTIValuePredicateFn
-    IsAlwaysUniformUD::Ptr{Cvoid}
     GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetAssumedAddressSpaceUD::Ptr{Cvoid}
     GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
     RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    RewriteIntrinsicWithASUD::Ptr{Cvoid}
     CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+    UserData::Ptr{Cvoid}
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)

--- a/lib/16/libLLVM.jl
+++ b/lib/16/libLLVM.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const IS_LIBC_MUSL = occursin("musl", Base.MACHINE)
 
@@ -843,11 +843,11 @@ end
 end
 
 """
-    ##Ctag#232
+    ##Ctag#279
 
 Attribute index are either LLVMAttributeReturnIndex, LLVMAttributeFunctionIndex or a parameter number from 1 to N.
 """
-@cenum var"##Ctag#232"::Int32 begin
+@cenum var"##Ctag#279"::Int32 begin
     LLVMAttributeReturnIndex = 0
     LLVMAttributeFunctionIndex = -1
 end
@@ -3373,6 +3373,14 @@ function LLVMGetAggregateElement(C, Idx)
     ccall((:LLVMGetAggregateElement, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, Idx)
 end
 
+"""
+    LLVMGetElementAsConstant(C, idx)
+
+Get an element at specified index as a constant.
+
+# See also
+ConstantDataSequential::getElementAsConstant()
+"""
 function LLVMGetElementAsConstant(C, idx)
     ccall((:LLVMGetElementAsConstant, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, idx)
 end
@@ -6522,11 +6530,11 @@ The amount of debug information to emit.
 end
 
 """
-    ##Ctag#233
+    ##Ctag#280
 
 The kind of metadata nodes.
 """
-@cenum var"##Ctag#233"::UInt32 begin
+@cenum var"##Ctag#280"::UInt32 begin
     LLVMMDStringMetadataKind = 0
     LLVMConstantAsMetadataMetadataKind = 1
     LLVMLocalAsMetadataMetadataKind = 2

--- a/lib/16/libLLVM_extra.jl
+++ b/lib/16/libLLVM_extra.jl
@@ -1,4 +1,9 @@
-using CEnum
+using CEnum: CEnum, @cenum
+
+# no prototype is found for this function at LLVMExtra.h:16:6, please use with caution
+function dummy()
+    ccall((:dummy, libLLVMExtra), Cvoid, ())
+end
 
 function LLVMExtraInitializeNativeTarget()
     ccall((:LLVMExtraInitializeNativeTarget, libLLVMExtra), LLVMBool, ())
@@ -399,6 +404,57 @@ end
 
 function LLVMRunJuliaPassesOnFunction(F, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPassesOnFunction, libLLVMExtra), LLVMErrorRef, (LLVMValueRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), F, Passes, TM, Options, Extensions)
+end
+
+# typedef LLVMBool ( * LLVMTTIASPairPredicateFn ) ( unsigned FromAS , unsigned ToAS , void * UserData )
+const LLVMTTIASPairPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIASPredicateFn ) ( unsigned AS , void * UserData )
+const LLVMTTIASPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIValuePredicateFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIValuePredicateFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetAssumedAddressSpaceFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIGetAssumedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetPredicatedAddressSpaceFn ) ( LLVMValueRef V , LLVMValueRef * OutPredicate , void * UserData )
+const LLVMTTIGetPredicatedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef LLVMValueRef ( * LLVMTTIRewriteIntrinsicFn ) ( LLVMValueRef II , LLVMValueRef OldV , LLVMValueRef NewV , void * UserData )
+const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
+const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
+
+struct LLVMTTIOptions
+    FlatAddressSpace::Cuint
+    HasBranchDivergence::Int32
+    IsSingleThreaded::Int32
+    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
+    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsValidAddrSpaceCastUD::Ptr{Cvoid}
+    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
+    AddrSpacesMayAliasUD::Ptr{Cvoid}
+    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
+    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
+    IsSourceOfDivergence::LLVMTTIValuePredicateFn
+    IsSourceOfDivergenceUD::Ptr{Cvoid}
+    IsAlwaysUniform::LLVMTTIValuePredicateFn
+    IsAlwaysUniformUD::Ptr{Cvoid}
+    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
+    GetAssumedAddressSpaceUD::Ptr{Cvoid}
+    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
+    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
+    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
+    RewriteIntrinsicWithASUD::Ptr{Cvoid}
+    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
+    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+end
+
+function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/16/libLLVM_extra.jl
+++ b/lib/16/libLLVM_extra.jl
@@ -427,25 +427,72 @@ const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
 # typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
 const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
 
-struct LLVMTTIOptions
-    FlatAddressSpace::Cuint
-    HasBranchDivergence::Int32
-    IsSingleThreaded::Int32
-    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsAlwaysUniform::LLVMTTIValuePredicateFn
-    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    UserData::Ptr{Cvoid}
+mutable struct LLVMOpaqueTTIOptions end
+
+const LLVMTTIOptionsRef = Ptr{LLVMOpaqueTTIOptions}
+
+function LLVMCreateTTIOptions()
+    ccall((:LLVMCreateTTIOptions, libLLVMExtra), LLVMTTIOptionsRef, ())
+end
+
+function LLVMDisposeTTIOptions(Options)
+    ccall((:LLVMDisposeTTIOptions, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef,), Options)
+end
+
+function LLVMTTIOptionsSetFlatAddressSpace(Options, AS)
+    ccall((:LLVMTTIOptionsSetFlatAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, Cuint), Options, AS)
+end
+
+function LLVMTTIOptionsSetHasBranchDivergence(Options, Value)
+    ccall((:LLVMTTIOptionsSetHasBranchDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsSingleThreaded(Options, Value)
+    ccall((:LLVMTTIOptionsSetIsSingleThreaded, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsNoopAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsNoopAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsValidAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsValidAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetAddrSpacesMayAlias(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetAddrSpacesMayAlias, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCanHaveGlobalInitializerInAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsSourceOfDivergence(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsSourceOfDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsAlwaysUniform(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsAlwaysUniform, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetAssumedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetAssumedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetAssumedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetPredicatedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetPredicatedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetPredicatedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetRewriteIntrinsicWithAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetRewriteIntrinsicWithAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIRewriteIntrinsicFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCollectFlatAddressOperands(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCollectFlatAddressOperands, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTICollectFlatAddressOperandsFn, Ptr{Cvoid}), Options, Callback, UserData)
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
-    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, LLVMTTIOptionsRef), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/16/libLLVM_extra.jl
+++ b/lib/16/libLLVM_extra.jl
@@ -432,25 +432,16 @@ struct LLVMTTIOptions
     HasBranchDivergence::Int32
     IsSingleThreaded::Int32
     IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
     IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCastUD::Ptr{Cvoid}
     AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAliasUD::Ptr{Cvoid}
     CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
     IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsSourceOfDivergenceUD::Ptr{Cvoid}
     IsAlwaysUniform::LLVMTTIValuePredicateFn
-    IsAlwaysUniformUD::Ptr{Cvoid}
     GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetAssumedAddressSpaceUD::Ptr{Cvoid}
     GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
     RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    RewriteIntrinsicWithASUD::Ptr{Cvoid}
     CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+    UserData::Ptr{Cvoid}
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)

--- a/lib/17/libLLVM.jl
+++ b/lib/17/libLLVM.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const IS_LIBC_MUSL = occursin("musl", Base.MACHINE)
 
@@ -841,11 +841,11 @@ end
 end
 
 """
-    ##Ctag#234
+    ##Ctag#281
 
 Attribute index are either LLVMAttributeReturnIndex, LLVMAttributeFunctionIndex or a parameter number from 1 to N.
 """
-@cenum var"##Ctag#234"::Int32 begin
+@cenum var"##Ctag#281"::Int32 begin
     LLVMAttributeReturnIndex = 0
     LLVMAttributeFunctionIndex = -1
 end
@@ -3398,6 +3398,14 @@ function LLVMGetAggregateElement(C, Idx)
     ccall((:LLVMGetAggregateElement, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, Idx)
 end
 
+"""
+    LLVMGetElementAsConstant(C, idx)
+
+Get an element at specified index as a constant.
+
+# See also
+ConstantDataSequential::getElementAsConstant()
+"""
 function LLVMGetElementAsConstant(C, idx)
     ccall((:LLVMGetElementAsConstant, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, idx)
 end
@@ -6568,11 +6576,11 @@ The amount of debug information to emit.
 end
 
 """
-    ##Ctag#235
+    ##Ctag#282
 
 The kind of metadata nodes.
 """
-@cenum var"##Ctag#235"::UInt32 begin
+@cenum var"##Ctag#282"::UInt32 begin
     LLVMMDStringMetadataKind = 0
     LLVMConstantAsMetadataMetadataKind = 1
     LLVMLocalAsMetadataMetadataKind = 2

--- a/lib/17/libLLVM_extra.jl
+++ b/lib/17/libLLVM_extra.jl
@@ -1,4 +1,9 @@
-using CEnum
+using CEnum: CEnum, @cenum
+
+# no prototype is found for this function at LLVMExtra.h:16:6, please use with caution
+function dummy()
+    ccall((:dummy, libLLVMExtra), Cvoid, ())
+end
 
 function LLVMExtraInitializeNativeTarget()
     ccall((:LLVMExtraInitializeNativeTarget, libLLVMExtra), LLVMBool, ())
@@ -359,6 +364,57 @@ end
 
 function LLVMRunJuliaPassesOnFunction(F, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPassesOnFunction, libLLVMExtra), LLVMErrorRef, (LLVMValueRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), F, Passes, TM, Options, Extensions)
+end
+
+# typedef LLVMBool ( * LLVMTTIASPairPredicateFn ) ( unsigned FromAS , unsigned ToAS , void * UserData )
+const LLVMTTIASPairPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIASPredicateFn ) ( unsigned AS , void * UserData )
+const LLVMTTIASPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIValuePredicateFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIValuePredicateFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetAssumedAddressSpaceFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIGetAssumedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetPredicatedAddressSpaceFn ) ( LLVMValueRef V , LLVMValueRef * OutPredicate , void * UserData )
+const LLVMTTIGetPredicatedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef LLVMValueRef ( * LLVMTTIRewriteIntrinsicFn ) ( LLVMValueRef II , LLVMValueRef OldV , LLVMValueRef NewV , void * UserData )
+const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
+const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
+
+struct LLVMTTIOptions
+    FlatAddressSpace::Cuint
+    HasBranchDivergence::Int32
+    IsSingleThreaded::Int32
+    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
+    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsValidAddrSpaceCastUD::Ptr{Cvoid}
+    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
+    AddrSpacesMayAliasUD::Ptr{Cvoid}
+    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
+    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
+    IsSourceOfDivergence::LLVMTTIValuePredicateFn
+    IsSourceOfDivergenceUD::Ptr{Cvoid}
+    IsAlwaysUniform::LLVMTTIValuePredicateFn
+    IsAlwaysUniformUD::Ptr{Cvoid}
+    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
+    GetAssumedAddressSpaceUD::Ptr{Cvoid}
+    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
+    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
+    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
+    RewriteIntrinsicWithASUD::Ptr{Cvoid}
+    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
+    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+end
+
+function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/17/libLLVM_extra.jl
+++ b/lib/17/libLLVM_extra.jl
@@ -392,25 +392,16 @@ struct LLVMTTIOptions
     HasBranchDivergence::Int32
     IsSingleThreaded::Int32
     IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
     IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCastUD::Ptr{Cvoid}
     AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAliasUD::Ptr{Cvoid}
     CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
     IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsSourceOfDivergenceUD::Ptr{Cvoid}
     IsAlwaysUniform::LLVMTTIValuePredicateFn
-    IsAlwaysUniformUD::Ptr{Cvoid}
     GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetAssumedAddressSpaceUD::Ptr{Cvoid}
     GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
     RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    RewriteIntrinsicWithASUD::Ptr{Cvoid}
     CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+    UserData::Ptr{Cvoid}
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)

--- a/lib/17/libLLVM_extra.jl
+++ b/lib/17/libLLVM_extra.jl
@@ -387,25 +387,72 @@ const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
 # typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
 const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
 
-struct LLVMTTIOptions
-    FlatAddressSpace::Cuint
-    HasBranchDivergence::Int32
-    IsSingleThreaded::Int32
-    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsAlwaysUniform::LLVMTTIValuePredicateFn
-    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    UserData::Ptr{Cvoid}
+mutable struct LLVMOpaqueTTIOptions end
+
+const LLVMTTIOptionsRef = Ptr{LLVMOpaqueTTIOptions}
+
+function LLVMCreateTTIOptions()
+    ccall((:LLVMCreateTTIOptions, libLLVMExtra), LLVMTTIOptionsRef, ())
+end
+
+function LLVMDisposeTTIOptions(Options)
+    ccall((:LLVMDisposeTTIOptions, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef,), Options)
+end
+
+function LLVMTTIOptionsSetFlatAddressSpace(Options, AS)
+    ccall((:LLVMTTIOptionsSetFlatAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, Cuint), Options, AS)
+end
+
+function LLVMTTIOptionsSetHasBranchDivergence(Options, Value)
+    ccall((:LLVMTTIOptionsSetHasBranchDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsSingleThreaded(Options, Value)
+    ccall((:LLVMTTIOptionsSetIsSingleThreaded, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsNoopAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsNoopAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsValidAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsValidAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetAddrSpacesMayAlias(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetAddrSpacesMayAlias, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCanHaveGlobalInitializerInAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsSourceOfDivergence(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsSourceOfDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsAlwaysUniform(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsAlwaysUniform, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetAssumedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetAssumedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetAssumedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetPredicatedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetPredicatedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetPredicatedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetRewriteIntrinsicWithAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetRewriteIntrinsicWithAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIRewriteIntrinsicFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCollectFlatAddressOperands(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCollectFlatAddressOperands, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTICollectFlatAddressOperandsFn, Ptr{Cvoid}), Options, Callback, UserData)
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
-    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, LLVMTTIOptionsRef), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/18/libLLVM.jl
+++ b/lib/18/libLLVM.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const IS_LIBC_MUSL = occursin("musl", Base.MACHINE)
 
@@ -848,11 +848,11 @@ end
 end
 
 """
-    ##Ctag#236
+    ##Ctag#283
 
 Attribute index are either LLVMAttributeReturnIndex, LLVMAttributeFunctionIndex or a parameter number from 1 to N.
 """
-@cenum var"##Ctag#236"::Int32 begin
+@cenum var"##Ctag#283"::Int32 begin
     LLVMAttributeReturnIndex = 0
     LLVMAttributeFunctionIndex = -1
 end
@@ -876,7 +876,7 @@ end
 
 const LLVMAttributeIndex = Cuint
 
-@cenum var"##Ctag#237"::UInt32 begin
+@cenum var"##Ctag#284"::UInt32 begin
     LLVMFastMathAllowReassoc = 1
     LLVMFastMathNoNaNs = 2
     LLVMFastMathNoInfs = 4
@@ -3507,6 +3507,14 @@ function LLVMGetAggregateElement(C, Idx)
     ccall((:LLVMGetAggregateElement, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, Idx)
 end
 
+"""
+    LLVMGetElementAsConstant(C, idx)
+
+Get an element at specified index as a constant.
+
+# See also
+ConstantDataSequential::getElementAsConstant()
+"""
 function LLVMGetElementAsConstant(C, idx)
     ccall((:LLVMGetElementAsConstant, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, idx)
 end
@@ -6827,11 +6835,11 @@ The amount of debug information to emit.
 end
 
 """
-    ##Ctag#238
+    ##Ctag#285
 
 The kind of metadata nodes.
 """
-@cenum var"##Ctag#238"::UInt32 begin
+@cenum var"##Ctag#285"::UInt32 begin
     LLVMMDStringMetadataKind = 0
     LLVMConstantAsMetadataMetadataKind = 1
     LLVMLocalAsMetadataMetadataKind = 2

--- a/lib/18/libLLVM_extra.jl
+++ b/lib/18/libLLVM_extra.jl
@@ -321,25 +321,72 @@ const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
 # typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
 const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
 
-struct LLVMTTIOptions
-    FlatAddressSpace::Cuint
-    HasBranchDivergence::Int32
-    IsSingleThreaded::Int32
-    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsAlwaysUniform::LLVMTTIValuePredicateFn
-    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    UserData::Ptr{Cvoid}
+mutable struct LLVMOpaqueTTIOptions end
+
+const LLVMTTIOptionsRef = Ptr{LLVMOpaqueTTIOptions}
+
+function LLVMCreateTTIOptions()
+    ccall((:LLVMCreateTTIOptions, libLLVMExtra), LLVMTTIOptionsRef, ())
+end
+
+function LLVMDisposeTTIOptions(Options)
+    ccall((:LLVMDisposeTTIOptions, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef,), Options)
+end
+
+function LLVMTTIOptionsSetFlatAddressSpace(Options, AS)
+    ccall((:LLVMTTIOptionsSetFlatAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, Cuint), Options, AS)
+end
+
+function LLVMTTIOptionsSetHasBranchDivergence(Options, Value)
+    ccall((:LLVMTTIOptionsSetHasBranchDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsSingleThreaded(Options, Value)
+    ccall((:LLVMTTIOptionsSetIsSingleThreaded, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsNoopAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsNoopAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsValidAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsValidAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetAddrSpacesMayAlias(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetAddrSpacesMayAlias, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCanHaveGlobalInitializerInAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsSourceOfDivergence(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsSourceOfDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsAlwaysUniform(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsAlwaysUniform, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetAssumedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetAssumedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetAssumedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetPredicatedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetPredicatedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetPredicatedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetRewriteIntrinsicWithAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetRewriteIntrinsicWithAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIRewriteIntrinsicFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCollectFlatAddressOperands(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCollectFlatAddressOperands, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTICollectFlatAddressOperandsFn, Ptr{Cvoid}), Options, Callback, UserData)
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
-    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, LLVMTTIOptionsRef), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/18/libLLVM_extra.jl
+++ b/lib/18/libLLVM_extra.jl
@@ -1,4 +1,9 @@
-using CEnum
+using CEnum: CEnum, @cenum
+
+# no prototype is found for this function at LLVMExtra.h:16:6, please use with caution
+function dummy()
+    ccall((:dummy, libLLVMExtra), Cvoid, ())
+end
 
 function LLVMExtraInitializeNativeTarget()
     ccall((:LLVMExtraInitializeNativeTarget, libLLVMExtra), LLVMBool, ())
@@ -293,6 +298,57 @@ end
 
 function LLVMRunJuliaPassesOnFunction(F, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPassesOnFunction, libLLVMExtra), LLVMErrorRef, (LLVMValueRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), F, Passes, TM, Options, Extensions)
+end
+
+# typedef LLVMBool ( * LLVMTTIASPairPredicateFn ) ( unsigned FromAS , unsigned ToAS , void * UserData )
+const LLVMTTIASPairPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIASPredicateFn ) ( unsigned AS , void * UserData )
+const LLVMTTIASPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIValuePredicateFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIValuePredicateFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetAssumedAddressSpaceFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIGetAssumedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetPredicatedAddressSpaceFn ) ( LLVMValueRef V , LLVMValueRef * OutPredicate , void * UserData )
+const LLVMTTIGetPredicatedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef LLVMValueRef ( * LLVMTTIRewriteIntrinsicFn ) ( LLVMValueRef II , LLVMValueRef OldV , LLVMValueRef NewV , void * UserData )
+const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
+const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
+
+struct LLVMTTIOptions
+    FlatAddressSpace::Cuint
+    HasBranchDivergence::Int32
+    IsSingleThreaded::Int32
+    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
+    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsValidAddrSpaceCastUD::Ptr{Cvoid}
+    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
+    AddrSpacesMayAliasUD::Ptr{Cvoid}
+    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
+    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
+    IsSourceOfDivergence::LLVMTTIValuePredicateFn
+    IsSourceOfDivergenceUD::Ptr{Cvoid}
+    IsAlwaysUniform::LLVMTTIValuePredicateFn
+    IsAlwaysUniformUD::Ptr{Cvoid}
+    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
+    GetAssumedAddressSpaceUD::Ptr{Cvoid}
+    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
+    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
+    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
+    RewriteIntrinsicWithASUD::Ptr{Cvoid}
+    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
+    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+end
+
+function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/18/libLLVM_extra.jl
+++ b/lib/18/libLLVM_extra.jl
@@ -326,25 +326,16 @@ struct LLVMTTIOptions
     HasBranchDivergence::Int32
     IsSingleThreaded::Int32
     IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
     IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCastUD::Ptr{Cvoid}
     AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAliasUD::Ptr{Cvoid}
     CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
     IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsSourceOfDivergenceUD::Ptr{Cvoid}
     IsAlwaysUniform::LLVMTTIValuePredicateFn
-    IsAlwaysUniformUD::Ptr{Cvoid}
     GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetAssumedAddressSpaceUD::Ptr{Cvoid}
     GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
     RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    RewriteIntrinsicWithASUD::Ptr{Cvoid}
     CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+    UserData::Ptr{Cvoid}
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)

--- a/lib/19/libLLVM.jl
+++ b/lib/19/libLLVM.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const IS_LIBC_MUSL = occursin("musl", Base.MACHINE)
 
@@ -855,11 +855,11 @@ end
 end
 
 """
-    ##Ctag#239
+    ##Ctag#286
 
 Attribute index are either LLVMAttributeReturnIndex, LLVMAttributeFunctionIndex or a parameter number from 1 to N.
 """
-@cenum var"##Ctag#239"::Int32 begin
+@cenum var"##Ctag#286"::Int32 begin
     LLVMAttributeReturnIndex = 0
     LLVMAttributeFunctionIndex = -1
 end
@@ -883,7 +883,7 @@ CallInst::TailCallKind
     LLVMTailCallKindNoTail = 3
 end
 
-@cenum var"##Ctag#240"::UInt32 begin
+@cenum var"##Ctag#287"::UInt32 begin
     LLVMFastMathAllowReassoc = 1
     LLVMFastMathNoNaNs = 2
     LLVMFastMathNoInfs = 4
@@ -902,7 +902,7 @@ See https://llvm.org/docs/LangRef.html#fast-math-flags
 """
 const LLVMFastMathFlags = Cuint
 
-@cenum var"##Ctag#241"::UInt32 begin
+@cenum var"##Ctag#288"::UInt32 begin
     LLVMGEPFlagInBounds = 1
     LLVMGEPFlagNUSW = 2
     LLVMGEPFlagNUW = 4
@@ -3706,6 +3706,14 @@ function LLVMGetAggregateElement(C, Idx)
     ccall((:LLVMGetAggregateElement, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, Idx)
 end
 
+"""
+    LLVMGetElementAsConstant(C, idx)
+
+Get an element at specified index as a constant.
+
+# See also
+ConstantDataSequential::getElementAsConstant()
+"""
 function LLVMGetElementAsConstant(C, idx)
     ccall((:LLVMGetElementAsConstant, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, idx)
 end
@@ -7226,11 +7234,11 @@ The amount of debug information to emit.
 end
 
 """
-    ##Ctag#242
+    ##Ctag#289
 
 The kind of metadata nodes.
 """
-@cenum var"##Ctag#242"::UInt32 begin
+@cenum var"##Ctag#289"::UInt32 begin
     LLVMMDStringMetadataKind = 0
     LLVMConstantAsMetadataMetadataKind = 1
     LLVMLocalAsMetadataMetadataKind = 2

--- a/lib/19/libLLVM_extra.jl
+++ b/lib/19/libLLVM_extra.jl
@@ -321,25 +321,72 @@ const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
 # typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
 const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
 
-struct LLVMTTIOptions
-    FlatAddressSpace::Cuint
-    HasBranchDivergence::Int32
-    IsSingleThreaded::Int32
-    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsAlwaysUniform::LLVMTTIValuePredicateFn
-    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    UserData::Ptr{Cvoid}
+mutable struct LLVMOpaqueTTIOptions end
+
+const LLVMTTIOptionsRef = Ptr{LLVMOpaqueTTIOptions}
+
+function LLVMCreateTTIOptions()
+    ccall((:LLVMCreateTTIOptions, libLLVMExtra), LLVMTTIOptionsRef, ())
+end
+
+function LLVMDisposeTTIOptions(Options)
+    ccall((:LLVMDisposeTTIOptions, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef,), Options)
+end
+
+function LLVMTTIOptionsSetFlatAddressSpace(Options, AS)
+    ccall((:LLVMTTIOptionsSetFlatAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, Cuint), Options, AS)
+end
+
+function LLVMTTIOptionsSetHasBranchDivergence(Options, Value)
+    ccall((:LLVMTTIOptionsSetHasBranchDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsSingleThreaded(Options, Value)
+    ccall((:LLVMTTIOptionsSetIsSingleThreaded, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsNoopAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsNoopAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsValidAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsValidAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetAddrSpacesMayAlias(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetAddrSpacesMayAlias, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCanHaveGlobalInitializerInAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsSourceOfDivergence(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsSourceOfDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsAlwaysUniform(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsAlwaysUniform, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetAssumedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetAssumedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetAssumedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetPredicatedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetPredicatedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetPredicatedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetRewriteIntrinsicWithAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetRewriteIntrinsicWithAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIRewriteIntrinsicFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCollectFlatAddressOperands(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCollectFlatAddressOperands, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTICollectFlatAddressOperandsFn, Ptr{Cvoid}), Options, Callback, UserData)
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
-    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, LLVMTTIOptionsRef), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/19/libLLVM_extra.jl
+++ b/lib/19/libLLVM_extra.jl
@@ -1,4 +1,9 @@
-using CEnum
+using CEnum: CEnum, @cenum
+
+# no prototype is found for this function at LLVMExtra.h:16:6, please use with caution
+function dummy()
+    ccall((:dummy, libLLVMExtra), Cvoid, ())
+end
 
 function LLVMExtraInitializeNativeTarget()
     ccall((:LLVMExtraInitializeNativeTarget, libLLVMExtra), LLVMBool, ())
@@ -293,6 +298,57 @@ end
 
 function LLVMRunJuliaPassesOnFunction(F, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPassesOnFunction, libLLVMExtra), LLVMErrorRef, (LLVMValueRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), F, Passes, TM, Options, Extensions)
+end
+
+# typedef LLVMBool ( * LLVMTTIASPairPredicateFn ) ( unsigned FromAS , unsigned ToAS , void * UserData )
+const LLVMTTIASPairPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIASPredicateFn ) ( unsigned AS , void * UserData )
+const LLVMTTIASPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIValuePredicateFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIValuePredicateFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetAssumedAddressSpaceFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIGetAssumedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetPredicatedAddressSpaceFn ) ( LLVMValueRef V , LLVMValueRef * OutPredicate , void * UserData )
+const LLVMTTIGetPredicatedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef LLVMValueRef ( * LLVMTTIRewriteIntrinsicFn ) ( LLVMValueRef II , LLVMValueRef OldV , LLVMValueRef NewV , void * UserData )
+const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
+const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
+
+struct LLVMTTIOptions
+    FlatAddressSpace::Cuint
+    HasBranchDivergence::Int32
+    IsSingleThreaded::Int32
+    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
+    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsValidAddrSpaceCastUD::Ptr{Cvoid}
+    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
+    AddrSpacesMayAliasUD::Ptr{Cvoid}
+    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
+    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
+    IsSourceOfDivergence::LLVMTTIValuePredicateFn
+    IsSourceOfDivergenceUD::Ptr{Cvoid}
+    IsAlwaysUniform::LLVMTTIValuePredicateFn
+    IsAlwaysUniformUD::Ptr{Cvoid}
+    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
+    GetAssumedAddressSpaceUD::Ptr{Cvoid}
+    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
+    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
+    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
+    RewriteIntrinsicWithASUD::Ptr{Cvoid}
+    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
+    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+end
+
+function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/19/libLLVM_extra.jl
+++ b/lib/19/libLLVM_extra.jl
@@ -326,25 +326,16 @@ struct LLVMTTIOptions
     HasBranchDivergence::Int32
     IsSingleThreaded::Int32
     IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
     IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCastUD::Ptr{Cvoid}
     AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAliasUD::Ptr{Cvoid}
     CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
     IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsSourceOfDivergenceUD::Ptr{Cvoid}
     IsAlwaysUniform::LLVMTTIValuePredicateFn
-    IsAlwaysUniformUD::Ptr{Cvoid}
     GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetAssumedAddressSpaceUD::Ptr{Cvoid}
     GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
     RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    RewriteIntrinsicWithASUD::Ptr{Cvoid}
     CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+    UserData::Ptr{Cvoid}
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)

--- a/lib/20/libLLVM.jl
+++ b/lib/20/libLLVM.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const IS_LIBC_MUSL = occursin("musl", Base.MACHINE)
 
@@ -857,11 +857,11 @@ end
 end
 
 """
-    ##Ctag#243
+    ##Ctag#290
 
 Attribute index are either LLVMAttributeReturnIndex, LLVMAttributeFunctionIndex or a parameter number from 1 to N.
 """
-@cenum var"##Ctag#243"::Int32 begin
+@cenum var"##Ctag#290"::Int32 begin
     LLVMAttributeReturnIndex = 0
     LLVMAttributeFunctionIndex = -1
 end
@@ -885,7 +885,7 @@ CallInst::TailCallKind
     LLVMTailCallKindNoTail = 3
 end
 
-@cenum var"##Ctag#244"::UInt32 begin
+@cenum var"##Ctag#291"::UInt32 begin
     LLVMFastMathAllowReassoc = 1
     LLVMFastMathNoNaNs = 2
     LLVMFastMathNoInfs = 4
@@ -904,7 +904,7 @@ See https://llvm.org/docs/LangRef.html#fast-math-flags
 """
 const LLVMFastMathFlags = Cuint
 
-@cenum var"##Ctag#245"::UInt32 begin
+@cenum var"##Ctag#292"::UInt32 begin
     LLVMGEPFlagInBounds = 1
     LLVMGEPFlagNUSW = 2
     LLVMGEPFlagNUW = 4
@@ -3730,6 +3730,14 @@ function LLVMGetAggregateElement(C, Idx)
     ccall((:LLVMGetAggregateElement, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, Idx)
 end
 
+"""
+    LLVMGetElementAsConstant(C, idx)
+
+Get an element at specified index as a constant.
+
+# See also
+ConstantDataSequential::getElementAsConstant()
+"""
 function LLVMGetElementAsConstant(C, idx)
     ccall((:LLVMGetElementAsConstant, libllvm), LLVMValueRef, (LLVMValueRef, Cuint), C, idx)
 end
@@ -7365,11 +7373,11 @@ The amount of debug information to emit.
 end
 
 """
-    ##Ctag#246
+    ##Ctag#293
 
 The kind of metadata nodes.
 """
-@cenum var"##Ctag#246"::UInt32 begin
+@cenum var"##Ctag#293"::UInt32 begin
     LLVMMDStringMetadataKind = 0
     LLVMConstantAsMetadataMetadataKind = 1
     LLVMLocalAsMetadataMetadataKind = 2

--- a/lib/20/libLLVM_extra.jl
+++ b/lib/20/libLLVM_extra.jl
@@ -278,25 +278,16 @@ struct LLVMTTIOptions
     HasBranchDivergence::Int32
     IsSingleThreaded::Int32
     IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
     IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCastUD::Ptr{Cvoid}
     AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAliasUD::Ptr{Cvoid}
     CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
     IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsSourceOfDivergenceUD::Ptr{Cvoid}
     IsAlwaysUniform::LLVMTTIValuePredicateFn
-    IsAlwaysUniformUD::Ptr{Cvoid}
     GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetAssumedAddressSpaceUD::Ptr{Cvoid}
     GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
     RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    RewriteIntrinsicWithASUD::Ptr{Cvoid}
     CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+    UserData::Ptr{Cvoid}
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)

--- a/lib/20/libLLVM_extra.jl
+++ b/lib/20/libLLVM_extra.jl
@@ -273,25 +273,72 @@ const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
 # typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
 const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
 
-struct LLVMTTIOptions
-    FlatAddressSpace::Cuint
-    HasBranchDivergence::Int32
-    IsSingleThreaded::Int32
-    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
-    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
-    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
-    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
-    IsSourceOfDivergence::LLVMTTIValuePredicateFn
-    IsAlwaysUniform::LLVMTTIValuePredicateFn
-    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
-    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
-    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
-    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
-    UserData::Ptr{Cvoid}
+mutable struct LLVMOpaqueTTIOptions end
+
+const LLVMTTIOptionsRef = Ptr{LLVMOpaqueTTIOptions}
+
+function LLVMCreateTTIOptions()
+    ccall((:LLVMCreateTTIOptions, libLLVMExtra), LLVMTTIOptionsRef, ())
+end
+
+function LLVMDisposeTTIOptions(Options)
+    ccall((:LLVMDisposeTTIOptions, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef,), Options)
+end
+
+function LLVMTTIOptionsSetFlatAddressSpace(Options, AS)
+    ccall((:LLVMTTIOptionsSetFlatAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, Cuint), Options, AS)
+end
+
+function LLVMTTIOptionsSetHasBranchDivergence(Options, Value)
+    ccall((:LLVMTTIOptionsSetHasBranchDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsSingleThreaded(Options, Value)
+    ccall((:LLVMTTIOptionsSetIsSingleThreaded, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMBool), Options, Value)
+end
+
+function LLVMTTIOptionsSetIsNoopAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsNoopAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsValidAddrSpaceCast(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsValidAddrSpaceCast, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetAddrSpacesMayAlias(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetAddrSpacesMayAlias, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPairPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCanHaveGlobalInitializerInAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIASPredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsSourceOfDivergence(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsSourceOfDivergence, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetIsAlwaysUniform(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetIsAlwaysUniform, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIValuePredicateFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetAssumedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetAssumedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetAssumedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetGetPredicatedAddressSpace(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetGetPredicatedAddressSpace, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIGetPredicatedAddressSpaceFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetRewriteIntrinsicWithAS(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetRewriteIntrinsicWithAS, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTIRewriteIntrinsicFn, Ptr{Cvoid}), Options, Callback, UserData)
+end
+
+function LLVMTTIOptionsSetCollectFlatAddressOperands(Options, Callback, UserData)
+    ccall((:LLVMTTIOptionsSetCollectFlatAddressOperands, libLLVMExtra), Cvoid, (LLVMTTIOptionsRef, LLVMTTICollectFlatAddressOperandsFn, Ptr{Cvoid}), Options, Callback, UserData)
 end
 
 function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
-    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, LLVMTTIOptionsRef), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/lib/20/libLLVM_extra.jl
+++ b/lib/20/libLLVM_extra.jl
@@ -1,4 +1,9 @@
-using CEnum
+using CEnum: CEnum, @cenum
+
+# no prototype is found for this function at LLVMExtra.h:16:6, please use with caution
+function dummy()
+    ccall((:dummy, libLLVMExtra), Cvoid, ())
+end
 
 function LLVMExtraInitializeNativeTarget()
     ccall((:LLVMExtraInitializeNativeTarget, libLLVMExtra), LLVMBool, ())
@@ -245,6 +250,57 @@ end
 
 function LLVMRunJuliaPassesOnFunction(F, Passes, TM, Options, Extensions)
     ccall((:LLVMRunJuliaPassesOnFunction, libLLVMExtra), LLVMErrorRef, (LLVMValueRef, Cstring, LLVMTargetMachineRef, LLVMPassBuilderOptionsRef, LLVMPassBuilderExtensionsRef), F, Passes, TM, Options, Extensions)
+end
+
+# typedef LLVMBool ( * LLVMTTIASPairPredicateFn ) ( unsigned FromAS , unsigned ToAS , void * UserData )
+const LLVMTTIASPairPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIASPredicateFn ) ( unsigned AS , void * UserData )
+const LLVMTTIASPredicateFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTIValuePredicateFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIValuePredicateFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetAssumedAddressSpaceFn ) ( LLVMValueRef V , void * UserData )
+const LLVMTTIGetAssumedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef unsigned ( * LLVMTTIGetPredicatedAddressSpaceFn ) ( LLVMValueRef V , LLVMValueRef * OutPredicate , void * UserData )
+const LLVMTTIGetPredicatedAddressSpaceFn = Ptr{Cvoid}
+
+# typedef LLVMValueRef ( * LLVMTTIRewriteIntrinsicFn ) ( LLVMValueRef II , LLVMValueRef OldV , LLVMValueRef NewV , void * UserData )
+const LLVMTTIRewriteIntrinsicFn = Ptr{Cvoid}
+
+# typedef LLVMBool ( * LLVMTTICollectFlatAddressOperandsFn ) ( unsigned IID , int * OutOps , unsigned MaxCount , unsigned * OutCount , void * UserData )
+const LLVMTTICollectFlatAddressOperandsFn = Ptr{Cvoid}
+
+struct LLVMTTIOptions
+    FlatAddressSpace::Cuint
+    HasBranchDivergence::Int32
+    IsSingleThreaded::Int32
+    IsNoopAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsNoopAddrSpaceCastUD::Ptr{Cvoid}
+    IsValidAddrSpaceCast::LLVMTTIASPairPredicateFn
+    IsValidAddrSpaceCastUD::Ptr{Cvoid}
+    AddrSpacesMayAlias::LLVMTTIASPairPredicateFn
+    AddrSpacesMayAliasUD::Ptr{Cvoid}
+    CanHaveGlobalInitializerInAS::LLVMTTIASPredicateFn
+    CanHaveGlobalInitializerInASUD::Ptr{Cvoid}
+    IsSourceOfDivergence::LLVMTTIValuePredicateFn
+    IsSourceOfDivergenceUD::Ptr{Cvoid}
+    IsAlwaysUniform::LLVMTTIValuePredicateFn
+    IsAlwaysUniformUD::Ptr{Cvoid}
+    GetAssumedAddressSpace::LLVMTTIGetAssumedAddressSpaceFn
+    GetAssumedAddressSpaceUD::Ptr{Cvoid}
+    GetPredicatedAddressSpace::LLVMTTIGetPredicatedAddressSpaceFn
+    GetPredicatedAddressSpaceUD::Ptr{Cvoid}
+    RewriteIntrinsicWithAS::LLVMTTIRewriteIntrinsicFn
+    RewriteIntrinsicWithASUD::Ptr{Cvoid}
+    CollectFlatAddressOperands::LLVMTTICollectFlatAddressOperandsFn
+    CollectFlatAddressOperandsUD::Ptr{Cvoid}
+end
+
+function LLVMPassBuilderExtensionsSetTTI(Extensions, Options)
+    ccall((:LLVMPassBuilderExtensionsSetTTI, libLLVMExtra), Cvoid, (LLVMPassBuilderExtensionsRef, Ptr{LLVMTTIOptions}), Extensions, Options)
 end
 
 function LLVMGlobalsAddressSpace(TD)

--- a/src/LLVM.jl
+++ b/src/LLVM.jl
@@ -79,6 +79,7 @@ end
 include("debuginfo.jl")
 include("utils.jl")
 include("orc.jl")
+include("targetinfo.jl")
 include("newpm.jl")
 
 # high-level functionality

--- a/src/base.jl
+++ b/src/base.jl
@@ -6,6 +6,22 @@ function unsafe_message(ptr, args...)
     str
 end
 
+# `@public foo, bar` → `public foo, bar` on Julia ≥ 1.11, nothing on older.
+# `public` is only parseable at module top-level on all Julia versions, so a
+# bare `@static if ...; public foo; end` would fail at parse time. Taking the
+# names through a macro sidesteps that: `foo, bar` parses as a plain tuple,
+# and we splice its members into an `Expr(:public, ...)` the lowerer accepts.
+macro public(names)
+    @static if VERSION >= v"1.11"
+        syms = names isa Symbol ? (names,) :
+               Meta.isexpr(names, :tuple) ? names.args :
+               error("@public expects a symbol or a comma-separated list of symbols")
+        return esc(Expr(:public, syms...))
+    else
+        return nothing
+    end
+end
+
 
 ## defining types in the LLVM type hierarchy
 

--- a/src/newpm.jl
+++ b/src/newpm.jl
@@ -213,7 +213,7 @@ mutable struct NewPMPassBuilder <: AbstractPassManager
     passes::Vector{String}
     aa_passes::Vector{String}
     custom_passes::Vector{NewPMCustomPass}
-    custom_tti::Any  # ::Union{CustomTargetTransformInfo,Nothing}; forward ref
+    custom_tti::Any  # ::Union{AbstractTargetTransformInfo,Nothing}; forward ref
 end
 
 Base.string(pm::NewPMPassBuilder) = join(pm.passes, ",")
@@ -275,105 +275,116 @@ function register!(pb::NewPMPassBuilder, pass::NewPMCustomPass)
     push!(pb.custom_passes, pass)
 end
 
-export CustomTargetTransformInfo, target_transform_info!
+export AbstractTargetTransformInfo, target_transform_info!
+
+# The query methods below are meant to be overridden on subtypes
+@public flat_address_space, has_branch_divergence, is_single_threaded,
+        is_noop_addr_space_cast, is_valid_addr_space_cast, addrspaces_may_alias,
+        can_have_non_undef_global_initializer_in_address_space,
+        is_source_of_divergence, is_always_uniform,
+        get_assumed_addr_space, get_predicated_addr_space,
+        rewrite_intrinsic_with_address_space, collect_flat_address_operands
 
 """
-    CustomTargetTransformInfo(; kwargs...)
+    abstract type AbstractTargetTransformInfo
 
-A data-driven override for LLVM's `TargetTransformInfo`, intended for pipelines
-that lack a `TargetMachine` (e.g. out-of-tree backends invoked through a CLI)
-where the default TTI would otherwise be the conservative baseline and disable
-TTI-sensitive passes such as `InferAddressSpacesPass` or `UniformityAnalysis`.
+Subtype this and override the query methods to supply a `TargetTransformInfo`
+for pipelines that lack a `TargetMachine` (e.g. out-of-tree backends invoked
+through a CLI) where the default TTI would otherwise be the conservative
+baseline and disable TTI-sensitive passes such as `InferAddressSpacesPass` or
+`UniformityAnalysis`.
 
-Any field left as `nothing` defers to the baseline TTI's behavior for that
-query. Callback fields take Julia functions and are invoked through a cfunction
-trampoline at pass-run time.
+Only the subset of TTI hooks relevant to those passes is exposed; each has a
+default method on `AbstractTargetTransformInfo` that matches LLVM's
+`TargetTransformInfoImplBase` behavior, so subtypes only need to override the
+queries they care about.
+
+Attach an instance with [`target_transform_info!`](@ref). To run a pipeline
+against LLVM's native TTI (including `TargetMachine`-derived and
+`DataLayout`/`Module`-dependent defaults), pass `nothing` instead of an
+instance — no callbacks are registered in that case.
 
 # Simple knobs
 
-- `flat_address_space::Integer`: address space LLVM should treat as "flat" /
-  generic. Required for `InferAddressSpacesPass` and for folding
-  `addrspacecast`s.
-- `has_branch_divergence::Bool`: declare that this target can produce divergent
-  control flow. Enables divergence-aware variants in passes like `SimplifyCFG`.
-- `is_single_threaded::Bool`: declare that this target is single-threaded. A
-  few passes skip concurrency-related transformations under this.
+- [`flat_address_space`](@ref)`(tti) -> UInt`: address space LLVM should treat
+  as "flat" / generic. Required for `InferAddressSpacesPass` and for folding
+  `addrspacecast`s. Default: `typemax(UInt)` (no flat AS).
+- [`has_branch_divergence`](@ref)`(tti) -> Bool`: whether this target can
+  produce divergent control flow. Default: `false`.
+- [`is_single_threaded`](@ref)`(tti) -> Bool`: whether this target is
+  single-threaded. Default: `false`.
 
-# Address-space predicate callbacks
+# Address-space predicates
 
-Each is a function `(from::UInt, to::UInt) -> Bool` (or `(as::UInt) -> Bool`):
+- [`is_noop_addr_space_cast`](@ref)`(tti, from, to) -> Bool`: whether an
+  addrspacecast between the given AS pair is a noop. Required (alongside
+  `flat_address_space`) for `InferAddressSpacesPass` to actually fold casts.
+  Default: `false`.
+- [`is_valid_addr_space_cast`](@ref)`(tti, from, to) -> Bool`. Default: `false`.
+- [`addrspaces_may_alias`](@ref)`(tti, as0, as1) -> Bool`. Default: `true`
+  (conservative — pointers may alias unless proven otherwise).
+- [`can_have_non_undef_global_initializer_in_address_space`](@ref)`(tti, as) -> Bool`.
+  Default: `true`. LLVM's real baseline also considers
+  `DataLayout::isNonIntegralAddressSpace`, which isn't reachable from a
+  Julia-side default; override if your target has non-integral ASes.
 
-- `is_noop_addr_space_cast`: whether an addrspacecast between the given AS pair
-  is a noop at runtime. Required (alongside `flat_address_space`) for
-  `InferAddressSpacesPass` to actually fold casts — without it the pass sees
-  that it has a flat AS to infer but finds no casts it may eliminate.
-  A common GPU-style choice is `(from, to) -> from == flat || to == flat`,
-  but this is target-specific and must be supplied by the caller.
-- `is_valid_addr_space_cast`: whether an addrspacecast between the given AS
-  pair is permitted.
-- `addrspaces_may_alias`: whether pointers in the two ASes may alias.
-- `can_have_non_undef_global_initializer_in_address_space`: whether globals in
-  the given AS may have non-undef initializers.
+# Value-oriented queries
 
-# Value-oriented callbacks
+- [`is_source_of_divergence`](@ref)`(tti, v::Value) -> Bool`. Default: `false`.
+- [`is_always_uniform`](@ref)`(tti, v::Value) -> Bool`. Default: `false`.
+- [`get_assumed_addr_space`](@ref)`(tti, v::Value) -> Unsigned`: an AS known to
+  hold for this value, or `typemax(UInt)` for "no assumption". Default:
+  `typemax(UInt)`.
+- [`get_predicated_addr_space`](@ref)`(tti, v::Value) -> (predicate, as)`: an
+  AS that holds when `predicate::Union{Value,Nothing}` is true. Default:
+  `(nothing, typemax(UInt))`.
 
-- `get_assumed_addr_space(v::Value) -> Unsigned`: an AS known to hold for this
-  Value, or `typemax(UInt)` (i.e. `~0u`) for "no assumption".
-- `get_predicated_addr_space(v::Value) -> (predicate::Union{Value,Nothing}, as::Unsigned)`:
-  an AS that holds for this Value when `predicate` is true. Return `nothing`
-  for the predicate and `typemax(UInt)` for the AS to indicate no inference.
-- `is_source_of_divergence(v::Value) -> Bool`: used by `UniformityAnalysis`.
-- `is_always_uniform(v::Value) -> Bool`: used by `UniformityAnalysis`.
+# Intrinsic hooks
 
-# Intrinsic callbacks
-
-- `rewrite_intrinsic_with_address_space(ii::Value, old::Value, new::Value) -> Union{Value,Nothing}`:
-  rewrite a target intrinsic call after one of its pointer operands has been
-  moved to a specific AS. Return `nothing` to keep the existing call.
-- `collect_flat_address_operands(iid::UInt) -> Vector{Int}`: which operand
-  indices of intrinsic `iid` are flat-AS pointer operands. Capped at 32 entries.
+- [`rewrite_intrinsic_with_address_space`](@ref)`(tti, ii::Value, old::Value, new::Value) -> Union{Value,Nothing}`.
+  Default: `nothing` (no rewrite).
+- [`collect_flat_address_operands`](@ref)`(tti, iid::UInt) -> Vector{Int}`:
+  flat-AS pointer operand indices of intrinsic `iid`. Capped at 32 entries.
+  Default: `Int[]`.
 """
-Base.@kwdef struct CustomTargetTransformInfo
-    # Simple knobs
-    flat_address_space::Union{Integer,Nothing} = nothing
-    has_branch_divergence::Union{Bool,Nothing} = nothing
-    is_single_threaded::Union{Bool,Nothing}    = nothing
+abstract type AbstractTargetTransformInfo end
 
-    # AS-pair predicates: (from, to) -> Bool
-    is_noop_addr_space_cast                              = nothing
-    is_valid_addr_space_cast                             = nothing
-    addrspaces_may_alias                                 = nothing
+# Defaults matching LLVM's `TargetTransformInfoImplBase`. Two queries
+# (`can_have_non_undef_global_initializer_in_address_space`, `is_single_threaded`)
+# have LLVM baselines that depend on `DataLayout`/`Module` state not reachable
+# from these callbacks; we pick the common-case static answer and document that
+# subtypes must override if they need the full LLVM behavior.
+flat_address_space(::AbstractTargetTransformInfo) = typemax(UInt)
+has_branch_divergence(::AbstractTargetTransformInfo) = false
+is_single_threaded(::AbstractTargetTransformInfo) = false
 
-    # AS predicate: (as) -> Bool
-    can_have_non_undef_global_initializer_in_address_space = nothing
+is_noop_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
+is_valid_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
+addrspaces_may_alias(::AbstractTargetTransformInfo, as0::Unsigned, as1::Unsigned) = true
+can_have_non_undef_global_initializer_in_address_space(::AbstractTargetTransformInfo, as::Unsigned) = true
 
-    # Value predicates: (v) -> Bool
-    is_source_of_divergence = nothing
-    is_always_uniform       = nothing
+is_source_of_divergence(::AbstractTargetTransformInfo, v::Value) = false
+is_always_uniform(::AbstractTargetTransformInfo, v::Value) = false
+get_assumed_addr_space(::AbstractTargetTransformInfo, v::Value) = typemax(UInt)
+get_predicated_addr_space(::AbstractTargetTransformInfo, v::Value) =
+    (nothing, typemax(UInt))
 
-    # Value → AS
-    get_assumed_addr_space     = nothing
-    get_predicated_addr_space  = nothing
+rewrite_intrinsic_with_address_space(::AbstractTargetTransformInfo,
+                                     ii::Value, old::Value, new::Value) = nothing
+collect_flat_address_operands(::AbstractTargetTransformInfo, iid::Unsigned) = Int[]
 
-    # Intrinsic rewriting
-    rewrite_intrinsic_with_address_space = nothing
-    collect_flat_address_operands        = nothing
-end
-
-# Mutable shim that holds the `CustomTargetTransformInfo` alongside any caught
-# exception. A pointer to this object is passed to C as the `UserData` for
-# every callback, and the trampolines unwrap it to dispatch.
+# Mutable shim that holds the `AbstractTargetTransformInfo` alongside any
+# caught exception. A pointer to this object is passed to C as the `UserData`
+# for every callback, and the trampolines unwrap it to dispatch.
 mutable struct CustomTTIState
-    tti::CustomTargetTransformInfo
+    tti::AbstractTargetTransformInfo
     exception::Union{Nothing,Tuple{Any,Vector}}
     CustomTTIState(tti) = new(tti, nothing)
 end
 
 # Each trampoline is a top-level (non-closure) function so it can be
 # `@cfunction`'d. They swallow exceptions and record them on the state —
-# LLVM must not see a Julia exception unwind into C. Trampolines that run
-# multiple ccall-visible variants (e.g. the three AS-pair predicates) share
-# an inner generic body that dispatches on a `Val(::Symbol)` field tag.
+# LLVM must not see a Julia exception unwind into C.
 
 function custom_tti_capture_exception!(state::CustomTTIState, err)
     # Keep the first caught exception; ignore subsequent ones from the same run.
@@ -382,60 +393,85 @@ function custom_tti_capture_exception!(state::CustomTTIState, err)
     end
 end
 
-@inline function custom_tti_as_pair_dispatch(from::Cuint, to::Cuint,
-                                             ud::Ptr{Cvoid},
-                                             ::Val{field})::API.LLVMBool where {field}
+function custom_tti_is_noop_addr_space_cast_callback(from::Cuint, to::Cuint,
+                                                     ud::Ptr{Cvoid})::API.LLVMBool
     state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
     try
-        return getfield(state.tti, field)(from, to)::Bool
-    catch err
-        custom_tti_capture_exception!(state, err)
-        return false
-    end
-end
-custom_tti_is_noop_addr_space_cast_callback(from::Cuint, to::Cuint, ud::Ptr{Cvoid}) =
-    custom_tti_as_pair_dispatch(from, to, ud, Val(:is_noop_addr_space_cast))
-custom_tti_is_valid_addr_space_cast_callback(from::Cuint, to::Cuint, ud::Ptr{Cvoid}) =
-    custom_tti_as_pair_dispatch(from, to, ud, Val(:is_valid_addr_space_cast))
-custom_tti_addrspaces_may_alias_callback(from::Cuint, to::Cuint, ud::Ptr{Cvoid}) =
-    custom_tti_as_pair_dispatch(from, to, ud, Val(:addrspaces_may_alias))
-
-function custom_tti_can_have_global_initializer_in_as_callback(
-        as::Cuint, ud::Ptr{Cvoid})::API.LLVMBool
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        return state.tti.can_have_non_undef_global_initializer_in_address_space(as)::Bool
+        return is_noop_addr_space_cast(state.tti, UInt(from), UInt(to))::Bool
     catch err
         custom_tti_capture_exception!(state, err)
         return false
     end
 end
 
-@inline function custom_tti_value_predicate_dispatch(ref::API.LLVMValueRef,
-                                                     ud::Ptr{Cvoid},
-                                                     ::Val{field})::API.LLVMBool where {field}
+function custom_tti_is_valid_addr_space_cast_callback(from::Cuint, to::Cuint,
+                                                      ud::Ptr{Cvoid})::API.LLVMBool
     state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
     try
-        return getfield(state.tti, field)(Value(ref))::Bool
+        return is_valid_addr_space_cast(state.tti, UInt(from), UInt(to))::Bool
     catch err
         custom_tti_capture_exception!(state, err)
         return false
     end
 end
-custom_tti_is_source_of_divergence_callback(ref::API.LLVMValueRef, ud::Ptr{Cvoid}) =
-    custom_tti_value_predicate_dispatch(ref, ud, Val(:is_source_of_divergence))
-custom_tti_is_always_uniform_callback(ref::API.LLVMValueRef, ud::Ptr{Cvoid}) =
-    custom_tti_value_predicate_dispatch(ref, ud, Val(:is_always_uniform))
 
-function custom_tti_get_assumed_address_space_callback(
-        ref::API.LLVMValueRef, ud::Ptr{Cvoid})::Cuint
+function custom_tti_addrspaces_may_alias_callback(as0::Cuint, as1::Cuint,
+                                                  ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return addrspaces_may_alias(state.tti, UInt(as0), UInt(as1))::Bool
+    catch err
+        # Conservative default on exception: may alias. Matches LLVM's BaseT
+        # and avoids the risk of incorrect optimization on partially-transformed
+        # IR before the captured exception is re-raised.
+        custom_tti_capture_exception!(state, err)
+        return true
+    end
+end
+
+function custom_tti_can_have_global_initializer_in_as_callback(as::Cuint,
+                                                               ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return can_have_non_undef_global_initializer_in_address_space(
+                   state.tti, UInt(as))::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+
+function custom_tti_is_source_of_divergence_callback(ref::API.LLVMValueRef,
+                                                     ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return is_source_of_divergence(state.tti, Value(ref))::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+
+function custom_tti_is_always_uniform_callback(ref::API.LLVMValueRef,
+                                               ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return is_always_uniform(state.tti, Value(ref))::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+
+function custom_tti_get_assumed_address_space_callback(ref::API.LLVMValueRef,
+                                                       ud::Ptr{Cvoid})::Cuint
     state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
     try
         # `% Cuint` truncates modulo 2^32 rather than throwing on
         # `typemax(UInt)` — users naturally reach for that as the "no
         # assumption" sentinel, and we want both 32- and 64-bit spellings
         # of ~0 to work.
-        return state.tti.get_assumed_addr_space(Value(ref))::Integer % Cuint
+        return get_assumed_addr_space(state.tti, Value(ref))::Integer % Cuint
     catch err
         custom_tti_capture_exception!(state, err)
         return typemax(Cuint)
@@ -448,7 +484,7 @@ function custom_tti_get_predicated_address_space_callback(
         ud::Ptr{Cvoid})::Cuint
     state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
     try
-        (pred, as) = state.tti.get_predicated_addr_space(Value(ref))
+        (pred, as) = get_predicated_addr_space(state.tti, Value(ref))
         pred_ref = pred === nothing ? API.LLVMValueRef(C_NULL) :
                                       Base.unsafe_convert(API.LLVMValueRef, pred::Value)
         unsafe_store!(out_predicate, pred_ref)
@@ -465,7 +501,7 @@ function custom_tti_rewrite_intrinsic_with_as_callback(
         ud::Ptr{Cvoid})::API.LLVMValueRef
     state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
     try
-        result = state.tti.rewrite_intrinsic_with_address_space(
+        result = rewrite_intrinsic_with_address_space(state.tti,
                      Value(ii), Value(old), Value(new))
         result === nothing && return API.LLVMValueRef(C_NULL)
         return Base.unsafe_convert(API.LLVMValueRef, result::Value)
@@ -481,13 +517,13 @@ function custom_tti_collect_flat_address_operands_callback(
         ud::Ptr{Cvoid})::API.LLVMBool
     state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
     try
-        ops = state.tti.collect_flat_address_operands(iid)::AbstractVector
+        ops = collect_flat_address_operands(state.tti, UInt(iid))::AbstractVector
         n = min(length(ops), Int(max_count))
         for i in 1:n
             unsafe_store!(out_ops, Cint(ops[i]), i)
         end
         unsafe_store!(out_count, Cuint(n))
-        return !isempty(ops)
+        return n > 0
     catch err
         custom_tti_capture_exception!(state, err)
         unsafe_store!(out_count, Cuint(0))
@@ -495,71 +531,54 @@ function custom_tti_collect_flat_address_operands_callback(
     end
 end
 
-# Build the C-side `LLVMTTIOptions` and attach it to the extensions
-# struct. The C side copies the options struct, but the function pointers and
-# the UD pointer (into `state`) remain live references — the returned state
-# must outlive `run!`.
+# Build the C-side `LLVMTTIOptions` and attach it to the extensions struct. All
+# callbacks are registered unconditionally; default-method dispatch on
+# `AbstractTargetTransformInfo` supplies baseline-equivalent answers for
+# queries the subtype didn't override.
 function install_custom_tti!(exts::API.LLVMPassBuilderExtensionsRef,
-                             tti::CustomTargetTransformInfo)
+                             tti::AbstractTargetTransformInfo)
     state = CustomTTIState(tti)
     ud = Base.pointer_from_objref(state)
 
-    # For each callback field: (fnptr, userdata) if the callback is set,
-    # (C_NULL, C_NULL) otherwise.
-    cbptr(f::Nothing, _cf) = (Ptr{Cvoid}(C_NULL), Ptr{Cvoid}(C_NULL))
-    cbptr(_,          cf)  = (Base.unsafe_convert(Ptr{Cvoid}, cf), ud)
+    noop_cb = @cfunction(custom_tti_is_noop_addr_space_cast_callback,
+                         API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
+    valid_cb = @cfunction(custom_tti_is_valid_addr_space_cast_callback,
+                          API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
+    alias_cb = @cfunction(custom_tti_addrspaces_may_alias_callback,
+                          API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
+    ginit_cb = @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
+                          API.LLVMBool, (Cuint, Ptr{Cvoid}))
+    srcdiv_cb = @cfunction(custom_tti_is_source_of_divergence_callback,
+                           API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
+    unif_cb = @cfunction(custom_tti_is_always_uniform_callback,
+                         API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
+    assas_cb = @cfunction(custom_tti_get_assumed_address_space_callback,
+                          Cuint, (API.LLVMValueRef, Ptr{Cvoid}))
+    predas_cb = @cfunction(custom_tti_get_predicated_address_space_callback,
+                           Cuint, (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid}))
+    rewrite_cb = @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
+                            API.LLVMValueRef,
+                            (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid}))
+    collect_cb = @cfunction(custom_tti_collect_flat_address_operands_callback,
+                            API.LLVMBool,
+                            (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid}))
 
-    noop_cb, noop_ud = cbptr(tti.is_noop_addr_space_cast,
-        @cfunction(custom_tti_is_noop_addr_space_cast_callback,
-                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})))
-    valid_cb, valid_ud = cbptr(tti.is_valid_addr_space_cast,
-        @cfunction(custom_tti_is_valid_addr_space_cast_callback,
-                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})))
-    alias_cb, alias_ud = cbptr(tti.addrspaces_may_alias,
-        @cfunction(custom_tti_addrspaces_may_alias_callback,
-                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})))
-    ginit_cb, ginit_ud = cbptr(tti.can_have_non_undef_global_initializer_in_address_space,
-        @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
-                   API.LLVMBool, (Cuint, Ptr{Cvoid})))
-    srcdiv_cb, srcdiv_ud = cbptr(tti.is_source_of_divergence,
-        @cfunction(custom_tti_is_source_of_divergence_callback,
-                   API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})))
-    unif_cb, unif_ud = cbptr(tti.is_always_uniform,
-        @cfunction(custom_tti_is_always_uniform_callback,
-                   API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})))
-    assas_cb, assas_ud = cbptr(tti.get_assumed_addr_space,
-        @cfunction(custom_tti_get_assumed_address_space_callback,
-                   Cuint, (API.LLVMValueRef, Ptr{Cvoid})))
-    predas_cb, predas_ud = cbptr(tti.get_predicated_addr_space,
-        @cfunction(custom_tti_get_predicated_address_space_callback, Cuint,
-                   (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid})))
-    rewrite_cb, rewrite_ud = cbptr(tti.rewrite_intrinsic_with_address_space,
-        @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
-                   API.LLVMValueRef,
-                   (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid})))
-    collect_cb, collect_ud = cbptr(tti.collect_flat_address_operands,
-        @cfunction(custom_tti_collect_flat_address_operands_callback,
-                   API.LLVMBool,
-                   (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid})))
-
-    tri_state(::Nothing) = Int32(-1)
-    tri_state(x::Bool)   = Int32(x)
+    p(cf) = Base.unsafe_convert(Ptr{Cvoid}, cf)
 
     opts = Ref(API.LLVMTTIOptions(
-        tti.flat_address_space === nothing ? typemax(Cuint) :
-                                             Cuint(tti.flat_address_space),
-        tri_state(tti.has_branch_divergence),
-        tri_state(tti.is_single_threaded),
-        noop_cb,    noop_ud,
-        valid_cb,   valid_ud,
-        alias_cb,   alias_ud,
-        ginit_cb,   ginit_ud,
-        srcdiv_cb,  srcdiv_ud,
-        unif_cb,    unif_ud,
-        assas_cb,   assas_ud,
-        predas_cb,  predas_ud,
-        rewrite_cb, rewrite_ud,
-        collect_cb, collect_ud,
+        flat_address_space(tti) % Cuint,
+        Int32(has_branch_divergence(tti)),
+        Int32(is_single_threaded(tti)),
+        p(noop_cb),    ud,
+        p(valid_cb),   ud,
+        p(alias_cb),   ud,
+        p(ginit_cb),   ud,
+        p(srcdiv_cb),  ud,
+        p(unif_cb),    ud,
+        p(assas_cb),   ud,
+        p(predas_cb),  ud,
+        p(rewrite_cb), ud,
+        p(collect_cb), ud,
     ))
 
     API.LLVMPassBuilderExtensionsSetTTI(exts, opts)
@@ -567,15 +586,17 @@ function install_custom_tti!(exts::API.LLVMPassBuilderExtensionsRef,
 end
 
 """
-    target_transform_info!(pb::NewPMPassBuilder, tti::CustomTargetTransformInfo)
+    target_transform_info!(pb::NewPMPassBuilder, tti::AbstractTargetTransformInfo)
     target_transform_info!(pb::NewPMPassBuilder, ::Nothing)
 
-Attach a [`CustomTargetTransformInfo`](@ref) to the pass builder, replacing any
-previously-attached custom TTI. Pass `nothing` to revert to the default TTI
-(derived from the `TargetMachine`, if any).
+Attach an [`AbstractTargetTransformInfo`](@ref) subtype instance to the pass
+builder, replacing any previously-attached custom TTI. Pass `nothing` to
+revert to LLVM's native TTI (derived from the `TargetMachine`, if any;
+otherwise `TargetTransformInfoImplBase` with full `DataLayout`/`Module`-aware
+defaults).
 """
 function target_transform_info!(pb::NewPMPassBuilder,
-                                tti::CustomTargetTransformInfo)
+                                tti::AbstractTargetTransformInfo)
     pb.custom_tti = tti
     return pb
 end

--- a/src/newpm.jl
+++ b/src/newpm.jl
@@ -120,13 +120,16 @@ end
 export PassException
 struct PassException <: Exception
     ex::Any
-    processed_bt::Vector{Any}
+    processed_bt::Vector{Base.StackTraces.StackFrame}
 
-    function PassException(ex, bt_raw::Vector{Union{Ptr{Nothing}, Base.InterpreterIP}})
-        bt_processed = Base.process_backtrace(bt_raw)
+    function PassException(ex, bt)
+        # `stacktrace` accepts either a raw bt from `catch_backtrace()` or
+        # an already-processed frame vector, and is stable across Julia
+        # versions (unlike `Base.process_backtrace`, whose method for the
+        # raw bt type was dropped in 1.14).
+        bt_processed = stacktrace(bt)
         new(ex, bt_processed[1:min(100, end)])
     end
-    PassException(ex, processed_bt::Vector{Any}) = new(ex, processed_bt)
 end
 
 function Base.showerror(io::IO, e::PassException)

--- a/src/newpm.jl
+++ b/src/newpm.jl
@@ -216,7 +216,7 @@ mutable struct NewPMPassBuilder <: AbstractPassManager
     passes::Vector{String}
     aa_passes::Vector{String}
     custom_passes::Vector{NewPMCustomPass}
-    custom_tti::Any  # ::Union{AbstractTargetTransformInfo,Nothing}; forward ref
+    custom_tti::Union{AbstractTargetTransformInfo,Nothing}
 end
 
 Base.string(pm::NewPMPassBuilder) = join(pm.passes, ",")
@@ -278,314 +278,17 @@ function register!(pb::NewPMPassBuilder, pass::NewPMCustomPass)
     push!(pb.custom_passes, pass)
 end
 
-export AbstractTargetTransformInfo, target_transform_info!
+export target_transform_info!
 
-# The query methods below are meant to be overridden on subtypes
-@public flat_address_space, has_branch_divergence, is_single_threaded,
-        is_noop_addr_space_cast, is_valid_addr_space_cast, addrspaces_may_alias,
-        can_have_non_undef_global_initializer_in_address_space,
-        is_source_of_divergence, is_always_uniform,
-        get_assumed_addr_space, get_predicated_addr_space,
-        rewrite_intrinsic_with_address_space, collect_flat_address_operands
-
-"""
-    abstract type AbstractTargetTransformInfo
-
-Subtype this and override the query methods to supply a `TargetTransformInfo`
-for pipelines that lack a `TargetMachine` (e.g. out-of-tree backends invoked
-through a CLI) where the default TTI would otherwise be the conservative
-baseline and disable TTI-sensitive passes such as `InferAddressSpacesPass` or
-`UniformityAnalysis`.
-
-Only the subset of TTI hooks relevant to those passes is exposed; each has a
-default method on `AbstractTargetTransformInfo` that matches LLVM's
-`TargetTransformInfoImplBase` behavior, so subtypes only need to override the
-queries they care about.
-
-Attach an instance with [`target_transform_info!`](@ref). To run a pipeline
-against LLVM's native TTI (including `TargetMachine`-derived and
-`DataLayout`/`Module`-dependent defaults), pass `nothing` instead of an
-instance — no callbacks are registered in that case.
-
-# Simple knobs
-
-- [`flat_address_space`](@ref)`(tti) -> UInt`: address space LLVM should treat
-  as "flat" / generic. Required for `InferAddressSpacesPass` and for folding
-  `addrspacecast`s. Default: `typemax(UInt)` (no flat AS).
-- [`has_branch_divergence`](@ref)`(tti) -> Bool`: whether this target can
-  produce divergent control flow. Default: `false`.
-- [`is_single_threaded`](@ref)`(tti) -> Bool`: whether this target is
-  single-threaded. Default: `false`.
-
-# Address-space predicates
-
-- [`is_noop_addr_space_cast`](@ref)`(tti, from, to) -> Bool`: whether an
-  addrspacecast between the given AS pair is a noop. Required (alongside
-  `flat_address_space`) for `InferAddressSpacesPass` to actually fold casts.
-  Default: `false`.
-- [`is_valid_addr_space_cast`](@ref)`(tti, from, to) -> Bool`. Default: `false`.
-- [`addrspaces_may_alias`](@ref)`(tti, as0, as1) -> Bool`. Default: `true`
-  (conservative — pointers may alias unless proven otherwise).
-- [`can_have_non_undef_global_initializer_in_address_space`](@ref)`(tti, as) -> Bool`.
-  Default: `true`. LLVM's real baseline also considers
-  `DataLayout::isNonIntegralAddressSpace`, which isn't reachable from a
-  Julia-side default; override if your target has non-integral ASes.
-
-# Value-oriented queries
-
-- [`is_source_of_divergence`](@ref)`(tti, v::Value) -> Bool`. Default: `false`.
-- [`is_always_uniform`](@ref)`(tti, v::Value) -> Bool`. Default: `false`.
-- [`get_assumed_addr_space`](@ref)`(tti, v::Value) -> Unsigned`: an AS known to
-  hold for this value, or `typemax(UInt)` for "no assumption". Default:
-  `typemax(UInt)`.
-- [`get_predicated_addr_space`](@ref)`(tti, v::Value) -> (predicate, as)`: an
-  AS that holds when `predicate::Union{Value,Nothing}` is true. Default:
-  `(nothing, typemax(UInt))`.
-
-# Intrinsic hooks
-
-- [`rewrite_intrinsic_with_address_space`](@ref)`(tti, ii::Value, old::Value, new::Value) -> Union{Value,Nothing}`.
-  Default: `nothing` (no rewrite).
-- [`collect_flat_address_operands`](@ref)`(tti, iid::UInt) -> Vector{Int}`:
-  flat-AS pointer operand indices of intrinsic `iid`. Capped at 32 entries.
-  Default: `Int[]`.
-"""
-abstract type AbstractTargetTransformInfo end
-
-# Defaults matching LLVM's `TargetTransformInfoImplBase`. Two queries
-# (`can_have_non_undef_global_initializer_in_address_space`, `is_single_threaded`)
-# have LLVM baselines that depend on `DataLayout`/`Module` state not reachable
-# from these callbacks; we pick the common-case static answer and document that
-# subtypes must override if they need the full LLVM behavior.
-flat_address_space(::AbstractTargetTransformInfo) = typemax(UInt)
-has_branch_divergence(::AbstractTargetTransformInfo) = false
-is_single_threaded(::AbstractTargetTransformInfo) = false
-
-is_noop_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
-is_valid_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
-addrspaces_may_alias(::AbstractTargetTransformInfo, as0::Unsigned, as1::Unsigned) = true
-can_have_non_undef_global_initializer_in_address_space(::AbstractTargetTransformInfo, as::Unsigned) = true
-
-is_source_of_divergence(::AbstractTargetTransformInfo, v::Value) = false
-is_always_uniform(::AbstractTargetTransformInfo, v::Value) = false
-get_assumed_addr_space(::AbstractTargetTransformInfo, v::Value) = typemax(UInt)
-get_predicated_addr_space(::AbstractTargetTransformInfo, v::Value) =
-    (nothing, typemax(UInt))
-
-rewrite_intrinsic_with_address_space(::AbstractTargetTransformInfo,
-                                     ii::Value, old::Value, new::Value) = nothing
-collect_flat_address_operands(::AbstractTargetTransformInfo, iid::Unsigned) = Int[]
-
-# Mutable shim that holds the `AbstractTargetTransformInfo` alongside any
-# caught exception. A pointer to this object is passed to C as the `UserData`
-# for every callback, and the trampolines unwrap it to dispatch.
-mutable struct CustomTTIState
-    tti::AbstractTargetTransformInfo
-    exception::Union{Nothing,Tuple{Any,Vector}}
-    CustomTTIState(tti) = new(tti, nothing)
-end
-
-# Each trampoline is a top-level (non-closure) function so it can be
-# `@cfunction`'d. They swallow exceptions and record them on the state —
-# LLVM must not see a Julia exception unwind into C.
-
-function custom_tti_capture_exception!(state::CustomTTIState, err)
-    # Keep the first caught exception; ignore subsequent ones from the same run.
-    if state.exception === nothing
-        state.exception = (err, Base.catch_backtrace())
-    end
-end
-
-function custom_tti_is_noop_addr_space_cast_callback(from::Cuint, to::Cuint,
-                                                     ud::Ptr{Cvoid})::API.LLVMBool
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        return is_noop_addr_space_cast(state.tti, UInt(from), UInt(to))::Bool
-    catch err
-        custom_tti_capture_exception!(state, err)
-        return false
-    end
-end
-
-function custom_tti_is_valid_addr_space_cast_callback(from::Cuint, to::Cuint,
-                                                      ud::Ptr{Cvoid})::API.LLVMBool
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        return is_valid_addr_space_cast(state.tti, UInt(from), UInt(to))::Bool
-    catch err
-        custom_tti_capture_exception!(state, err)
-        return false
-    end
-end
-
-function custom_tti_addrspaces_may_alias_callback(as0::Cuint, as1::Cuint,
-                                                  ud::Ptr{Cvoid})::API.LLVMBool
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        return addrspaces_may_alias(state.tti, UInt(as0), UInt(as1))::Bool
-    catch err
-        # Conservative default on exception: may alias. Matches LLVM's BaseT
-        # and avoids the risk of incorrect optimization on partially-transformed
-        # IR before the captured exception is re-raised.
-        custom_tti_capture_exception!(state, err)
-        return true
-    end
-end
-
-function custom_tti_can_have_global_initializer_in_as_callback(as::Cuint,
-                                                               ud::Ptr{Cvoid})::API.LLVMBool
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        return can_have_non_undef_global_initializer_in_address_space(
-                   state.tti, UInt(as))::Bool
-    catch err
-        custom_tti_capture_exception!(state, err)
-        return false
-    end
-end
-
-function custom_tti_is_source_of_divergence_callback(ref::API.LLVMValueRef,
-                                                     ud::Ptr{Cvoid})::API.LLVMBool
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        return is_source_of_divergence(state.tti, Value(ref))::Bool
-    catch err
-        custom_tti_capture_exception!(state, err)
-        return false
-    end
-end
-
-function custom_tti_is_always_uniform_callback(ref::API.LLVMValueRef,
-                                               ud::Ptr{Cvoid})::API.LLVMBool
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        return is_always_uniform(state.tti, Value(ref))::Bool
-    catch err
-        custom_tti_capture_exception!(state, err)
-        return false
-    end
-end
-
-function custom_tti_get_assumed_address_space_callback(ref::API.LLVMValueRef,
-                                                       ud::Ptr{Cvoid})::Cuint
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        # `% Cuint` truncates modulo 2^32 rather than throwing on
-        # `typemax(UInt)` — users naturally reach for that as the "no
-        # assumption" sentinel, and we want both 32- and 64-bit spellings
-        # of ~0 to work.
-        return get_assumed_addr_space(state.tti, Value(ref))::Integer % Cuint
-    catch err
-        custom_tti_capture_exception!(state, err)
-        return typemax(Cuint)
-    end
-end
-
-function custom_tti_get_predicated_address_space_callback(
-        ref::API.LLVMValueRef,
-        out_predicate::Ptr{API.LLVMValueRef},
-        ud::Ptr{Cvoid})::Cuint
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        (pred, as) = get_predicated_addr_space(state.tti, Value(ref))
-        pred_ref = pred === nothing ? API.LLVMValueRef(C_NULL) :
-                                      Base.unsafe_convert(API.LLVMValueRef, pred::Value)
-        unsafe_store!(out_predicate, pred_ref)
-        return as::Integer % Cuint
-    catch err
-        custom_tti_capture_exception!(state, err)
-        unsafe_store!(out_predicate, API.LLVMValueRef(C_NULL))
-        return typemax(Cuint)
-    end
-end
-
-function custom_tti_rewrite_intrinsic_with_as_callback(
-        ii::API.LLVMValueRef, old::API.LLVMValueRef, new::API.LLVMValueRef,
-        ud::Ptr{Cvoid})::API.LLVMValueRef
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        result = rewrite_intrinsic_with_address_space(state.tti,
-                     Value(ii), Value(old), Value(new))
-        result === nothing && return API.LLVMValueRef(C_NULL)
-        return Base.unsafe_convert(API.LLVMValueRef, result::Value)
-    catch err
-        custom_tti_capture_exception!(state, err)
-        return API.LLVMValueRef(C_NULL)
-    end
-end
-
-function custom_tti_collect_flat_address_operands_callback(
-        iid::Cuint, out_ops::Ptr{Cint},
-        max_count::Cuint, out_count::Ptr{Cuint},
-        ud::Ptr{Cvoid})::API.LLVMBool
-    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
-    try
-        ops = collect_flat_address_operands(state.tti, UInt(iid))::AbstractVector
-        n = min(length(ops), Int(max_count))
-        for i in 1:n
-            unsafe_store!(out_ops, Cint(ops[i]), i)
-        end
-        unsafe_store!(out_count, Cuint(n))
-        return n > 0
-    catch err
-        custom_tti_capture_exception!(state, err)
-        unsafe_store!(out_count, Cuint(0))
-        return false
-    end
-end
-
-# Build the C-side `LLVMTTIOptions` and attach it to the extensions struct. All
-# callbacks are registered unconditionally; default-method dispatch on
-# `AbstractTargetTransformInfo` supplies baseline-equivalent answers for
-# queries the subtype didn't override.
 function install_custom_tti!(exts::API.LLVMPassBuilderExtensionsRef,
                              tti::AbstractTargetTransformInfo)
-    state = CustomTTIState(tti)
-    ud = Base.pointer_from_objref(state)
-
-    noop_cb = @cfunction(custom_tti_is_noop_addr_space_cast_callback,
-                         API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
-    valid_cb = @cfunction(custom_tti_is_valid_addr_space_cast_callback,
-                          API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
-    alias_cb = @cfunction(custom_tti_addrspaces_may_alias_callback,
-                          API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
-    ginit_cb = @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
-                          API.LLVMBool, (Cuint, Ptr{Cvoid}))
-    srcdiv_cb = @cfunction(custom_tti_is_source_of_divergence_callback,
-                           API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
-    unif_cb = @cfunction(custom_tti_is_always_uniform_callback,
-                         API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
-    assas_cb = @cfunction(custom_tti_get_assumed_address_space_callback,
-                          Cuint, (API.LLVMValueRef, Ptr{Cvoid}))
-    predas_cb = @cfunction(custom_tti_get_predicated_address_space_callback,
-                           Cuint, (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid}))
-    rewrite_cb = @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
-                            API.LLVMValueRef,
-                            (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid}))
-    collect_cb = @cfunction(custom_tti_collect_flat_address_operands_callback,
-                            API.LLVMBool,
-                            (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid}))
-
-    p(cf) = Base.unsafe_convert(Ptr{Cvoid}, cf)
-
-    opts = Ref(API.LLVMTTIOptions(
-        flat_address_space(tti) % Cuint,
-        Int32(has_branch_divergence(tti)),
-        Int32(is_single_threaded(tti)),
-        p(noop_cb),    ud,
-        p(valid_cb),   ud,
-        p(alias_cb),   ud,
-        p(ginit_cb),   ud,
-        p(srcdiv_cb),  ud,
-        p(unif_cb),    ud,
-        p(assas_cb),   ud,
-        p(predas_cb),  ud,
-        p(rewrite_cb), ud,
-        p(collect_cb), ud,
-    ))
-
+    state, opts = build_custom_tti_options(tti)
     API.LLVMPassBuilderExtensionsSetTTI(exts, opts)
-    return state
+    # Return both: `state` owns the CustomTTIState (exception capture +
+    # `ud` backing pointer); `opts` owns the `LLVMTTIOptions` Ref that
+    # holds the `@cfunction` handles. Both must stay GC-rooted until
+    # `run!` completes.
+    return state, opts
 end
 
 """
@@ -630,9 +333,9 @@ function run!(pb::NewPMPassBuilder, target::Union{Module,Function}, tm::Union{No
 
     # Create state objects to hold callbacks and any caught exceptions
     states = [CustomPassState(pass.callback) for pass in pb.custom_passes]
-    tti_state = pb.custom_tti === nothing ? nothing :
-                install_custom_tti!(pb.exts, pb.custom_tti)
-    GC.@preserve states tti_state aa_pipeline begin
+    tti_state, tti_opts = pb.custom_tti === nothing ? (nothing, nothing) :
+                          install_custom_tti!(pb.exts, pb.custom_tti)
+    GC.@preserve states tti_state tti_opts aa_pipeline begin
         # register custom passes
         for (i,pass) in enumerate(pb.custom_passes)
             if pass.type === :module

--- a/src/newpm.jl
+++ b/src/newpm.jl
@@ -213,6 +213,7 @@ mutable struct NewPMPassBuilder <: AbstractPassManager
     passes::Vector{String}
     aa_passes::Vector{String}
     custom_passes::Vector{NewPMCustomPass}
+    custom_tti::Any  # ::Union{CustomTargetTransformInfo,Nothing}; forward ref
 end
 
 Base.string(pm::NewPMPassBuilder) = join(pm.passes, ",")
@@ -223,7 +224,7 @@ Base.unsafe_convert(::Type{API.LLVMPassBuilderOptionsRef}, pb::NewPMPassBuilder)
 function NewPMPassBuilder(; kwargs...)
     opts = API.LLVMCreatePassBuilderOptions()
     exts = API.LLVMCreatePassBuilderExtensions()
-    obj = mark_alloc(NewPMPassBuilder(opts, exts, [], [], []))
+    obj = mark_alloc(NewPMPassBuilder(opts, exts, [], [], [], nothing))
 
     for (name, value) in pairs(kwargs)
         if name == :verify_each
@@ -274,6 +275,317 @@ function register!(pb::NewPMPassBuilder, pass::NewPMCustomPass)
     push!(pb.custom_passes, pass)
 end
 
+export CustomTargetTransformInfo, target_transform_info!
+
+"""
+    CustomTargetTransformInfo(; kwargs...)
+
+A data-driven override for LLVM's `TargetTransformInfo`, intended for pipelines
+that lack a `TargetMachine` (e.g. out-of-tree backends invoked through a CLI)
+where the default TTI would otherwise be the conservative baseline and disable
+TTI-sensitive passes such as `InferAddressSpacesPass` or `UniformityAnalysis`.
+
+Any field left as `nothing` defers to the baseline TTI's behavior for that
+query. Callback fields take Julia functions and are invoked through a cfunction
+trampoline at pass-run time.
+
+# Simple knobs
+
+- `flat_address_space::Integer`: address space LLVM should treat as "flat" /
+  generic. Required for `InferAddressSpacesPass` and for folding
+  `addrspacecast`s.
+- `has_branch_divergence::Bool`: declare that this target can produce divergent
+  control flow. Enables divergence-aware variants in passes like `SimplifyCFG`.
+- `is_single_threaded::Bool`: declare that this target is single-threaded. A
+  few passes skip concurrency-related transformations under this.
+
+# Address-space predicate callbacks
+
+Each is a function `(from::UInt, to::UInt) -> Bool` (or `(as::UInt) -> Bool`):
+
+- `is_noop_addr_space_cast`: whether an addrspacecast between the given AS pair
+  is a noop at runtime. Required (alongside `flat_address_space`) for
+  `InferAddressSpacesPass` to actually fold casts — without it the pass sees
+  that it has a flat AS to infer but finds no casts it may eliminate.
+  A common GPU-style choice is `(from, to) -> from == flat || to == flat`,
+  but this is target-specific and must be supplied by the caller.
+- `is_valid_addr_space_cast`: whether an addrspacecast between the given AS
+  pair is permitted.
+- `addrspaces_may_alias`: whether pointers in the two ASes may alias.
+- `can_have_non_undef_global_initializer_in_address_space`: whether globals in
+  the given AS may have non-undef initializers.
+
+# Value-oriented callbacks
+
+- `get_assumed_addr_space(v::Value) -> Unsigned`: an AS known to hold for this
+  Value, or `typemax(UInt)` (i.e. `~0u`) for "no assumption".
+- `get_predicated_addr_space(v::Value) -> (predicate::Union{Value,Nothing}, as::Unsigned)`:
+  an AS that holds for this Value when `predicate` is true. Return `nothing`
+  for the predicate and `typemax(UInt)` for the AS to indicate no inference.
+- `is_source_of_divergence(v::Value) -> Bool`: used by `UniformityAnalysis`.
+- `is_always_uniform(v::Value) -> Bool`: used by `UniformityAnalysis`.
+
+# Intrinsic callbacks
+
+- `rewrite_intrinsic_with_address_space(ii::Value, old::Value, new::Value) -> Union{Value,Nothing}`:
+  rewrite a target intrinsic call after one of its pointer operands has been
+  moved to a specific AS. Return `nothing` to keep the existing call.
+- `collect_flat_address_operands(iid::UInt) -> Vector{Int}`: which operand
+  indices of intrinsic `iid` are flat-AS pointer operands. Capped at 32 entries.
+"""
+Base.@kwdef struct CustomTargetTransformInfo
+    # Simple knobs
+    flat_address_space::Union{Integer,Nothing} = nothing
+    has_branch_divergence::Union{Bool,Nothing} = nothing
+    is_single_threaded::Union{Bool,Nothing}    = nothing
+
+    # AS-pair predicates: (from, to) -> Bool
+    is_noop_addr_space_cast                              = nothing
+    is_valid_addr_space_cast                             = nothing
+    addrspaces_may_alias                                 = nothing
+
+    # AS predicate: (as) -> Bool
+    can_have_non_undef_global_initializer_in_address_space = nothing
+
+    # Value predicates: (v) -> Bool
+    is_source_of_divergence = nothing
+    is_always_uniform       = nothing
+
+    # Value → AS
+    get_assumed_addr_space     = nothing
+    get_predicated_addr_space  = nothing
+
+    # Intrinsic rewriting
+    rewrite_intrinsic_with_address_space = nothing
+    collect_flat_address_operands        = nothing
+end
+
+# Mutable shim that holds the `CustomTargetTransformInfo` alongside any caught
+# exception. A pointer to this object is passed to C as the `UserData` for
+# every callback, and the trampolines unwrap it to dispatch.
+mutable struct CustomTTIState
+    tti::CustomTargetTransformInfo
+    exception::Union{Nothing,Tuple{Any,Vector}}
+    CustomTTIState(tti) = new(tti, nothing)
+end
+
+# Each trampoline is a top-level (non-closure) function so it can be
+# `@cfunction`'d. They swallow exceptions and record them on the state —
+# LLVM must not see a Julia exception unwind into C. Trampolines that run
+# multiple ccall-visible variants (e.g. the three AS-pair predicates) share
+# an inner generic body that dispatches on a `Val(::Symbol)` field tag.
+
+function custom_tti_capture_exception!(state::CustomTTIState, err)
+    # Keep the first caught exception; ignore subsequent ones from the same run.
+    if state.exception === nothing
+        state.exception = (err, Base.catch_backtrace())
+    end
+end
+
+@inline function custom_tti_as_pair_dispatch(from::Cuint, to::Cuint,
+                                             ud::Ptr{Cvoid},
+                                             ::Val{field})::API.LLVMBool where {field}
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return getfield(state.tti, field)(from, to)::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+custom_tti_is_noop_addr_space_cast_callback(from::Cuint, to::Cuint, ud::Ptr{Cvoid}) =
+    custom_tti_as_pair_dispatch(from, to, ud, Val(:is_noop_addr_space_cast))
+custom_tti_is_valid_addr_space_cast_callback(from::Cuint, to::Cuint, ud::Ptr{Cvoid}) =
+    custom_tti_as_pair_dispatch(from, to, ud, Val(:is_valid_addr_space_cast))
+custom_tti_addrspaces_may_alias_callback(from::Cuint, to::Cuint, ud::Ptr{Cvoid}) =
+    custom_tti_as_pair_dispatch(from, to, ud, Val(:addrspaces_may_alias))
+
+function custom_tti_can_have_global_initializer_in_as_callback(
+        as::Cuint, ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return state.tti.can_have_non_undef_global_initializer_in_address_space(as)::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+
+@inline function custom_tti_value_predicate_dispatch(ref::API.LLVMValueRef,
+                                                     ud::Ptr{Cvoid},
+                                                     ::Val{field})::API.LLVMBool where {field}
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return getfield(state.tti, field)(Value(ref))::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+custom_tti_is_source_of_divergence_callback(ref::API.LLVMValueRef, ud::Ptr{Cvoid}) =
+    custom_tti_value_predicate_dispatch(ref, ud, Val(:is_source_of_divergence))
+custom_tti_is_always_uniform_callback(ref::API.LLVMValueRef, ud::Ptr{Cvoid}) =
+    custom_tti_value_predicate_dispatch(ref, ud, Val(:is_always_uniform))
+
+function custom_tti_get_assumed_address_space_callback(
+        ref::API.LLVMValueRef, ud::Ptr{Cvoid})::Cuint
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        # `% Cuint` truncates modulo 2^32 rather than throwing on
+        # `typemax(UInt)` — users naturally reach for that as the "no
+        # assumption" sentinel, and we want both 32- and 64-bit spellings
+        # of ~0 to work.
+        return state.tti.get_assumed_addr_space(Value(ref))::Integer % Cuint
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return typemax(Cuint)
+    end
+end
+
+function custom_tti_get_predicated_address_space_callback(
+        ref::API.LLVMValueRef,
+        out_predicate::Ptr{API.LLVMValueRef},
+        ud::Ptr{Cvoid})::Cuint
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        (pred, as) = state.tti.get_predicated_addr_space(Value(ref))
+        pred_ref = pred === nothing ? API.LLVMValueRef(C_NULL) :
+                                      Base.unsafe_convert(API.LLVMValueRef, pred::Value)
+        unsafe_store!(out_predicate, pred_ref)
+        return as::Integer % Cuint
+    catch err
+        custom_tti_capture_exception!(state, err)
+        unsafe_store!(out_predicate, API.LLVMValueRef(C_NULL))
+        return typemax(Cuint)
+    end
+end
+
+function custom_tti_rewrite_intrinsic_with_as_callback(
+        ii::API.LLVMValueRef, old::API.LLVMValueRef, new::API.LLVMValueRef,
+        ud::Ptr{Cvoid})::API.LLVMValueRef
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        result = state.tti.rewrite_intrinsic_with_address_space(
+                     Value(ii), Value(old), Value(new))
+        result === nothing && return API.LLVMValueRef(C_NULL)
+        return Base.unsafe_convert(API.LLVMValueRef, result::Value)
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return API.LLVMValueRef(C_NULL)
+    end
+end
+
+function custom_tti_collect_flat_address_operands_callback(
+        iid::Cuint, out_ops::Ptr{Cint},
+        max_count::Cuint, out_count::Ptr{Cuint},
+        ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        ops = state.tti.collect_flat_address_operands(iid)::AbstractVector
+        n = min(length(ops), Int(max_count))
+        for i in 1:n
+            unsafe_store!(out_ops, Cint(ops[i]), i)
+        end
+        unsafe_store!(out_count, Cuint(n))
+        return !isempty(ops)
+    catch err
+        custom_tti_capture_exception!(state, err)
+        unsafe_store!(out_count, Cuint(0))
+        return false
+    end
+end
+
+# Build the C-side `LLVMTTIOptions` and attach it to the extensions
+# struct. The C side copies the options struct, but the function pointers and
+# the UD pointer (into `state`) remain live references — the returned state
+# must outlive `run!`.
+function install_custom_tti!(exts::API.LLVMPassBuilderExtensionsRef,
+                             tti::CustomTargetTransformInfo)
+    state = CustomTTIState(tti)
+    ud = Base.pointer_from_objref(state)
+
+    # For each callback field: (fnptr, userdata) if the callback is set,
+    # (C_NULL, C_NULL) otherwise.
+    cbptr(f::Nothing, _cf) = (Ptr{Cvoid}(C_NULL), Ptr{Cvoid}(C_NULL))
+    cbptr(_,          cf)  = (Base.unsafe_convert(Ptr{Cvoid}, cf), ud)
+
+    noop_cb, noop_ud = cbptr(tti.is_noop_addr_space_cast,
+        @cfunction(custom_tti_is_noop_addr_space_cast_callback,
+                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})))
+    valid_cb, valid_ud = cbptr(tti.is_valid_addr_space_cast,
+        @cfunction(custom_tti_is_valid_addr_space_cast_callback,
+                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})))
+    alias_cb, alias_ud = cbptr(tti.addrspaces_may_alias,
+        @cfunction(custom_tti_addrspaces_may_alias_callback,
+                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})))
+    ginit_cb, ginit_ud = cbptr(tti.can_have_non_undef_global_initializer_in_address_space,
+        @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
+                   API.LLVMBool, (Cuint, Ptr{Cvoid})))
+    srcdiv_cb, srcdiv_ud = cbptr(tti.is_source_of_divergence,
+        @cfunction(custom_tti_is_source_of_divergence_callback,
+                   API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})))
+    unif_cb, unif_ud = cbptr(tti.is_always_uniform,
+        @cfunction(custom_tti_is_always_uniform_callback,
+                   API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})))
+    assas_cb, assas_ud = cbptr(tti.get_assumed_addr_space,
+        @cfunction(custom_tti_get_assumed_address_space_callback,
+                   Cuint, (API.LLVMValueRef, Ptr{Cvoid})))
+    predas_cb, predas_ud = cbptr(tti.get_predicated_addr_space,
+        @cfunction(custom_tti_get_predicated_address_space_callback, Cuint,
+                   (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid})))
+    rewrite_cb, rewrite_ud = cbptr(tti.rewrite_intrinsic_with_address_space,
+        @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
+                   API.LLVMValueRef,
+                   (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid})))
+    collect_cb, collect_ud = cbptr(tti.collect_flat_address_operands,
+        @cfunction(custom_tti_collect_flat_address_operands_callback,
+                   API.LLVMBool,
+                   (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid})))
+
+    tri_state(::Nothing) = Int32(-1)
+    tri_state(x::Bool)   = Int32(x)
+
+    opts = Ref(API.LLVMTTIOptions(
+        tti.flat_address_space === nothing ? typemax(Cuint) :
+                                             Cuint(tti.flat_address_space),
+        tri_state(tti.has_branch_divergence),
+        tri_state(tti.is_single_threaded),
+        noop_cb,    noop_ud,
+        valid_cb,   valid_ud,
+        alias_cb,   alias_ud,
+        ginit_cb,   ginit_ud,
+        srcdiv_cb,  srcdiv_ud,
+        unif_cb,    unif_ud,
+        assas_cb,   assas_ud,
+        predas_cb,  predas_ud,
+        rewrite_cb, rewrite_ud,
+        collect_cb, collect_ud,
+    ))
+
+    API.LLVMPassBuilderExtensionsSetTTI(exts, opts)
+    return state
+end
+
+"""
+    target_transform_info!(pb::NewPMPassBuilder, tti::CustomTargetTransformInfo)
+    target_transform_info!(pb::NewPMPassBuilder, ::Nothing)
+
+Attach a [`CustomTargetTransformInfo`](@ref) to the pass builder, replacing any
+previously-attached custom TTI. Pass `nothing` to revert to the default TTI
+(derived from the `TargetMachine`, if any).
+"""
+function target_transform_info!(pb::NewPMPassBuilder,
+                                tti::CustomTargetTransformInfo)
+    pb.custom_tti = tti
+    return pb
+end
+
+function target_transform_info!(pb::NewPMPassBuilder, ::Nothing)
+    pb.custom_tti = nothing
+    API.LLVMPassBuilderExtensionsSetTTI(pb.exts, Ptr{API.LLVMTTIOptions}(C_NULL))
+    return pb
+end
+
 """
     run!(pb::NewPMPassBuilder, mod::Module, [tm::TargetMachine])
     run!(pipeline::String, mod::Module, [tm::TargetMachine])
@@ -294,7 +606,9 @@ function run!(pb::NewPMPassBuilder, target::Union{Module,Function}, tm::Union{No
 
     # Create state objects to hold callbacks and any caught exceptions
     states = [CustomPassState(pass.callback) for pass in pb.custom_passes]
-    GC.@preserve states aa_pipeline begin
+    tti_state = pb.custom_tti === nothing ? nothing :
+                install_custom_tti!(pb.exts, pb.custom_tti)
+    GC.@preserve states tti_state aa_pipeline begin
         # register custom passes
         for (i,pass) in enumerate(pb.custom_passes)
             if pass.type === :module
@@ -336,6 +650,10 @@ function run!(pb::NewPMPassBuilder, target::Union{Module,Function}, tm::Union{No
                 (err, bt) = state.exception
                 throw(PassException(err, bt))
             end
+        end
+        if tti_state !== nothing && tti_state.exception !== nothing
+            (err, bt) = tti_state.exception
+            throw(PassException(err, bt))
         end
     end
 end

--- a/src/newpm.jl
+++ b/src/newpm.jl
@@ -281,14 +281,14 @@ end
 export target_transform_info!
 
 function install_custom_tti!(exts::API.LLVMPassBuilderExtensionsRef,
-                             tti::AbstractTargetTransformInfo)
+                              tti::AbstractTargetTransformInfo)
     state, opts = build_custom_tti_options(tti)
     API.LLVMPassBuilderExtensionsSetTTI(exts, opts)
-    # Return both: `state` owns the CustomTTIState (exception capture +
-    # `ud` backing pointer); `opts` owns the `LLVMTTIOptions` Ref that
-    # holds the `@cfunction` handles. Both must stay GC-rooted until
-    # `run!` completes.
-    return state, opts
+    # `SetTTI` copies the options into the extensions, so `opts` can be freed
+    # right away. `state` backs the `UserData` pointer the C++ side kept and
+    # must stay GC-rooted until `run!` completes.
+    API.LLVMDisposeTTIOptions(opts)
+    return state
 end
 
 """
@@ -309,7 +309,7 @@ end
 
 function target_transform_info!(pb::NewPMPassBuilder, ::Nothing)
     pb.custom_tti = nothing
-    API.LLVMPassBuilderExtensionsSetTTI(pb.exts, Ptr{API.LLVMTTIOptions}(C_NULL))
+    API.LLVMPassBuilderExtensionsSetTTI(pb.exts, API.LLVMTTIOptionsRef(C_NULL))
     return pb
 end
 
@@ -333,9 +333,9 @@ function run!(pb::NewPMPassBuilder, target::Union{Module,Function}, tm::Union{No
 
     # Create state objects to hold callbacks and any caught exceptions
     states = [CustomPassState(pass.callback) for pass in pb.custom_passes]
-    tti_state, tti_opts = pb.custom_tti === nothing ? (nothing, nothing) :
-                          install_custom_tti!(pb.exts, pb.custom_tti)
-    GC.@preserve states tti_state tti_opts aa_pipeline begin
+    tti_state = pb.custom_tti === nothing ? nothing :
+                install_custom_tti!(pb.exts, pb.custom_tti)
+    GC.@preserve states tti_state aa_pipeline begin
         # register custom passes
         for (i,pass) in enumerate(pb.custom_passes)
             if pass.type === :module

--- a/src/targetinfo.jl
+++ b/src/targetinfo.jl
@@ -3,8 +3,7 @@
 # Abstract type + query function declarations, plus the @cfunction trampolines
 # that let passes reach those methods through the C API. Subtypes override
 # only the queries they care about; anything they don't override is not wired
-# up on the C side and LLVM's `TargetTransformInfoImplBase` handles it. LLVM
-# stays the single source of truth for baseline behavior.
+# up on the C side and LLVM's `TargetTransformInfoImplBase` handles it.
 
 export AbstractTargetTransformInfo
 
@@ -32,13 +31,11 @@ passes such as `InferAddressSpacesPass` or `UniformityAnalysis` silently
 no-op.
 
 Subtypes override only the queries they care about; any query left
-un-overridden is handled by LLVM's `TargetTransformInfoImplBase` — there is
-no Julia-side default that could drift from LLVM's baseline.
+un-overridden is handled by LLVM's `TargetTransformInfoImplBase`.
 
 Attach an instance with [`target_transform_info!`](@ref); attaching `nothing`
 reverts to LLVM's native TTI. When a `TargetMachine` is also supplied to
-[`run!`](@ref), a custom TTI takes precedence — so this type is usable as a
-one-off override on top of an existing target as well.
+[`run!`](@ref), a custom TTI takes precedence.
 
 Overridable queries:
 
@@ -54,10 +51,6 @@ Overridable queries:
   [`collect_flat_address_operands`](@ref).
 """
 abstract type AbstractTargetTransformInfo end
-
-# Query functions are declared without default methods. Subtypes add a method
-# for each query they want to override; anything left unimplemented is
-# detected by `hasmethod` at pipeline-build time and left to LLVM's baseline.
 
 """
     flat_address_space(tti::AbstractTargetTransformInfo) -> Unsigned
@@ -191,7 +184,7 @@ end
 # `@cfunction`'d. They swallow exceptions and record them on the state —
 # LLVM must not see a Julia exception unwind into C.
 
-function custom_tti_capture_exception!(state::CustomTTIState, err)
+function capture_exception!(state::CustomTTIState, err)
     # Keep the first caught exception; ignore subsequent ones from the same run.
     if state.exception === nothing
         state.exception = (err, Base.catch_backtrace())
@@ -204,7 +197,7 @@ function custom_tti_is_noop_addr_space_cast_callback(from::Cuint, to::Cuint,
     try
         return is_noop_addr_space_cast(state.tti, UInt(from), UInt(to))::Bool
     catch err
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         return false
     end
 end
@@ -215,7 +208,7 @@ function custom_tti_is_valid_addr_space_cast_callback(from::Cuint, to::Cuint,
     try
         return is_valid_addr_space_cast(state.tti, UInt(from), UInt(to))::Bool
     catch err
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         return false
     end
 end
@@ -229,7 +222,7 @@ function custom_tti_addrspaces_may_alias_callback(as0::Cuint, as1::Cuint,
         # Conservative default on exception: may alias. Matches LLVM's BaseT
         # and avoids the risk of incorrect optimization on partially-transformed
         # IR before the captured exception is re-raised.
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         return true
     end
 end
@@ -241,7 +234,7 @@ function custom_tti_can_have_global_initializer_in_as_callback(as::Cuint,
         return can_have_non_undef_global_initializer_in_address_space(
                    state.tti, UInt(as))::Bool
     catch err
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         return false
     end
 end
@@ -252,7 +245,7 @@ function custom_tti_is_source_of_divergence_callback(ref::API.LLVMValueRef,
     try
         return is_source_of_divergence(state.tti, Value(ref))::Bool
     catch err
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         return false
     end
 end
@@ -263,7 +256,7 @@ function custom_tti_is_always_uniform_callback(ref::API.LLVMValueRef,
     try
         return is_always_uniform(state.tti, Value(ref))::Bool
     catch err
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         return false
     end
 end
@@ -278,7 +271,7 @@ function custom_tti_get_assumed_address_space_callback(ref::API.LLVMValueRef,
         # of ~0 to work.
         return get_assumed_addr_space(state.tti, Value(ref))::Integer % Cuint
     catch err
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         return typemax(Cuint)
     end
 end
@@ -295,7 +288,7 @@ function custom_tti_get_predicated_address_space_callback(
         unsafe_store!(out_predicate, pred_ref)
         return as::Integer % Cuint
     catch err
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         unsafe_store!(out_predicate, API.LLVMValueRef(C_NULL))
         return typemax(Cuint)
     end
@@ -311,7 +304,7 @@ function custom_tti_rewrite_intrinsic_with_as_callback(
         result === nothing && return API.LLVMValueRef(C_NULL)
         return Base.unsafe_convert(API.LLVMValueRef, result::Value)
     catch err
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         return API.LLVMValueRef(C_NULL)
     end
 end
@@ -330,7 +323,7 @@ function custom_tti_collect_flat_address_operands_callback(
         unsafe_store!(out_count, Cuint(n))
         return n > 0
     catch err
-        custom_tti_capture_exception!(state, err)
+        capture_exception!(state, err)
         unsafe_store!(out_count, Cuint(0))
         return false
     end
@@ -342,7 +335,7 @@ end
 # must be freed with `API.LLVMDisposeTTIOptions` afterwards.
 function build_custom_tti_options(tti::AbstractTargetTransformInfo)
     state = CustomTTIState(tti)
-    ud = Base.pointer_from_objref(state)
+    ud = Ref(state)
     opts = API.LLVMCreateTTIOptions()
 
     T = typeof(tti)

--- a/src/targetinfo.jl
+++ b/src/targetinfo.jl
@@ -1,0 +1,314 @@
+# Custom TargetTransformInfo
+#
+# Abstract type + default methods that mirror LLVM's `TargetTransformInfoImplBase`,
+# plus the @cfunction trampolines that let passes reach those methods through
+# the C API. Consumers (e.g. `newpm.jl`) plug these into whichever pipeline
+# they wrap.
+
+export AbstractTargetTransformInfo
+
+# The query methods below are meant to be overridden on subtypes.
+@public flat_address_space, has_branch_divergence, is_single_threaded,
+        is_noop_addr_space_cast, is_valid_addr_space_cast, addrspaces_may_alias,
+        can_have_non_undef_global_initializer_in_address_space,
+        is_source_of_divergence, is_always_uniform,
+        get_assumed_addr_space, get_predicated_addr_space,
+        rewrite_intrinsic_with_address_space, collect_flat_address_operands
+
+"""
+    abstract type AbstractTargetTransformInfo
+
+Subtype this and override the query methods to supply a `TargetTransformInfo`
+for pipelines that lack a `TargetMachine` (e.g. out-of-tree backends invoked
+through a CLI) where the default TTI would otherwise be the conservative
+baseline and disable TTI-sensitive passes such as `InferAddressSpacesPass` or
+`UniformityAnalysis`.
+
+Only the subset of TTI hooks relevant to those passes is exposed; each has a
+default method on `AbstractTargetTransformInfo` that matches LLVM's
+`TargetTransformInfoImplBase` behavior, so subtypes only need to override the
+queries they care about.
+
+Attach an instance with [`target_transform_info!`](@ref). To run a pipeline
+against LLVM's native TTI (including `TargetMachine`-derived and
+`DataLayout`/`Module`-dependent defaults), pass `nothing` instead of an
+instance — no callbacks are registered in that case.
+
+# Simple knobs
+
+- [`flat_address_space`](@ref)`(tti) -> UInt`: address space LLVM should treat
+  as "flat" / generic. Required for `InferAddressSpacesPass` and for folding
+  `addrspacecast`s. Default: `typemax(UInt)` (no flat AS).
+- [`has_branch_divergence`](@ref)`(tti) -> Bool`: whether this target can
+  produce divergent control flow. Default: `false`.
+- [`is_single_threaded`](@ref)`(tti) -> Bool`: whether this target is
+  single-threaded. Default: `false`.
+
+# Address-space predicates
+
+- [`is_noop_addr_space_cast`](@ref)`(tti, from, to) -> Bool`: whether an
+  addrspacecast between the given AS pair is a noop. Required (alongside
+  `flat_address_space`) for `InferAddressSpacesPass` to actually fold casts.
+  Default: `false`.
+- [`is_valid_addr_space_cast`](@ref)`(tti, from, to) -> Bool`. Default: `false`.
+- [`addrspaces_may_alias`](@ref)`(tti, as0, as1) -> Bool`. Default: `true`
+  (conservative — pointers may alias unless proven otherwise).
+- [`can_have_non_undef_global_initializer_in_address_space`](@ref)`(tti, as) -> Bool`.
+  Default: `true`. LLVM's real baseline also considers
+  `DataLayout::isNonIntegralAddressSpace`, which isn't reachable from a
+  Julia-side default; override if your target has non-integral ASes.
+
+# Value-oriented queries
+
+- [`is_source_of_divergence`](@ref)`(tti, v::Value) -> Bool`. Default: `false`.
+- [`is_always_uniform`](@ref)`(tti, v::Value) -> Bool`. Default: `false`.
+- [`get_assumed_addr_space`](@ref)`(tti, v::Value) -> Unsigned`: an AS known to
+  hold for this value, or `typemax(UInt)` for "no assumption". Default:
+  `typemax(UInt)`.
+- [`get_predicated_addr_space`](@ref)`(tti, v::Value) -> (predicate, as)`: an
+  AS that holds when `predicate::Union{Value,Nothing}` is true. Default:
+  `(nothing, typemax(UInt))`.
+
+# Intrinsic hooks
+
+- [`rewrite_intrinsic_with_address_space`](@ref)`(tti, ii::Value, old::Value, new::Value) -> Union{Value,Nothing}`.
+  Default: `nothing` (no rewrite).
+- [`collect_flat_address_operands`](@ref)`(tti, iid::UInt) -> Vector{Int}`:
+  flat-AS pointer operand indices of intrinsic `iid`. Capped at 32 entries.
+  Default: `Int[]`.
+"""
+abstract type AbstractTargetTransformInfo end
+
+# Defaults matching LLVM's `TargetTransformInfoImplBase`. Two queries
+# (`can_have_non_undef_global_initializer_in_address_space`, `is_single_threaded`)
+# have LLVM baselines that depend on `DataLayout`/`Module` state not reachable
+# from these callbacks; we pick the common-case static answer and document that
+# subtypes must override if they need the full LLVM behavior.
+flat_address_space(::AbstractTargetTransformInfo) = typemax(UInt)
+has_branch_divergence(::AbstractTargetTransformInfo) = false
+is_single_threaded(::AbstractTargetTransformInfo) = false
+
+is_noop_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
+is_valid_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
+addrspaces_may_alias(::AbstractTargetTransformInfo, as0::Unsigned, as1::Unsigned) = true
+can_have_non_undef_global_initializer_in_address_space(::AbstractTargetTransformInfo, as::Unsigned) = true
+
+is_source_of_divergence(::AbstractTargetTransformInfo, v::Value) = false
+is_always_uniform(::AbstractTargetTransformInfo, v::Value) = false
+get_assumed_addr_space(::AbstractTargetTransformInfo, v::Value) = typemax(UInt)
+get_predicated_addr_space(::AbstractTargetTransformInfo, v::Value) =
+    (nothing, typemax(UInt))
+
+rewrite_intrinsic_with_address_space(::AbstractTargetTransformInfo,
+                                     ii::Value, old::Value, new::Value) = nothing
+collect_flat_address_operands(::AbstractTargetTransformInfo, iid::Unsigned) = Int[]
+
+# Mutable shim that holds the `AbstractTargetTransformInfo` alongside any
+# caught exception. A pointer to this object is passed to C as the `UserData`
+# for every callback, and the trampolines unwrap it to dispatch.
+mutable struct CustomTTIState
+    tti::AbstractTargetTransformInfo
+    exception::Union{Nothing,Tuple{Any,Vector}}
+    CustomTTIState(tti) = new(tti, nothing)
+end
+
+# Each trampoline is a top-level (non-closure) function so it can be
+# `@cfunction`'d. They swallow exceptions and record them on the state —
+# LLVM must not see a Julia exception unwind into C.
+
+function custom_tti_capture_exception!(state::CustomTTIState, err)
+    # Keep the first caught exception; ignore subsequent ones from the same run.
+    if state.exception === nothing
+        state.exception = (err, Base.catch_backtrace())
+    end
+end
+
+function custom_tti_is_noop_addr_space_cast_callback(from::Cuint, to::Cuint,
+                                                     ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return is_noop_addr_space_cast(state.tti, UInt(from), UInt(to))::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+
+function custom_tti_is_valid_addr_space_cast_callback(from::Cuint, to::Cuint,
+                                                      ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return is_valid_addr_space_cast(state.tti, UInt(from), UInt(to))::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+
+function custom_tti_addrspaces_may_alias_callback(as0::Cuint, as1::Cuint,
+                                                  ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return addrspaces_may_alias(state.tti, UInt(as0), UInt(as1))::Bool
+    catch err
+        # Conservative default on exception: may alias. Matches LLVM's BaseT
+        # and avoids the risk of incorrect optimization on partially-transformed
+        # IR before the captured exception is re-raised.
+        custom_tti_capture_exception!(state, err)
+        return true
+    end
+end
+
+function custom_tti_can_have_global_initializer_in_as_callback(as::Cuint,
+                                                               ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return can_have_non_undef_global_initializer_in_address_space(
+                   state.tti, UInt(as))::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+
+function custom_tti_is_source_of_divergence_callback(ref::API.LLVMValueRef,
+                                                     ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return is_source_of_divergence(state.tti, Value(ref))::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+
+function custom_tti_is_always_uniform_callback(ref::API.LLVMValueRef,
+                                               ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        return is_always_uniform(state.tti, Value(ref))::Bool
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return false
+    end
+end
+
+function custom_tti_get_assumed_address_space_callback(ref::API.LLVMValueRef,
+                                                       ud::Ptr{Cvoid})::Cuint
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        # `% Cuint` truncates modulo 2^32 rather than throwing on
+        # `typemax(UInt)` — users naturally reach for that as the "no
+        # assumption" sentinel, and we want both 32- and 64-bit spellings
+        # of ~0 to work.
+        return get_assumed_addr_space(state.tti, Value(ref))::Integer % Cuint
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return typemax(Cuint)
+    end
+end
+
+function custom_tti_get_predicated_address_space_callback(
+        ref::API.LLVMValueRef,
+        out_predicate::Ptr{API.LLVMValueRef},
+        ud::Ptr{Cvoid})::Cuint
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        (pred, as) = get_predicated_addr_space(state.tti, Value(ref))
+        pred_ref = pred === nothing ? API.LLVMValueRef(C_NULL) :
+                                      Base.unsafe_convert(API.LLVMValueRef, pred::Value)
+        unsafe_store!(out_predicate, pred_ref)
+        return as::Integer % Cuint
+    catch err
+        custom_tti_capture_exception!(state, err)
+        unsafe_store!(out_predicate, API.LLVMValueRef(C_NULL))
+        return typemax(Cuint)
+    end
+end
+
+function custom_tti_rewrite_intrinsic_with_as_callback(
+        ii::API.LLVMValueRef, old::API.LLVMValueRef, new::API.LLVMValueRef,
+        ud::Ptr{Cvoid})::API.LLVMValueRef
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        result = rewrite_intrinsic_with_address_space(state.tti,
+                     Value(ii), Value(old), Value(new))
+        result === nothing && return API.LLVMValueRef(C_NULL)
+        return Base.unsafe_convert(API.LLVMValueRef, result::Value)
+    catch err
+        custom_tti_capture_exception!(state, err)
+        return API.LLVMValueRef(C_NULL)
+    end
+end
+
+function custom_tti_collect_flat_address_operands_callback(
+        iid::Cuint, out_ops::Ptr{Cint},
+        max_count::Cuint, out_count::Ptr{Cuint},
+        ud::Ptr{Cvoid})::API.LLVMBool
+    state = Base.unsafe_pointer_to_objref(ud)::CustomTTIState
+    try
+        ops = collect_flat_address_operands(state.tti, UInt(iid))::AbstractVector
+        n = min(length(ops), Int(max_count))
+        for i in 1:n
+            unsafe_store!(out_ops, Cint(ops[i]), i)
+        end
+        unsafe_store!(out_count, Cuint(n))
+        return n > 0
+    catch err
+        custom_tti_capture_exception!(state, err)
+        unsafe_store!(out_count, Cuint(0))
+        return false
+    end
+end
+
+# Build the C-side `LLVMTTIOptions` struct from the TTI object. Returns a
+# `(state, opts_ref)` pair; callers pass `opts_ref` to whatever
+# `…SetTTI` entrypoint their pipeline wrapper exposes, and must keep both
+# `state` and `opts_ref` alive for the duration of the pipeline run.
+function build_custom_tti_options(tti::AbstractTargetTransformInfo)
+    state = CustomTTIState(tti)
+    ud = Base.pointer_from_objref(state)
+
+    noop_cb = @cfunction(custom_tti_is_noop_addr_space_cast_callback,
+                         API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
+    valid_cb = @cfunction(custom_tti_is_valid_addr_space_cast_callback,
+                          API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
+    alias_cb = @cfunction(custom_tti_addrspaces_may_alias_callback,
+                          API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
+    ginit_cb = @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
+                          API.LLVMBool, (Cuint, Ptr{Cvoid}))
+    srcdiv_cb = @cfunction(custom_tti_is_source_of_divergence_callback,
+                           API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
+    unif_cb = @cfunction(custom_tti_is_always_uniform_callback,
+                         API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
+    assas_cb = @cfunction(custom_tti_get_assumed_address_space_callback,
+                          Cuint, (API.LLVMValueRef, Ptr{Cvoid}))
+    predas_cb = @cfunction(custom_tti_get_predicated_address_space_callback,
+                           Cuint, (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid}))
+    rewrite_cb = @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
+                            API.LLVMValueRef,
+                            (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid}))
+    collect_cb = @cfunction(custom_tti_collect_flat_address_operands_callback,
+                            API.LLVMBool,
+                            (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid}))
+
+    p(cf) = Base.unsafe_convert(Ptr{Cvoid}, cf)
+
+    opts = Ref(API.LLVMTTIOptions(
+        flat_address_space(tti) % Cuint,
+        Int32(has_branch_divergence(tti)),
+        Int32(is_single_threaded(tti)),
+        p(noop_cb),    ud,
+        p(valid_cb),   ud,
+        p(alias_cb),   ud,
+        p(ginit_cb),   ud,
+        p(srcdiv_cb),  ud,
+        p(unif_cb),    ud,
+        p(assas_cb),   ud,
+        p(predas_cb),  ud,
+        p(rewrite_cb), ud,
+        p(collect_cb), ud,
+    ))
+
+    return state, opts
+end

--- a/src/targetinfo.jl
+++ b/src/targetinfo.jl
@@ -349,59 +349,72 @@ function build_custom_tti_options(tti::AbstractTargetTransformInfo)
 
     # Scalar fields: only set when the subtype has an override. Unset fields
     # leave LLVM's `TargetTransformInfoImplBase` to answer the query.
-    hasmethod(flat_address_space, Tuple{T}) &&
+    if hasmethod(flat_address_space, Tuple{T})
         API.LLVMTTIOptionsSetFlatAddressSpace(opts, flat_address_space(tti) % Cuint)
-    hasmethod(has_branch_divergence, Tuple{T}) &&
+    end
+    if hasmethod(has_branch_divergence, Tuple{T})
         API.LLVMTTIOptionsSetHasBranchDivergence(opts, has_branch_divergence(tti))
-    hasmethod(is_single_threaded, Tuple{T}) &&
+    end
+    if hasmethod(is_single_threaded, Tuple{T})
         API.LLVMTTIOptionsSetIsSingleThreaded(opts, is_single_threaded(tti))
+    end
 
     # Callbacks: install the @cfunction trampoline only when a concrete
     # override exists for this subtype.
-    hasmethod(is_noop_addr_space_cast, Tuple{T, Unsigned, Unsigned}) &&
-        API.LLVMTTIOptionsSetIsNoopAddrSpaceCast(opts,
-            @cfunction(custom_tti_is_noop_addr_space_cast_callback,
-                       API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
-    hasmethod(is_valid_addr_space_cast, Tuple{T, Unsigned, Unsigned}) &&
-        API.LLVMTTIOptionsSetIsValidAddrSpaceCast(opts,
-            @cfunction(custom_tti_is_valid_addr_space_cast_callback,
-                       API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
-    hasmethod(addrspaces_may_alias, Tuple{T, Unsigned, Unsigned}) &&
-        API.LLVMTTIOptionsSetAddrSpacesMayAlias(opts,
-            @cfunction(custom_tti_addrspaces_may_alias_callback,
-                       API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
-    hasmethod(can_have_non_undef_global_initializer_in_address_space,
-              Tuple{T, Unsigned}) &&
-        API.LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(opts,
-            @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
-                       API.LLVMBool, (Cuint, Ptr{Cvoid})), ud)
-    hasmethod(is_source_of_divergence, Tuple{T, Value}) &&
-        API.LLVMTTIOptionsSetIsSourceOfDivergence(opts,
-            @cfunction(custom_tti_is_source_of_divergence_callback,
-                       API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})), ud)
-    hasmethod(is_always_uniform, Tuple{T, Value}) &&
-        API.LLVMTTIOptionsSetIsAlwaysUniform(opts,
-            @cfunction(custom_tti_is_always_uniform_callback,
-                       API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})), ud)
-    hasmethod(get_assumed_addr_space, Tuple{T, Value}) &&
-        API.LLVMTTIOptionsSetGetAssumedAddressSpace(opts,
-            @cfunction(custom_tti_get_assumed_address_space_callback,
-                       Cuint, (API.LLVMValueRef, Ptr{Cvoid})), ud)
-    hasmethod(get_predicated_addr_space, Tuple{T, Value}) &&
-        API.LLVMTTIOptionsSetGetPredicatedAddressSpace(opts,
-            @cfunction(custom_tti_get_predicated_address_space_callback,
-                       Cuint, (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid})), ud)
-    hasmethod(rewrite_intrinsic_with_address_space,
-              Tuple{T, Value, Value, Value}) &&
-        API.LLVMTTIOptionsSetRewriteIntrinsicWithAS(opts,
-            @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
-                       API.LLVMValueRef,
-                       (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid})), ud)
-    hasmethod(collect_flat_address_operands, Tuple{T, Unsigned}) &&
-        API.LLVMTTIOptionsSetCollectFlatAddressOperands(opts,
-            @cfunction(custom_tti_collect_flat_address_operands_callback,
-                       API.LLVMBool,
-                       (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid})), ud)
+    if hasmethod(is_noop_addr_space_cast, Tuple{T, Unsigned, Unsigned})
+        cb = @cfunction(custom_tti_is_noop_addr_space_cast_callback,
+                        API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetIsNoopAddrSpaceCast(opts, cb, ud)
+    end
+    if hasmethod(is_valid_addr_space_cast, Tuple{T, Unsigned, Unsigned})
+        cb = @cfunction(custom_tti_is_valid_addr_space_cast_callback,
+                        API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetIsValidAddrSpaceCast(opts, cb, ud)
+    end
+    if hasmethod(addrspaces_may_alias, Tuple{T, Unsigned, Unsigned})
+        cb = @cfunction(custom_tti_addrspaces_may_alias_callback,
+                        API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetAddrSpacesMayAlias(opts, cb, ud)
+    end
+    if hasmethod(can_have_non_undef_global_initializer_in_address_space,
+                 Tuple{T, Unsigned})
+        cb = @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
+                        API.LLVMBool, (Cuint, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(opts, cb, ud)
+    end
+    if hasmethod(is_source_of_divergence, Tuple{T, Value})
+        cb = @cfunction(custom_tti_is_source_of_divergence_callback,
+                        API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetIsSourceOfDivergence(opts, cb, ud)
+    end
+    if hasmethod(is_always_uniform, Tuple{T, Value})
+        cb = @cfunction(custom_tti_is_always_uniform_callback,
+                        API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetIsAlwaysUniform(opts, cb, ud)
+    end
+    if hasmethod(get_assumed_addr_space, Tuple{T, Value})
+        cb = @cfunction(custom_tti_get_assumed_address_space_callback,
+                        Cuint, (API.LLVMValueRef, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetGetAssumedAddressSpace(opts, cb, ud)
+    end
+    if hasmethod(get_predicated_addr_space, Tuple{T, Value})
+        cb = @cfunction(custom_tti_get_predicated_address_space_callback,
+                        Cuint, (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetGetPredicatedAddressSpace(opts, cb, ud)
+    end
+    if hasmethod(rewrite_intrinsic_with_address_space,
+                 Tuple{T, Value, Value, Value})
+        cb = @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
+                        API.LLVMValueRef,
+                        (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetRewriteIntrinsicWithAS(opts, cb, ud)
+    end
+    if hasmethod(collect_flat_address_operands, Tuple{T, Unsigned})
+        cb = @cfunction(custom_tti_collect_flat_address_operands_callback,
+                        API.LLVMBool,
+                        (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid}))
+        API.LLVMTTIOptionsSetCollectFlatAddressOperands(opts, cb, ud)
+    end
 
     return state, opts
 end

--- a/src/targetinfo.jl
+++ b/src/targetinfo.jl
@@ -18,64 +18,39 @@ export AbstractTargetTransformInfo
 """
     abstract type AbstractTargetTransformInfo
 
-Subtype this and override the query methods to supply a `TargetTransformInfo`
-for pipelines that lack a `TargetMachine` (e.g. out-of-tree backends invoked
-through a CLI) where the default TTI would otherwise be the conservative
-baseline and disable TTI-sensitive passes such as `InferAddressSpacesPass` or
-`UniformityAnalysis`.
+Subtype this to supply a custom `TargetTransformInfo` to pass pipelines that
+would otherwise see only LLVM's conservative baseline.
 
-Only the subset of TTI hooks relevant to those passes is exposed; each has a
-default method on `AbstractTargetTransformInfo` that matches LLVM's
-`TargetTransformInfoImplBase` behavior, so subtypes only need to override the
-queries they care about.
+Most LLVM back-ends (host CPU, NVPTX, AMDGPU) carry their own TTI through a
+`TargetMachine`; callers that already have one and pass it to
+[`run!`](@ref) don't need this. The feature is aimed at **out-of-tree
+back-ends not linked into libLLVM** (e.g. Metal) and at tooling that runs
+passes without a `TargetMachine` at all. In those pipelines, the baseline TTI
+reports no flat address space, no branch divergence, etc., and TTI-sensitive
+passes such as `InferAddressSpacesPass` or `UniformityAnalysis` silently
+no-op.
 
-Attach an instance with [`target_transform_info!`](@ref). To run a pipeline
-against LLVM's native TTI (including `TargetMachine`-derived and
-`DataLayout`/`Module`-dependent defaults), pass `nothing` instead of an
-instance — no callbacks are registered in that case.
+Each exposed query has a default method on `AbstractTargetTransformInfo` that
+matches LLVM's `TargetTransformInfoImplBase`, so subtypes override only what
+they need.
 
-# Simple knobs
+Attach an instance with [`target_transform_info!`](@ref); attaching `nothing`
+reverts to LLVM's native TTI. When a `TargetMachine` is also supplied to
+[`run!`](@ref), a custom TTI takes precedence — so this type is usable as a
+one-off override on top of an existing target as well.
 
-- [`flat_address_space`](@ref)`(tti) -> UInt`: address space LLVM should treat
-  as "flat" / generic. Required for `InferAddressSpacesPass` and for folding
-  `addrspacecast`s. Default: `typemax(UInt)` (no flat AS).
-- [`has_branch_divergence`](@ref)`(tti) -> Bool`: whether this target can
-  produce divergent control flow. Default: `false`.
-- [`is_single_threaded`](@ref)`(tti) -> Bool`: whether this target is
-  single-threaded. Default: `false`.
+Overridable queries:
 
-# Address-space predicates
-
-- [`is_noop_addr_space_cast`](@ref)`(tti, from, to) -> Bool`: whether an
-  addrspacecast between the given AS pair is a noop. Required (alongside
-  `flat_address_space`) for `InferAddressSpacesPass` to actually fold casts.
-  Default: `false`.
-- [`is_valid_addr_space_cast`](@ref)`(tti, from, to) -> Bool`. Default: `false`.
-- [`addrspaces_may_alias`](@ref)`(tti, as0, as1) -> Bool`. Default: `true`
-  (conservative — pointers may alias unless proven otherwise).
-- [`can_have_non_undef_global_initializer_in_address_space`](@ref)`(tti, as) -> Bool`.
-  Default: `true`. LLVM's real baseline also considers
-  `DataLayout::isNonIntegralAddressSpace`, which isn't reachable from a
-  Julia-side default; override if your target has non-integral ASes.
-
-# Value-oriented queries
-
-- [`is_source_of_divergence`](@ref)`(tti, v::Value) -> Bool`. Default: `false`.
-- [`is_always_uniform`](@ref)`(tti, v::Value) -> Bool`. Default: `false`.
-- [`get_assumed_addr_space`](@ref)`(tti, v::Value) -> Unsigned`: an AS known to
-  hold for this value, or `typemax(UInt)` for "no assumption". Default:
-  `typemax(UInt)`.
-- [`get_predicated_addr_space`](@ref)`(tti, v::Value) -> (predicate, as)`: an
-  AS that holds when `predicate::Union{Value,Nothing}` is true. Default:
-  `(nothing, typemax(UInt))`.
-
-# Intrinsic hooks
-
-- [`rewrite_intrinsic_with_address_space`](@ref)`(tti, ii::Value, old::Value, new::Value) -> Union{Value,Nothing}`.
-  Default: `nothing` (no rewrite).
-- [`collect_flat_address_operands`](@ref)`(tti, iid::UInt) -> Vector{Int}`:
-  flat-AS pointer operand indices of intrinsic `iid`. Capped at 32 entries.
-  Default: `Int[]`.
+- Target-level knobs: [`flat_address_space`](@ref),
+  [`has_branch_divergence`](@ref), [`is_single_threaded`](@ref).
+- Address-space predicates: [`is_noop_addr_space_cast`](@ref),
+  [`is_valid_addr_space_cast`](@ref), [`addrspaces_may_alias`](@ref),
+  [`can_have_non_undef_global_initializer_in_address_space`](@ref).
+- Per-`Value` queries: [`is_source_of_divergence`](@ref),
+  [`is_always_uniform`](@ref), [`get_assumed_addr_space`](@ref),
+  [`get_predicated_addr_space`](@ref).
+- Intrinsic hooks: [`rewrite_intrinsic_with_address_space`](@ref),
+  [`collect_flat_address_operands`](@ref).
 """
 abstract type AbstractTargetTransformInfo end
 
@@ -84,23 +59,123 @@ abstract type AbstractTargetTransformInfo end
 # have LLVM baselines that depend on `DataLayout`/`Module` state not reachable
 # from these callbacks; we pick the common-case static answer and document that
 # subtypes must override if they need the full LLVM behavior.
+
+"""
+    flat_address_space(tti::AbstractTargetTransformInfo) -> UInt
+
+Address space the target treats as "flat" / generic. Required — alongside
+[`is_noop_addr_space_cast`](@ref) — for `InferAddressSpacesPass` to fold
+`addrspacecast`s. Default: `typemax(UInt)` (no flat AS).
+"""
 flat_address_space(::AbstractTargetTransformInfo) = typemax(UInt)
+
+"""
+    has_branch_divergence(tti::AbstractTargetTransformInfo) -> Bool
+
+Whether the target can produce divergent control flow. Enables
+divergence-aware passes (`SimplifyCFG`, loop analyses) when true. Default:
+`false`.
+"""
 has_branch_divergence(::AbstractTargetTransformInfo) = false
+
+"""
+    is_single_threaded(tti::AbstractTargetTransformInfo) -> Bool
+
+Whether the target is single-threaded. A few passes skip concurrency-related
+transformations when true. Default: `false`. LLVM's actual baseline also
+consults the module's `"single-thread"` flag — override if you rely on that.
+"""
 is_single_threaded(::AbstractTargetTransformInfo) = false
 
+"""
+    is_noop_addr_space_cast(tti::AbstractTargetTransformInfo,
+                            from::Unsigned, to::Unsigned) -> Bool
+
+Whether an `addrspacecast` from `from` to `to` is a noop at runtime. Default:
+`false`.
+"""
 is_noop_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
+
+"""
+    is_valid_addr_space_cast(tti::AbstractTargetTransformInfo,
+                             from::Unsigned, to::Unsigned) -> Bool
+
+Whether an `addrspacecast` from `from` to `to` is permitted. Default: `false`.
+"""
 is_valid_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
+
+"""
+    addrspaces_may_alias(tti::AbstractTargetTransformInfo,
+                         as0::Unsigned, as1::Unsigned) -> Bool
+
+Whether pointers in address spaces `as0` and `as1` may alias. Default: `true`
+(conservative — pointers may alias unless proven otherwise).
+"""
 addrspaces_may_alias(::AbstractTargetTransformInfo, as0::Unsigned, as1::Unsigned) = true
+
+"""
+    can_have_non_undef_global_initializer_in_address_space(
+        tti::AbstractTargetTransformInfo, as::Unsigned) -> Bool
+
+Whether globals in address space `as` may have non-`undef` initializers.
+Default: `true`. LLVM's real baseline additionally consults
+`DataLayout::isNonIntegralAddressSpace`, which this default can't reach —
+override if the target has non-integral address spaces.
+"""
 can_have_non_undef_global_initializer_in_address_space(::AbstractTargetTransformInfo, as::Unsigned) = true
 
+"""
+    is_source_of_divergence(tti::AbstractTargetTransformInfo, v::Value) -> Bool
+
+Whether `v` is a source of divergence. Consulted by `UniformityAnalysis`.
+Default: `false`.
+"""
 is_source_of_divergence(::AbstractTargetTransformInfo, v::Value) = false
+
+"""
+    is_always_uniform(tti::AbstractTargetTransformInfo, v::Value) -> Bool
+
+Whether `v` is known to hold the same value across all threads. Consulted by
+`UniformityAnalysis`. Default: `false`.
+"""
 is_always_uniform(::AbstractTargetTransformInfo, v::Value) = false
+
+"""
+    get_assumed_addr_space(tti::AbstractTargetTransformInfo, v::Value) -> Unsigned
+
+Address space statically known to hold for `v`, or `typemax(UInt)` for "no
+assumption". Default: `typemax(UInt)`.
+"""
 get_assumed_addr_space(::AbstractTargetTransformInfo, v::Value) = typemax(UInt)
+
+"""
+    get_predicated_addr_space(tti::AbstractTargetTransformInfo, v::Value)
+        -> (predicate::Union{Value,Nothing}, as::Unsigned)
+
+Address space that holds for `v` when `predicate` is true. Return
+`(nothing, typemax(UInt))` for "no inference". Default: that sentinel.
+"""
 get_predicated_addr_space(::AbstractTargetTransformInfo, v::Value) =
     (nothing, typemax(UInt))
 
+"""
+    rewrite_intrinsic_with_address_space(tti::AbstractTargetTransformInfo,
+        ii::Value, old::Value, new::Value) -> Union{Value,Nothing}
+
+Rewrite an intrinsic call `ii` after its pointer operand `old` has been
+replaced by `new` (in a different address space). Return the rewritten value,
+or `nothing` to keep the existing call. Default: `nothing`.
+"""
 rewrite_intrinsic_with_address_space(::AbstractTargetTransformInfo,
                                      ii::Value, old::Value, new::Value) = nothing
+
+"""
+    collect_flat_address_operands(tti::AbstractTargetTransformInfo, iid::Unsigned)
+        -> Vector{Int}
+
+Operand indices of intrinsic `iid` that are flat-address-space pointer
+operands. Capped at 32 entries by the underlying C API. Default: `Int[]`.
+"""
 collect_flat_address_operands(::AbstractTargetTransformInfo, iid::Unsigned) = Int[]
 
 # Mutable shim that holds the `AbstractTargetTransformInfo` alongside any

--- a/src/targetinfo.jl
+++ b/src/targetinfo.jl
@@ -336,54 +336,51 @@ function custom_tti_collect_flat_address_operands_callback(
     end
 end
 
-# Build the C-side `LLVMTTIOptions` struct from the TTI object. Returns a
-# `(state, opts_ref)` pair; callers pass `opts_ref` to whatever
-# `…SetTTI` entrypoint their pipeline wrapper exposes, and must keep both
-# `state` and `opts_ref` alive for the duration of the pipeline run.
+# Allocate an `LLVMTTIOptionsRef` populated from the TTI object, along with
+# the `CustomTTIState` that backs its `UserData` pointer. The caller owns both:
+# `state` must stay GC-rooted for the duration of the pipeline run, and `opts`
+# must be freed with `API.LLVMDisposeTTIOptions` afterwards.
 function build_custom_tti_options(tti::AbstractTargetTransformInfo)
     state = CustomTTIState(tti)
+    ud = Base.pointer_from_objref(state)
+    opts = API.LLVMCreateTTIOptions()
 
-    noop_cb = @cfunction(custom_tti_is_noop_addr_space_cast_callback,
-                         API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
-    valid_cb = @cfunction(custom_tti_is_valid_addr_space_cast_callback,
-                          API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
-    alias_cb = @cfunction(custom_tti_addrspaces_may_alias_callback,
-                          API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
-    ginit_cb = @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
-                          API.LLVMBool, (Cuint, Ptr{Cvoid}))
-    srcdiv_cb = @cfunction(custom_tti_is_source_of_divergence_callback,
-                           API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
-    unif_cb = @cfunction(custom_tti_is_always_uniform_callback,
-                         API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid}))
-    assas_cb = @cfunction(custom_tti_get_assumed_address_space_callback,
-                          Cuint, (API.LLVMValueRef, Ptr{Cvoid}))
-    predas_cb = @cfunction(custom_tti_get_predicated_address_space_callback,
-                           Cuint, (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid}))
-    rewrite_cb = @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
-                            API.LLVMValueRef,
-                            (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid}))
-    collect_cb = @cfunction(custom_tti_collect_flat_address_operands_callback,
-                            API.LLVMBool,
-                            (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid}))
+    API.LLVMTTIOptionsSetFlatAddressSpace(opts, flat_address_space(tti) % Cuint)
+    API.LLVMTTIOptionsSetHasBranchDivergence(opts, has_branch_divergence(tti))
+    API.LLVMTTIOptionsSetIsSingleThreaded(opts, is_single_threaded(tti))
 
-    p(cf) = Base.unsafe_convert(Ptr{Cvoid}, cf)
-
-    opts = Ref(API.LLVMTTIOptions(
-        flat_address_space(tti) % Cuint,
-        Int32(has_branch_divergence(tti)),
-        Int32(is_single_threaded(tti)),
-        p(noop_cb),
-        p(valid_cb),
-        p(alias_cb),
-        p(ginit_cb),
-        p(srcdiv_cb),
-        p(unif_cb),
-        p(assas_cb),
-        p(predas_cb),
-        p(rewrite_cb),
-        p(collect_cb),
-        Base.pointer_from_objref(state),
-    ))
+    API.LLVMTTIOptionsSetIsNoopAddrSpaceCast(opts,
+        @cfunction(custom_tti_is_noop_addr_space_cast_callback,
+                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
+    API.LLVMTTIOptionsSetIsValidAddrSpaceCast(opts,
+        @cfunction(custom_tti_is_valid_addr_space_cast_callback,
+                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
+    API.LLVMTTIOptionsSetAddrSpacesMayAlias(opts,
+        @cfunction(custom_tti_addrspaces_may_alias_callback,
+                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
+    API.LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(opts,
+        @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
+                   API.LLVMBool, (Cuint, Ptr{Cvoid})), ud)
+    API.LLVMTTIOptionsSetIsSourceOfDivergence(opts,
+        @cfunction(custom_tti_is_source_of_divergence_callback,
+                   API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})), ud)
+    API.LLVMTTIOptionsSetIsAlwaysUniform(opts,
+        @cfunction(custom_tti_is_always_uniform_callback,
+                   API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})), ud)
+    API.LLVMTTIOptionsSetGetAssumedAddressSpace(opts,
+        @cfunction(custom_tti_get_assumed_address_space_callback,
+                   Cuint, (API.LLVMValueRef, Ptr{Cvoid})), ud)
+    API.LLVMTTIOptionsSetGetPredicatedAddressSpace(opts,
+        @cfunction(custom_tti_get_predicated_address_space_callback,
+                   Cuint, (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid})), ud)
+    API.LLVMTTIOptionsSetRewriteIntrinsicWithAS(opts,
+        @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
+                   API.LLVMValueRef,
+                   (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid})), ud)
+    API.LLVMTTIOptionsSetCollectFlatAddressOperands(opts,
+        @cfunction(custom_tti_collect_flat_address_operands_callback,
+                   API.LLVMBool,
+                   (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid})), ud)
 
     return state, opts
 end

--- a/src/targetinfo.jl
+++ b/src/targetinfo.jl
@@ -1,9 +1,10 @@
 # Custom TargetTransformInfo
 #
-# Abstract type + default methods that mirror LLVM's `TargetTransformInfoImplBase`,
-# plus the @cfunction trampolines that let passes reach those methods through
-# the C API. Consumers (e.g. `newpm.jl`) plug these into whichever pipeline
-# they wrap.
+# Abstract type + query function declarations, plus the @cfunction trampolines
+# that let passes reach those methods through the C API. Subtypes override
+# only the queries they care about; anything they don't override is not wired
+# up on the C side and LLVM's `TargetTransformInfoImplBase` handles it. LLVM
+# stays the single source of truth for baseline behavior.
 
 export AbstractTargetTransformInfo
 
@@ -30,9 +31,9 @@ reports no flat address space, no branch divergence, etc., and TTI-sensitive
 passes such as `InferAddressSpacesPass` or `UniformityAnalysis` silently
 no-op.
 
-Each exposed query has a default method on `AbstractTargetTransformInfo` that
-matches LLVM's `TargetTransformInfoImplBase`, so subtypes override only what
-they need.
+Subtypes override only the queries they care about; any query left
+un-overridden is handled by LLVM's `TargetTransformInfoImplBase` — there is
+no Julia-side default that could drift from LLVM's baseline.
 
 Attach an instance with [`target_transform_info!`](@ref); attaching `nothing`
 reverts to LLVM's native TTI. When a `TargetMachine` is also supplied to
@@ -54,109 +55,107 @@ Overridable queries:
 """
 abstract type AbstractTargetTransformInfo end
 
-# Defaults matching LLVM's `TargetTransformInfoImplBase`. Two queries
-# (`can_have_non_undef_global_initializer_in_address_space`, `is_single_threaded`)
-# have LLVM baselines that depend on `DataLayout`/`Module` state not reachable
-# from these callbacks; we pick the common-case static answer and document that
-# subtypes must override if they need the full LLVM behavior.
+# Query functions are declared without default methods. Subtypes add a method
+# for each query they want to override; anything left unimplemented is
+# detected by `hasmethod` at pipeline-build time and left to LLVM's baseline.
 
 """
-    flat_address_space(tti::AbstractTargetTransformInfo) -> UInt
+    flat_address_space(tti::AbstractTargetTransformInfo) -> Unsigned
 
 Address space the target treats as "flat" / generic. Required — alongside
 [`is_noop_addr_space_cast`](@ref) — for `InferAddressSpacesPass` to fold
-`addrspacecast`s. Default: `typemax(UInt)` (no flat AS).
+`addrspacecast`s. If not defined, LLVM reports no flat AS.
 """
-flat_address_space(::AbstractTargetTransformInfo) = typemax(UInt)
+function flat_address_space end
 
 """
     has_branch_divergence(tti::AbstractTargetTransformInfo) -> Bool
 
 Whether the target can produce divergent control flow. Enables
-divergence-aware passes (`SimplifyCFG`, loop analyses) when true. Default:
-`false`.
+divergence-aware passes (`SimplifyCFG`, loop analyses) when true. If not
+defined, falls back to LLVM's baseline.
 """
-has_branch_divergence(::AbstractTargetTransformInfo) = false
+function has_branch_divergence end
 
 """
     is_single_threaded(tti::AbstractTargetTransformInfo) -> Bool
 
 Whether the target is single-threaded. A few passes skip concurrency-related
-transformations when true. Default: `false`. LLVM's actual baseline also
-consults the module's `"single-thread"` flag — override if you rely on that.
+transformations when true. If not defined, falls back to LLVM's baseline
+(which consults the module's `"single-thread"` flag).
 """
-is_single_threaded(::AbstractTargetTransformInfo) = false
+function is_single_threaded end
 
 """
     is_noop_addr_space_cast(tti::AbstractTargetTransformInfo,
                             from::Unsigned, to::Unsigned) -> Bool
 
-Whether an `addrspacecast` from `from` to `to` is a noop at runtime. Default:
-`false`.
+Whether an `addrspacecast` from `from` to `to` is a noop at runtime. If not
+defined, falls back to LLVM's baseline.
 """
-is_noop_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
+function is_noop_addr_space_cast end
 
 """
     is_valid_addr_space_cast(tti::AbstractTargetTransformInfo,
                              from::Unsigned, to::Unsigned) -> Bool
 
-Whether an `addrspacecast` from `from` to `to` is permitted. Default: `false`.
+Whether an `addrspacecast` from `from` to `to` is permitted. If not defined,
+falls back to LLVM's baseline.
 """
-is_valid_addr_space_cast(::AbstractTargetTransformInfo, from::Unsigned, to::Unsigned) = false
+function is_valid_addr_space_cast end
 
 """
     addrspaces_may_alias(tti::AbstractTargetTransformInfo,
                          as0::Unsigned, as1::Unsigned) -> Bool
 
-Whether pointers in address spaces `as0` and `as1` may alias. Default: `true`
-(conservative — pointers may alias unless proven otherwise).
+Whether pointers in address spaces `as0` and `as1` may alias. If not defined,
+falls back to LLVM's (conservative) baseline.
 """
-addrspaces_may_alias(::AbstractTargetTransformInfo, as0::Unsigned, as1::Unsigned) = true
+function addrspaces_may_alias end
 
 """
     can_have_non_undef_global_initializer_in_address_space(
         tti::AbstractTargetTransformInfo, as::Unsigned) -> Bool
 
-Whether globals in address space `as` may have non-`undef` initializers.
-Default: `true`. LLVM's real baseline additionally consults
-`DataLayout::isNonIntegralAddressSpace`, which this default can't reach —
-override if the target has non-integral address spaces.
+Whether globals in address space `as` may have non-`undef` initializers. If
+not defined, falls back to LLVM's baseline (which consults
+`DataLayout::isNonIntegralAddressSpace`).
 """
-can_have_non_undef_global_initializer_in_address_space(::AbstractTargetTransformInfo, as::Unsigned) = true
+function can_have_non_undef_global_initializer_in_address_space end
 
 """
     is_source_of_divergence(tti::AbstractTargetTransformInfo, v::Value) -> Bool
 
-Whether `v` is a source of divergence. Consulted by `UniformityAnalysis`.
-Default: `false`.
+Whether `v` is a source of divergence. Consulted by `UniformityAnalysis`. If
+not defined, falls back to LLVM's baseline.
 """
-is_source_of_divergence(::AbstractTargetTransformInfo, v::Value) = false
+function is_source_of_divergence end
 
 """
     is_always_uniform(tti::AbstractTargetTransformInfo, v::Value) -> Bool
 
 Whether `v` is known to hold the same value across all threads. Consulted by
-`UniformityAnalysis`. Default: `false`.
+`UniformityAnalysis`. If not defined, falls back to LLVM's baseline.
 """
-is_always_uniform(::AbstractTargetTransformInfo, v::Value) = false
+function is_always_uniform end
 
 """
     get_assumed_addr_space(tti::AbstractTargetTransformInfo, v::Value) -> Unsigned
 
 Address space statically known to hold for `v`, or `typemax(UInt)` for "no
-assumption". Default: `typemax(UInt)`.
+assumption". If not defined, falls back to LLVM's baseline.
 """
-get_assumed_addr_space(::AbstractTargetTransformInfo, v::Value) = typemax(UInt)
+function get_assumed_addr_space end
 
 """
     get_predicated_addr_space(tti::AbstractTargetTransformInfo, v::Value)
         -> (predicate::Union{Value,Nothing}, as::Unsigned)
 
 Address space that holds for `v` when `predicate` is true. Return
-`(nothing, typemax(UInt))` for "no inference". Default: that sentinel.
+`(nothing, typemax(UInt))` for "no inference". If not defined, falls back to
+LLVM's baseline.
 """
-get_predicated_addr_space(::AbstractTargetTransformInfo, v::Value) =
-    (nothing, typemax(UInt))
+function get_predicated_addr_space end
 
 """
     rewrite_intrinsic_with_address_space(tti::AbstractTargetTransformInfo,
@@ -164,19 +163,20 @@ get_predicated_addr_space(::AbstractTargetTransformInfo, v::Value) =
 
 Rewrite an intrinsic call `ii` after its pointer operand `old` has been
 replaced by `new` (in a different address space). Return the rewritten value,
-or `nothing` to keep the existing call. Default: `nothing`.
+or `nothing` to keep the existing call. If not defined, falls back to LLVM's
+baseline.
 """
-rewrite_intrinsic_with_address_space(::AbstractTargetTransformInfo,
-                                     ii::Value, old::Value, new::Value) = nothing
+function rewrite_intrinsic_with_address_space end
 
 """
     collect_flat_address_operands(tti::AbstractTargetTransformInfo, iid::Unsigned)
         -> Vector{Int}
 
 Operand indices of intrinsic `iid` that are flat-address-space pointer
-operands. Capped at 32 entries by the underlying C API. Default: `Int[]`.
+operands. Capped at 32 entries by the underlying C API. If not defined, falls
+back to LLVM's baseline.
 """
-collect_flat_address_operands(::AbstractTargetTransformInfo, iid::Unsigned) = Int[]
+function collect_flat_address_operands end
 
 # Mutable shim that holds the `AbstractTargetTransformInfo` alongside any
 # caught exception. A pointer to this object is passed to C as the `UserData`
@@ -345,42 +345,63 @@ function build_custom_tti_options(tti::AbstractTargetTransformInfo)
     ud = Base.pointer_from_objref(state)
     opts = API.LLVMCreateTTIOptions()
 
-    API.LLVMTTIOptionsSetFlatAddressSpace(opts, flat_address_space(tti) % Cuint)
-    API.LLVMTTIOptionsSetHasBranchDivergence(opts, has_branch_divergence(tti))
-    API.LLVMTTIOptionsSetIsSingleThreaded(opts, is_single_threaded(tti))
+    T = typeof(tti)
 
-    API.LLVMTTIOptionsSetIsNoopAddrSpaceCast(opts,
-        @cfunction(custom_tti_is_noop_addr_space_cast_callback,
-                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
-    API.LLVMTTIOptionsSetIsValidAddrSpaceCast(opts,
-        @cfunction(custom_tti_is_valid_addr_space_cast_callback,
-                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
-    API.LLVMTTIOptionsSetAddrSpacesMayAlias(opts,
-        @cfunction(custom_tti_addrspaces_may_alias_callback,
-                   API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
-    API.LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(opts,
-        @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
-                   API.LLVMBool, (Cuint, Ptr{Cvoid})), ud)
-    API.LLVMTTIOptionsSetIsSourceOfDivergence(opts,
-        @cfunction(custom_tti_is_source_of_divergence_callback,
-                   API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})), ud)
-    API.LLVMTTIOptionsSetIsAlwaysUniform(opts,
-        @cfunction(custom_tti_is_always_uniform_callback,
-                   API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})), ud)
-    API.LLVMTTIOptionsSetGetAssumedAddressSpace(opts,
-        @cfunction(custom_tti_get_assumed_address_space_callback,
-                   Cuint, (API.LLVMValueRef, Ptr{Cvoid})), ud)
-    API.LLVMTTIOptionsSetGetPredicatedAddressSpace(opts,
-        @cfunction(custom_tti_get_predicated_address_space_callback,
-                   Cuint, (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid})), ud)
-    API.LLVMTTIOptionsSetRewriteIntrinsicWithAS(opts,
-        @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
-                   API.LLVMValueRef,
-                   (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid})), ud)
-    API.LLVMTTIOptionsSetCollectFlatAddressOperands(opts,
-        @cfunction(custom_tti_collect_flat_address_operands_callback,
-                   API.LLVMBool,
-                   (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid})), ud)
+    # Scalar fields: only set when the subtype has an override. Unset fields
+    # leave LLVM's `TargetTransformInfoImplBase` to answer the query.
+    hasmethod(flat_address_space, Tuple{T}) &&
+        API.LLVMTTIOptionsSetFlatAddressSpace(opts, flat_address_space(tti) % Cuint)
+    hasmethod(has_branch_divergence, Tuple{T}) &&
+        API.LLVMTTIOptionsSetHasBranchDivergence(opts, has_branch_divergence(tti))
+    hasmethod(is_single_threaded, Tuple{T}) &&
+        API.LLVMTTIOptionsSetIsSingleThreaded(opts, is_single_threaded(tti))
+
+    # Callbacks: install the @cfunction trampoline only when a concrete
+    # override exists for this subtype.
+    hasmethod(is_noop_addr_space_cast, Tuple{T, Unsigned, Unsigned}) &&
+        API.LLVMTTIOptionsSetIsNoopAddrSpaceCast(opts,
+            @cfunction(custom_tti_is_noop_addr_space_cast_callback,
+                       API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
+    hasmethod(is_valid_addr_space_cast, Tuple{T, Unsigned, Unsigned}) &&
+        API.LLVMTTIOptionsSetIsValidAddrSpaceCast(opts,
+            @cfunction(custom_tti_is_valid_addr_space_cast_callback,
+                       API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
+    hasmethod(addrspaces_may_alias, Tuple{T, Unsigned, Unsigned}) &&
+        API.LLVMTTIOptionsSetAddrSpacesMayAlias(opts,
+            @cfunction(custom_tti_addrspaces_may_alias_callback,
+                       API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid})), ud)
+    hasmethod(can_have_non_undef_global_initializer_in_address_space,
+              Tuple{T, Unsigned}) &&
+        API.LLVMTTIOptionsSetCanHaveGlobalInitializerInAS(opts,
+            @cfunction(custom_tti_can_have_global_initializer_in_as_callback,
+                       API.LLVMBool, (Cuint, Ptr{Cvoid})), ud)
+    hasmethod(is_source_of_divergence, Tuple{T, Value}) &&
+        API.LLVMTTIOptionsSetIsSourceOfDivergence(opts,
+            @cfunction(custom_tti_is_source_of_divergence_callback,
+                       API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})), ud)
+    hasmethod(is_always_uniform, Tuple{T, Value}) &&
+        API.LLVMTTIOptionsSetIsAlwaysUniform(opts,
+            @cfunction(custom_tti_is_always_uniform_callback,
+                       API.LLVMBool, (API.LLVMValueRef, Ptr{Cvoid})), ud)
+    hasmethod(get_assumed_addr_space, Tuple{T, Value}) &&
+        API.LLVMTTIOptionsSetGetAssumedAddressSpace(opts,
+            @cfunction(custom_tti_get_assumed_address_space_callback,
+                       Cuint, (API.LLVMValueRef, Ptr{Cvoid})), ud)
+    hasmethod(get_predicated_addr_space, Tuple{T, Value}) &&
+        API.LLVMTTIOptionsSetGetPredicatedAddressSpace(opts,
+            @cfunction(custom_tti_get_predicated_address_space_callback,
+                       Cuint, (API.LLVMValueRef, Ptr{API.LLVMValueRef}, Ptr{Cvoid})), ud)
+    hasmethod(rewrite_intrinsic_with_address_space,
+              Tuple{T, Value, Value, Value}) &&
+        API.LLVMTTIOptionsSetRewriteIntrinsicWithAS(opts,
+            @cfunction(custom_tti_rewrite_intrinsic_with_as_callback,
+                       API.LLVMValueRef,
+                       (API.LLVMValueRef, API.LLVMValueRef, API.LLVMValueRef, Ptr{Cvoid})), ud)
+    hasmethod(collect_flat_address_operands, Tuple{T, Unsigned}) &&
+        API.LLVMTTIOptionsSetCollectFlatAddressOperands(opts,
+            @cfunction(custom_tti_collect_flat_address_operands_callback,
+                       API.LLVMBool,
+                       (Cuint, Ptr{Cint}, Cuint, Ptr{Cuint}, Ptr{Cvoid})), ud)
 
     return state, opts
 end

--- a/src/targetinfo.jl
+++ b/src/targetinfo.jl
@@ -342,7 +342,6 @@ end
 # `state` and `opts_ref` alive for the duration of the pipeline run.
 function build_custom_tti_options(tti::AbstractTargetTransformInfo)
     state = CustomTTIState(tti)
-    ud = Base.pointer_from_objref(state)
 
     noop_cb = @cfunction(custom_tti_is_noop_addr_space_cast_callback,
                          API.LLVMBool, (Cuint, Cuint, Ptr{Cvoid}))
@@ -373,16 +372,17 @@ function build_custom_tti_options(tti::AbstractTargetTransformInfo)
         flat_address_space(tti) % Cuint,
         Int32(has_branch_divergence(tti)),
         Int32(is_single_threaded(tti)),
-        p(noop_cb),    ud,
-        p(valid_cb),   ud,
-        p(alias_cb),   ud,
-        p(ginit_cb),   ud,
-        p(srcdiv_cb),  ud,
-        p(unif_cb),    ud,
-        p(assas_cb),   ud,
-        p(predas_cb),  ud,
-        p(rewrite_cb), ud,
-        p(collect_cb), ud,
+        p(noop_cb),
+        p(valid_cb),
+        p(alias_cb),
+        p(ginit_cb),
+        p(srcdiv_cb),
+        p(unif_cb),
+        p(assas_cb),
+        p(predas_cb),
+        p(rewrite_cb),
+        p(collect_cb),
+        Base.pointer_from_objref(state),
     ))
 
     return state, opts

--- a/test/newpm.jl
+++ b/test/newpm.jl
@@ -259,9 +259,14 @@ end
     end
     has_addrspacecast(mod) = occursin("addrspacecast", string(functions(mod)["f"]))
 
-    # Baseline: no TTI → pass can't fold anything.
+    # A do-nothing subtype: exercises the abstract defaults, which must match
+    # LLVM's baseline well enough that InferAddressSpaces can't find a flat AS
+    # and therefore folds nothing — same observable behavior as no TTI at all.
+    struct BaselineTTI <: AbstractTargetTransformInfo end
+
     @dispose ctx=Context() mod=make_mod() begin
         @dispose pb=NewPMPassBuilder() begin
+            target_transform_info!(pb, BaselineTTI())
             add!(pb, NewPMFunctionPassManager()) do fpm
                 add!(fpm, InferAddressSpacesPass())
             end
@@ -270,14 +275,15 @@ end
         @test has_addrspacecast(mod)
     end
 
-    # With a TTI: cast gets folded.
+    # With an overriding subtype: cast gets folded.
+    struct FlatZeroTTI <: AbstractTargetTransformInfo end
+    LLVM.flat_address_space(::FlatZeroTTI) = UInt(0)
+    LLVM.is_noop_addr_space_cast(::FlatZeroTTI, from::Unsigned, to::Unsigned) =
+        from == 0 || to == 0
+
     @dispose ctx=Context() mod=make_mod() begin
-        tti = CustomTargetTransformInfo(
-            flat_address_space = 0,
-            is_noop_addr_space_cast = (from, to) -> from == 0 || to == 0,
-        )
         @dispose pb=NewPMPassBuilder() begin
-            target_transform_info!(pb, tti)
+            target_transform_info!(pb, FlatZeroTTI())
             add!(pb, NewPMFunctionPassManager()) do fpm
                 add!(fpm, InferAddressSpacesPass())
             end
@@ -291,31 +297,33 @@ end
     # during inference, making it a reliable observable; the other callbacks
     # fire only on paths InferAddressSpaces may or may not take for a given
     # module.
-    calls = 0
-    @dispose ctx=Context() mod=make_mod() begin
-        tti = CustomTargetTransformInfo(
-            flat_address_space = 0,
-            is_noop_addr_space_cast = (from, to) -> from == 0 || to == 0,
-            get_assumed_addr_space = (v) -> (calls += 1; typemax(UInt)),
-        )
-        @dispose pb=NewPMPassBuilder() begin
-            target_transform_info!(pb, tti)
-            add!(pb, NewPMFunctionPassManager()) do fpm
-                add!(fpm, InferAddressSpacesPass())
-            end
-            run!(pb, mod)
+    let calls = Ref(0)
+        # Subtype-local field lets the method see per-instance state.
+        struct CountingTTI <: AbstractTargetTransformInfo
+            calls::Base.RefValue{Int}
         end
-    end
-    @test calls > 0
+        LLVM.flat_address_space(::CountingTTI) = UInt(0)
+        LLVM.is_noop_addr_space_cast(::CountingTTI, from::Unsigned, to::Unsigned) =
+            from == 0 || to == 0
+        LLVM.get_assumed_addr_space(t::CountingTTI, ::LLVM.Value) =
+            (t.calls[] += 1; typemax(UInt))
 
-    # `target_transform_info!(pb, nothing)` reverts to the default TTI.
+        @dispose ctx=Context() mod=make_mod() begin
+            @dispose pb=NewPMPassBuilder() begin
+                target_transform_info!(pb, CountingTTI(calls))
+                add!(pb, NewPMFunctionPassManager()) do fpm
+                    add!(fpm, InferAddressSpacesPass())
+                end
+                run!(pb, mod)
+            end
+        end
+        @test calls[] > 0
+    end
+
+    # `target_transform_info!(pb, nothing)` reverts to LLVM's native TTI.
     @dispose ctx=Context() mod=make_mod() begin
-        tti = CustomTargetTransformInfo(
-            flat_address_space = 0,
-            is_noop_addr_space_cast = (from, to) -> from == 0 || to == 0,
-        )
         @dispose pb=NewPMPassBuilder() begin
-            target_transform_info!(pb, tti)
+            target_transform_info!(pb, FlatZeroTTI())
             target_transform_info!(pb, nothing)
             add!(pb, NewPMFunctionPassManager()) do fpm
                 add!(fpm, InferAddressSpacesPass())
@@ -326,13 +334,13 @@ end
     end
 
     # Exceptions in TTI callbacks are caught and rethrown as PassException.
+    struct BoomTTI <: AbstractTargetTransformInfo end
+    LLVM.flat_address_space(::BoomTTI) = UInt(0)
+    LLVM.get_assumed_addr_space(::BoomTTI, ::LLVM.Value) = error("TTI callback boom")
+
     @dispose ctx=Context() mod=make_mod() begin
-        tti = CustomTargetTransformInfo(
-            flat_address_space = 0,
-            get_assumed_addr_space = (v) -> error("TTI callback boom"),
-        )
         @dispose pb=NewPMPassBuilder() begin
-            target_transform_info!(pb, tti)
+            target_transform_info!(pb, BoomTTI())
             add!(pb, NewPMFunctionPassManager()) do fpm
                 add!(fpm, InferAddressSpacesPass())
             end

--- a/test/newpm.jl
+++ b/test/newpm.jl
@@ -230,6 +230,117 @@ end
     end
 end
 
+@testset "custom TTI" begin
+    # IR with an `addrspacecast` from AS 2 to the generic AS. With no TTI
+    # attached, `InferAddressSpacesPass` has no flat AS to infer against and
+    # bails. With a TTI that reports AS 0 as flat and declares the cast a
+    # noop, the pass folds it away and the load moves to AS 2.
+    function make_mod()
+        ir = if supports_typed_pointers()
+            """
+            @g = internal addrspace(2) constant i32 42
+            define i32 @f() {
+              %p = addrspacecast i32 addrspace(2)* @g to i32*
+              %v = load i32, i32* %p
+              ret i32 %v
+            }
+            """
+        else
+            """
+            @g = internal addrspace(2) constant i32 42
+            define i32 @f() {
+              %p = addrspacecast ptr addrspace(2) @g to ptr
+              %v = load i32, ptr %p
+              ret i32 %v
+            }
+            """
+        end
+        return parse(LLVM.Module, ir)
+    end
+    has_addrspacecast(mod) = occursin("addrspacecast", string(functions(mod)["f"]))
+
+    # Baseline: no TTI → pass can't fold anything.
+    @dispose ctx=Context() mod=make_mod() begin
+        @dispose pb=NewPMPassBuilder() begin
+            add!(pb, NewPMFunctionPassManager()) do fpm
+                add!(fpm, InferAddressSpacesPass())
+            end
+            run!(pb, mod)
+        end
+        @test has_addrspacecast(mod)
+    end
+
+    # With a TTI: cast gets folded.
+    @dispose ctx=Context() mod=make_mod() begin
+        tti = CustomTargetTransformInfo(
+            flat_address_space = 0,
+            is_noop_addr_space_cast = (from, to) -> from == 0 || to == 0,
+        )
+        @dispose pb=NewPMPassBuilder() begin
+            target_transform_info!(pb, tti)
+            add!(pb, NewPMFunctionPassManager()) do fpm
+                add!(fpm, InferAddressSpacesPass())
+            end
+            run!(pb, mod)
+        end
+        @test !has_addrspacecast(mod)
+    end
+
+    # Callbacks fire: observe the counter getting incremented.
+    # `get_assumed_addr_space` is queried unconditionally per pointer Value
+    # during inference, making it a reliable observable; the other callbacks
+    # fire only on paths InferAddressSpaces may or may not take for a given
+    # module.
+    calls = 0
+    @dispose ctx=Context() mod=make_mod() begin
+        tti = CustomTargetTransformInfo(
+            flat_address_space = 0,
+            is_noop_addr_space_cast = (from, to) -> from == 0 || to == 0,
+            get_assumed_addr_space = (v) -> (calls += 1; typemax(UInt)),
+        )
+        @dispose pb=NewPMPassBuilder() begin
+            target_transform_info!(pb, tti)
+            add!(pb, NewPMFunctionPassManager()) do fpm
+                add!(fpm, InferAddressSpacesPass())
+            end
+            run!(pb, mod)
+        end
+    end
+    @test calls > 0
+
+    # `target_transform_info!(pb, nothing)` reverts to the default TTI.
+    @dispose ctx=Context() mod=make_mod() begin
+        tti = CustomTargetTransformInfo(
+            flat_address_space = 0,
+            is_noop_addr_space_cast = (from, to) -> from == 0 || to == 0,
+        )
+        @dispose pb=NewPMPassBuilder() begin
+            target_transform_info!(pb, tti)
+            target_transform_info!(pb, nothing)
+            add!(pb, NewPMFunctionPassManager()) do fpm
+                add!(fpm, InferAddressSpacesPass())
+            end
+            run!(pb, mod)
+        end
+        @test has_addrspacecast(mod)
+    end
+
+    # Exceptions in TTI callbacks are caught and rethrown as PassException.
+    @dispose ctx=Context() mod=make_mod() begin
+        tti = CustomTargetTransformInfo(
+            flat_address_space = 0,
+            get_assumed_addr_space = (v) -> error("TTI callback boom"),
+        )
+        @dispose pb=NewPMPassBuilder() begin
+            target_transform_info!(pb, tti)
+            add!(pb, NewPMFunctionPassManager()) do fpm
+                add!(fpm, InferAddressSpacesPass())
+            end
+            @test_throws LLVM.PassException run!(pb, mod)
+        end
+    end
+end
+
 @testset "custom pass exceptions" begin
     # Test that exceptions in module passes are caught and rethrown
     @dispose ctx=Context() mod=test_module() begin


### PR DESCRIPTION
For the Metal back-end, we want to be able to run the InferAddrSpaces pass, which requires a TTI to not be a no-op. This PR makes that possible, obviating the need for a custom version of such passes in GPUCompiler.jl.

cc @vchuravy @gbaraldi 