### PR TITLE
Fix 32bit error during precompile

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -243,7 +243,9 @@ Base.run(engine::ExecutionEngine, f::Function, args::Vector{GenericValue}=Generi
 Look up the address of the given function in the execution engine.
 """
 function lookup(engine::ExecutionEngine, fn::String)
-    addr = Ptr{Nothing}(API.LLVMGetFunctionAddress(engine, fn))
+    # LLVMGetFunctionAddress returns UInt64 (even on 32-bit platforms)
+    # so we need to convert it to UInt first.
+    addr = Ptr{Nothing}(API.LLVMGetFunctionAddress(engine, fn) % UInt)
     if addr == C_NULL
         throw(KeyError(fn))
     end


### PR DESCRIPTION
Currently seeing a lot of failures in 32-bit CI like this:

```
ERROR: LoadError: MethodError: no method matching Ptr{Nothing}(::UInt64)

Closest candidates are:
  Ptr{T}(::Cwstring) where T<:Union{Nothing, Int32}
   @ Base c.jl:165
  Ptr{T}(::Cstring) where T<:Union{Nothing, Int8, UInt8}
   @ Base c.jl:164
  Ptr{T}() where T
   @ Core boot.jl:801
  ...

Stacktrace:
  [1] lookup(engine::LLVM.ExecutionEngine, fn::String)
    @ LLVM ~/.julia/packages/LLVM/xklRb/src/execution.jl:246
  [2] macro expansion
    @ ~/.julia/packages/LLVM/xklRb/src/precompile.jl:58 [inlined]
  [3] macro expansion
    @ ~/.julia/packages/LLVM/xklRb/src/base.jl:113 [inlined]
  [4] macro expansion
    @ ~/.julia/packages/LLVM/xklRb/src/precompile.jl:57 [inlined]
  [5] macro expansion
    @ ~/.julia/packages/LLVM/xklRb/src/base.jl:113 [inlined]
  [6] macro expansion
    @ ~/.julia/packages/LLVM/xklRb/src/precompile.jl:3 [inlined]
  [7] macro expansion
    @ ~/.julia/packages/PrecompileTools/L8A3n/src/workloads.jl:78 [inlined]
  [8] macro expansion
    @ ~/.julia/packages/LLVM/xklRb/src/precompile.jl:2 [inlined]
  [9] macro expansion
    @ ~/.julia/packages/PrecompileTools/L8A3n/src/workloads.jl:140 [inlined]
 [10] top-level scope
    @ ~/.julia/packages/LLVM/xklRb/src/precompile.jl:139
 [11] include(mod::Module, _path::String)
    @ Base ./Base.jl:495
 [12] include(x::String)
    @ LLVM ~/.julia/packages/LLVM/xklRb/src/LLVM.jl:1
 [13] top-level scope
    @ ~/.julia/packages/LLVM/xklRb/src/LLVM.jl:92
 [14] include
    @ ./Base.jl:495 [inlined]
 [15] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::String)
    @ Base ./loading.jl:2306
 [16] top-level scope
    @ stdin:5
in expression starting at /home/runner/.julia/packages/LLVM/xklRb/src/precompile.jl:1
in expression starting at /home/runner/.julia/packages/LLVM/xklRb/src/LLVM.jl:1
in expression starting at stdin:5
```
