### PR TITLE
Add support for parsing and linking modules lazily.

### DIFF
--- a/.github/workflows/Enzyme.yml
+++ b/.github/workflows/Enzyme.yml
@@ -47,6 +47,13 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@latest
+      - name: Build libLLVMExtra
+        run: julia --project=deps deps/build_ci.jl
+      - name: Propagate libLLVMExtra preference to downstream
+        run: |
+          if [ -f LocalPreferences.toml ]; then
+            cp LocalPreferences.toml downstream/LocalPreferences.toml
+          fi
       - name: Load this and run the downstream tests
         shell: julia --color=yes --project=downstream {0}
         run: |

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LLVM"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "9.5.0"
+version = "9.6.0"
 
 [workspace]
 projects = ["test", "docs", "examples", "deps", "res"]

--- a/deps/LLVMExtra/CMakeLists.txt
+++ b/deps/LLVMExtra/CMakeLists.txt
@@ -4,7 +4,7 @@ SET(CMAKE_CXX_FLAGS "-Wall -fPIC -fno-rtti")
 
 project(LLVMExtra
 VERSION
-    1.7
+    1.8
 LANGUAGES
    CXX
    C

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -363,6 +363,18 @@ void LLVMPassBuilderExtensionsSetTTI(LLVMPassBuilderExtensionsRef Extensions,
 // More DataLayout queries
 unsigned LLVMGlobalsAddressSpace(LLVMTargetDataRef TD);
 
+// Linker flags (mirrors `llvm::Linker::Flags`).
+typedef enum {
+  LLVMLinkerNone = 0,
+  LLVMLinkerOverrideFromSrc = (1 << 0),
+  LLVMLinkerLinkOnlyNeeded = (1 << 1),
+} LLVMLinkerFlags;
+
+// Extended variant of `LLVMLinkModules2` that accepts a bitmask of
+// `LLVMLinkerFlags`. Destroys `Src` on success or failure, matching
+// `LLVMLinkModules2`. Returns true on error.
+LLVMBool LLVMLinkModules3(LLVMModuleRef Dest, LLVMModuleRef Src, unsigned Flags);
+
 #if LLVM_VERSION_MAJOR >= 21
 LLVMContextRef LLVMOrcThreadSafeContextGetContext(LLVMOrcThreadSafeContextRef TSCtx);
 #endif

--- a/deps/LLVMExtra/lib/Core.cpp
+++ b/deps/LLVMExtra/lib/Core.cpp
@@ -20,6 +20,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
+#include <llvm/Linker/Linker.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Scalar.h>
@@ -808,6 +809,16 @@ LLVMContextRef LLVMGetBuilderContext(LLVMBuilderRef Builder) {
 
 unsigned LLVMGlobalsAddressSpace(LLVMTargetDataRef TD) {
   return unwrap(TD)->getDefaultGlobalsAddressSpace();
+}
+
+//
+// Linker extensions
+//
+
+LLVMBool LLVMLinkModules3(LLVMModuleRef Dest, LLVMModuleRef Src, unsigned Flags) {
+  Module *D = unwrap(Dest);
+  std::unique_ptr<Module> M(unwrap(Src));
+  return Linker::linkModules(*D, std::move(M), Flags);
 }
 
 #if LLVM_VERSION_MAJOR >= 21

--- a/docs/src/man/modules.md
+++ b/docs/src/man/modules.md
@@ -178,3 +178,35 @@ define void @foo() {
   ret void
 }
 ```
+
+Pass `only_needed=true` to only link symbols from the source module that are
+referenced (but not defined) in the destination module, leaving unreferenced
+definitions behind:
+
+```jldoctest
+julia> src = parse(LLVM.Module, """
+           define void @needed() { ret void }
+           define void @extra() { ret void }""");
+
+julia> dst = parse(LLVM.Module, """
+           declare void @needed()
+           define void @caller() {
+             call void @needed()
+             ret void
+           }""");
+
+julia> link!(dst, src; only_needed=true)
+
+julia> dst
+define void @caller() {
+  call void @needed()
+  ret void
+}
+
+define void @needed() {
+  ret void
+}
+```
+
+Pass `override_from_src=true` to have definitions in the source module shadow
+any conflicting definitions in the destination module.

--- a/lib/15/libLLVM_extra.jl
+++ b/lib/15/libLLVM_extra.jl
@@ -494,3 +494,13 @@ function LLVMGlobalsAddressSpace(TD)
     ccall((:LLVMGlobalsAddressSpace, libLLVMExtra), Cuint, (LLVMTargetDataRef,), TD)
 end
 
+@cenum LLVMLinkerFlags::UInt32 begin
+    LLVMLinkerNone = 0
+    LLVMLinkerOverrideFromSrc = 1
+    LLVMLinkerLinkOnlyNeeded = 2
+end
+
+function LLVMLinkModules3(Dest, Src, Flags)
+    ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
+end
+

--- a/lib/16/libLLVM_extra.jl
+++ b/lib/16/libLLVM_extra.jl
@@ -494,3 +494,13 @@ function LLVMGlobalsAddressSpace(TD)
     ccall((:LLVMGlobalsAddressSpace, libLLVMExtra), Cuint, (LLVMTargetDataRef,), TD)
 end
 
+@cenum LLVMLinkerFlags::UInt32 begin
+    LLVMLinkerNone = 0
+    LLVMLinkerOverrideFromSrc = 1
+    LLVMLinkerLinkOnlyNeeded = 2
+end
+
+function LLVMLinkModules3(Dest, Src, Flags)
+    ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
+end
+

--- a/lib/17/libLLVM_extra.jl
+++ b/lib/17/libLLVM_extra.jl
@@ -454,3 +454,13 @@ function LLVMGlobalsAddressSpace(TD)
     ccall((:LLVMGlobalsAddressSpace, libLLVMExtra), Cuint, (LLVMTargetDataRef,), TD)
 end
 
+@cenum LLVMLinkerFlags::UInt32 begin
+    LLVMLinkerNone = 0
+    LLVMLinkerOverrideFromSrc = 1
+    LLVMLinkerLinkOnlyNeeded = 2
+end
+
+function LLVMLinkModules3(Dest, Src, Flags)
+    ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
+end
+

--- a/lib/18/libLLVM_extra.jl
+++ b/lib/18/libLLVM_extra.jl
@@ -388,3 +388,13 @@ function LLVMGlobalsAddressSpace(TD)
     ccall((:LLVMGlobalsAddressSpace, libLLVMExtra), Cuint, (LLVMTargetDataRef,), TD)
 end
 
+@cenum LLVMLinkerFlags::UInt32 begin
+    LLVMLinkerNone = 0
+    LLVMLinkerOverrideFromSrc = 1
+    LLVMLinkerLinkOnlyNeeded = 2
+end
+
+function LLVMLinkModules3(Dest, Src, Flags)
+    ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
+end
+

--- a/lib/19/libLLVM_extra.jl
+++ b/lib/19/libLLVM_extra.jl
@@ -388,3 +388,13 @@ function LLVMGlobalsAddressSpace(TD)
     ccall((:LLVMGlobalsAddressSpace, libLLVMExtra), Cuint, (LLVMTargetDataRef,), TD)
 end
 
+@cenum LLVMLinkerFlags::UInt32 begin
+    LLVMLinkerNone = 0
+    LLVMLinkerOverrideFromSrc = 1
+    LLVMLinkerLinkOnlyNeeded = 2
+end
+
+function LLVMLinkModules3(Dest, Src, Flags)
+    ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
+end
+

--- a/lib/20/libLLVM_extra.jl
+++ b/lib/20/libLLVM_extra.jl
@@ -340,3 +340,13 @@ function LLVMGlobalsAddressSpace(TD)
     ccall((:LLVMGlobalsAddressSpace, libLLVMExtra), Cuint, (LLVMTargetDataRef,), TD)
 end
 
+@cenum LLVMLinkerFlags::UInt32 begin
+    LLVMLinkerNone = 0
+    LLVMLinkerOverrideFromSrc = 1
+    LLVMLinkerLinkOnlyNeeded = 2
+end
+
+function LLVMLinkModules3(Dest, Src, Flags)
+    ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
+end
+

--- a/lib/21/libLLVM_extra.jl
+++ b/lib/21/libLLVM_extra.jl
@@ -336,6 +336,16 @@ function LLVMGlobalsAddressSpace(TD)
     ccall((:LLVMGlobalsAddressSpace, libLLVMExtra), Cuint, (LLVMTargetDataRef,), TD)
 end
 
+@cenum LLVMLinkerFlags::UInt32 begin
+    LLVMLinkerNone = 0
+    LLVMLinkerOverrideFromSrc = 1
+    LLVMLinkerLinkOnlyNeeded = 2
+end
+
+function LLVMLinkModules3(Dest, Src, Flags)
+    ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
+end
+
 function LLVMOrcThreadSafeContextGetContext(TSCtx)
     ccall((:LLVMOrcThreadSafeContextGetContext, libLLVMExtra), LLVMContextRef, (LLVMOrcThreadSafeContextRef,), TSCtx)
 end

--- a/src/core/module.jl
+++ b/src/core/module.jl
@@ -213,27 +213,47 @@ Base.string(mod::Module) = unsafe_message(API.LLVMPrintModuleToString(mod))
 ## binary bitcode handling
 
 """
-    parse(::Type{Module}, membuf::MemoryBuffer)
+    parse(::Type{Module}, membuf::MemoryBuffer; lazy::Bool=false)
 
 Parse bitcode from the given memory buffer into a module.
+
+If `lazy` is `true`, only the module header is read; function bodies are deserialized on
+demand. The module then takes ownership of `membuf`, and the underlying byte storage
+(`membuf`'s data) must remain valid for the module's lifetime.
 """
-function Base.parse(::Type{Module}, membuf::MemoryBuffer)
+function Base.parse(::Type{Module}, membuf::MemoryBuffer; lazy::Bool=false)
     out_ref = Ref{API.LLVMModuleRef}()
 
-    status = API.LLVMParseBitcodeInContext2(context(), membuf, out_ref) |> Bool
-    @assert !status # caught by diagnostics handler
+    if lazy
+        # `LLVMGetBitcodeModuleInContext2` consumes `membuf` regardless of success
+        status = API.LLVMGetBitcodeModuleInContext2(context(), membuf, out_ref) |> Bool
+        mark_dispose(membuf)
+        @assert !status # caught by diagnostics handler
+    else
+        status = API.LLVMParseBitcodeInContext2(context(), membuf, out_ref) |> Bool
+        @assert !status # caught by diagnostics handler
+    end
 
     mark_alloc(Module(out_ref[]))
 end
 
 """
-    parse(::Type{Module}, data::Vector)
+    parse(::Type{Module}, data::Vector; lazy::Bool=false)
 
 Parse bitcode from the given byte vector into a module.
+
+If `lazy` is `true`, `data` must remain live (unmutated) for the module's lifetime, as the
+bitcode reader keeps reading from it on demand.
 """
-function Base.parse(::Type{Module}, data::Vector)
-    @dispose membuf = MemoryBuffer(data, "", false) begin
-        parse(Module, membuf)
+function Base.parse(::Type{Module}, data::Vector; lazy::Bool=false)
+    if lazy
+        # the module takes ownership of `membuf`, so don't @dispose it here
+        membuf = MemoryBuffer(data, "", false)
+        parse(Module, membuf; lazy=true)
+    else
+        @dispose membuf = MemoryBuffer(data, "", false) begin
+            parse(Module, membuf)
+        end
     end
 end
 

--- a/src/linker.jl
+++ b/src/linker.jl
@@ -1,13 +1,30 @@
 export link!
 
 """
-    link!(dst::Module, src::Module)
+    link!(dst::Module, src::Module; only_needed=false, override_from_src=false)
 
 Link the source module `src` into the destination module `dst`. The source module
 is destroyed in the process.
+
+Keyword arguments:
+
+- `only_needed`: if true, only link symbols from `src` that are needed by `dst`
+  (i.e., referenced but not defined there). This corresponds to LLVM's
+  `Linker::LinkOnlyNeeded` flag.
+- `override_from_src`: if true, have symbols from `src` shadow those in `dst`.
+  This corresponds to LLVM's `Linker::OverrideFromSrc` flag.
 """
-function link!(dst::Module, src::Module)
-    status = API.LLVMLinkModules2(dst, src) |> Bool
+function link!(dst::Module, src::Module;
+               only_needed::Bool=false, override_from_src::Bool=false)
+    flags = UInt32(0)
+    if only_needed
+        flags |= UInt32(API.LLVMLinkerLinkOnlyNeeded)
+    end
+    if override_from_src
+        flags |= UInt32(API.LLVMLinkerOverrideFromSrc)
+    end
+
+    status = API.LLVMLinkModules3(dst, src, flags) |> Bool
     @assert !status # caught by diagnostics handler
     mark_dispose(src)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1217,6 +1217,14 @@ end
             @test haskey(functions(mod), "SomeFunction")
         end
 
+        # lazy parse: module header is read but function bodies stay deferred
+        let lazy_bitcode = copy(bitcode)  # kept alive for the module's lifetime
+            @dispose mod = parse(LLVM.Module, lazy_bitcode; lazy=true) begin
+                verify(mod)
+                @test haskey(functions(mod), "SomeFunction")
+            end
+        end
+
         mktemp() do path, io
             mark(io)
             @test write(io, source_mod) > 0

--- a/test/linker.jl
+++ b/test/linker.jl
@@ -33,4 +33,43 @@
     dispose(mod1)
 end
 
+@testset "only_needed" begin
+    @dispose ctx=Context() begin
+        # `dst` declares (but does not define) `needed`; it does not reference `extra`.
+        @dispose dst=parse(LLVM.Module, """
+            declare void @needed()
+            define void @caller() {
+              call void @needed()
+              ret void
+            }""") begin
+            src = parse(LLVM.Module, """
+                define void @needed() { ret void }
+                define void @extra() { ret void }""")
+
+            link!(dst, src; only_needed=true)
+
+            @test haskey(functions(dst), "caller")
+            # `needed` is referenced from `dst`, so it must be linked in (and defined now).
+            @test haskey(functions(dst), "needed")
+            @test !isempty(blocks(functions(dst)["needed"]))
+            # `extra` is not referenced from `dst`, so it must be skipped.
+            @test !haskey(functions(dst), "extra")
+        end
+    end
+end
+
+@testset "override_from_src" begin
+    @dispose ctx=Context() begin
+        @dispose dst=parse(LLVM.Module, "@glob = global i32 1") begin
+            src = parse(LLVM.Module, "@glob = global i32 2")
+
+            link!(dst, src; override_from_src=true)
+
+            glob = globals(dst)["glob"]
+            init = LLVM.initializer(glob)
+            @test convert(Int, init) == 2
+        end
+    end
+end
+
 end


### PR DESCRIPTION
This makes it possible to always link CUDA.jl's libdevice, doing away with GPUCompiler.jl's `link_libraries` interface that passes the undefined symbols (which is ugly).