### PR TITLE
Memcheck improvements

### DIFF
--- a/src/core/context.jl
+++ b/src/core/context.jl
@@ -50,8 +50,10 @@ be used after this operation.
 """
 function dispose(ctx::Context)
     deactivate(ctx)
-    leak_contexts[] && return
-    mark_dispose(API.LLVMContextDispose, ctx)
+    # in the leak path we still record the dispose in memcheck bookkeeping,
+    # just without actually freeing, so report_leaks stays quiet and any real
+    # missing dispose still stands out.
+    mark_dispose(leak_contexts[] ? Returns(nothing) : API.LLVMContextDispose, ctx)
 end
 
 function Context(f::Core.Function; kwargs...)

--- a/src/targetmachine.jl
+++ b/src/targetmachine.jl
@@ -123,7 +123,12 @@ function emit(tm::TargetMachine, mod::Module, filetype::API.LLVMCodeGenFileType)
         throw(LLVMException(error))
     end
 
-    return convert(Vector{UInt8}, MemoryBuffer(out_membuf[]))
+    membuf = mark_alloc(MemoryBuffer(out_membuf[]))
+    try
+        convert(Vector{UInt8}, membuf)
+    finally
+        dispose(membuf)
+    end
 end
 
 """


### PR DESCRIPTION
After https://github.com/JuliaLLVM/LLVM.jl/pull/546 we weren't correctly registering context frees. Fix that, and fix a leak.