### PR TITLE
Fix `@asmcall` multi-output IR for homogeneous tuples

### DIFF
--- a/src/interop/asmcall.jl
+++ b/src/interop/asmcall.jl
@@ -1,20 +1,5 @@
 export @asmcall
 
-# Count direct (non-indirect) outputs in an LLVM inline-asm constraint string.
-# LLVM's rule: with N>=2 direct outputs, the asm call's return type is a struct
-# {T0,...,T_{N-1}}. Indirect outputs (`=*`) write through pointer args and do
-# not contribute to the return.
-function _count_direct_outputs(constraints::AbstractString)
-    n = 0
-    for tok in eachsplit(constraints, ',')
-        s = lstrip(strip(tok), ('&', '%'))
-        if startswith(s, "=") && !startswith(s, "=*")
-            n += 1
-        end
-    end
-    return n
-end
-
 @generated function _asmcall(::Val{asm}, ::Val{constraints}, ::Val{side_effects},
                              ::Val{rettyp}, ::Val{argtyp}, args...) where
                             {asm, constraints, side_effects, rettyp, argtyp}
@@ -23,19 +8,19 @@ end
         llvm_argtyp = LLVMType[convert.(LLVMType, [argtyp.parameters...])...]
         llvm_f, llvm_ft = create_function(llvm_rettyp, llvm_argtyp)
 
-        # Multi-output inline asm returns a struct in LLVM, but Julia lowers
-        # homogeneous tuples to [N x T] arrays. Bridge the mismatch with
-        # extractvalue/insertvalue.
-        n_outputs = _count_direct_outputs(String(constraints))
-        asm_ft = if n_outputs >= 2
-            if !(rettyp <: Tuple) || length(rettyp.parameters) != n_outputs
-                error("multi-output @asmcall with $n_outputs outputs requires a Tuple rettyp with $n_outputs elements, got $rettyp")
-            end
+        # LLVM dictates the inline asm's return shape from the number of direct
+        # outputs in the constraint string: 0 -> void, 1 -> T, N>=2 -> a struct
+        # { T0, ..., T_{N-1} }. Julia, however, lowers homogeneous Tuples (incl.
+        # NTuple) to [N x T]. Drive the asm callee's return type from `rettyp`
+        # (Tuple ⇒ struct, scalar ⇒ T) so we always match LLVM's rule, then
+        # bridge to llvm_rettyp via insertvalue when Julia's lowering disagrees.
+        asm_rettyp = if rettyp <: Tuple && length(rettyp.parameters) > 0
             elem_types = LLVMType[convert(LLVMType, T) for T in rettyp.parameters]
-            LLVM.FunctionType(LLVM.StructType(elem_types), llvm_argtyp)
+            length(elem_types) == 1 ? elem_types[1] : LLVM.StructType(elem_types)
         else
-            llvm_ft
+            llvm_rettyp
         end
+        asm_ft = LLVM.FunctionType(asm_rettyp, llvm_argtyp)
         inline_asm = InlineAsm(asm_ft, String(asm), String(constraints), side_effects)
 
         @dispose builder=IRBuilder() begin
@@ -45,15 +30,20 @@ end
             val = call!(builder, asm_ft, inline_asm, collect(parameters(llvm_f)))
             if rettyp === Nothing
                 ret!(builder)
-            elseif n_outputs >= 2
+            elseif asm_rettyp == llvm_rettyp
+                ret!(builder, val)
+            else
+                # asm returned T or { T0, ... }; outer fn must return llvm_rettyp
+                # (typically [N x T] for homogeneous tuples). Reshape via
+                # insertvalue; optimization folds it away or reduces to a small
+                # struct→array shuffle.
                 ret_val = LLVM.UndefValue(llvm_rettyp)
-                for i in 0:n_outputs-1
-                    ret_val = insert_value!(builder, ret_val,
-                                            extract_value!(builder, val, i), i)
+                n = length(rettyp.parameters)
+                for i in 0:n-1
+                    elem = n == 1 ? val : extract_value!(builder, val, i)
+                    ret_val = insert_value!(builder, ret_val, elem, i)
                 end
                 ret!(builder, ret_val)
-            else
-                ret!(builder, val)
             end
         end
 

--- a/src/interop/asmcall.jl
+++ b/src/interop/asmcall.jl
@@ -58,6 +58,21 @@ end
 Call some inline assembly `asm`, optionally constrained by `constraints` and denoting other
 side effects in `side_effects`, specifying the return type in `rettyp` and types of
 arguments as a tuple-type in `argtyp`.
+
+For inline asm with multiple direct outputs (e.g. constraints `"=r,=r"`), pass `rettyp` as a
+`Tuple` whose element count matches the number of `=` outputs in `constraints`; the result
+is returned as a Julia tuple. Use a scalar `rettyp` for a single output, and `Nothing` when
+the asm has no direct outputs (indirect `=*` outputs that write through pointer arguments
+do not contribute to the return).
+
+```julia
+# single output
+@asmcall("bswap \$0", "=r,r", UInt32, Tuple{UInt32}, x)
+
+# two outputs (heterogeneous and homogeneous both work)
+@asmcall("...", "=r,=r", Tuple{Int16,Int32})
+@asmcall("...", "=r,=r", Tuple{UInt32,UInt32})
+```
 """
 :(@asmcall)
 

--- a/src/interop/asmcall.jl
+++ b/src/interop/asmcall.jl
@@ -23,11 +23,9 @@ end
         llvm_argtyp = LLVMType[convert.(LLVMType, [argtyp.parameters...])...]
         llvm_f, llvm_ft = create_function(llvm_rettyp, llvm_argtyp)
 
-        # Multi-output inline asm must return a struct in LLVM IR. Julia's
-        # homogeneous-bitwidth tuples lower to [N x T] arrays instead, so build
-        # the asm's FunctionType with an explicit struct return and bridge to
-        # llvm_rettyp via extractvalue/insertvalue. For 0/1 outputs the asm's
-        # return type matches llvm_rettyp directly and no bridge is needed.
+        # Multi-output inline asm returns a struct in LLVM, but Julia lowers
+        # homogeneous-bitwidth tuples to [N x T] arrays. Bridge the mismatch
+        # with extractvalue/insertvalue.
         n_outputs = _count_direct_outputs(String(constraints))
         asm_ft = if n_outputs >= 2
             if !(rettyp <: Tuple) || length(rettyp.parameters) != n_outputs

--- a/src/interop/asmcall.jl
+++ b/src/interop/asmcall.jl
@@ -24,8 +24,8 @@ end
         llvm_f, llvm_ft = create_function(llvm_rettyp, llvm_argtyp)
 
         # Multi-output inline asm returns a struct in LLVM, but Julia lowers
-        # homogeneous-bitwidth tuples to [N x T] arrays. Bridge the mismatch
-        # with extractvalue/insertvalue.
+        # homogeneous tuples to [N x T] arrays. Bridge the mismatch with
+        # extractvalue/insertvalue.
         n_outputs = _count_direct_outputs(String(constraints))
         asm_ft = if n_outputs >= 2
             if !(rettyp <: Tuple) || length(rettyp.parameters) != n_outputs

--- a/src/interop/asmcall.jl
+++ b/src/interop/asmcall.jl
@@ -1,24 +1,59 @@
 export @asmcall
 
+# Count direct (non-indirect) outputs in an LLVM inline-asm constraint string.
+# LLVM's rule: with N>=2 direct outputs, the asm call's return type is a struct
+# {T0,...,T_{N-1}}. Indirect outputs (`=*`) write through pointer args and do
+# not contribute to the return.
+function _count_direct_outputs(constraints::AbstractString)
+    n = 0
+    for tok in eachsplit(constraints, ',')
+        s = lstrip(strip(tok), ('&', '%'))
+        if startswith(s, "=") && !startswith(s, "=*")
+            n += 1
+        end
+    end
+    return n
+end
+
 @generated function _asmcall(::Val{asm}, ::Val{constraints}, ::Val{side_effects},
                              ::Val{rettyp}, ::Val{argtyp}, args...) where
                             {asm, constraints, side_effects, rettyp, argtyp}
     @dispose ctx=Context() begin
-        # create a function
         llvm_rettyp = convert(LLVMType, rettyp)
         llvm_argtyp = LLVMType[convert.(LLVMType, [argtyp.parameters...])...]
         llvm_f, llvm_ft = create_function(llvm_rettyp, llvm_argtyp)
 
-        inline_asm = InlineAsm(llvm_ft, String(asm), String(constraints), side_effects)
+        # Multi-output inline asm must return a struct in LLVM IR. Julia's
+        # homogeneous-bitwidth tuples lower to [N x T] arrays instead, so build
+        # the asm's FunctionType with an explicit struct return and bridge to
+        # llvm_rettyp via extractvalue/insertvalue. For 0/1 outputs the asm's
+        # return type matches llvm_rettyp directly and no bridge is needed.
+        n_outputs = _count_direct_outputs(String(constraints))
+        asm_ft = if n_outputs >= 2
+            if !(rettyp <: Tuple) || length(rettyp.parameters) != n_outputs
+                error("multi-output @asmcall with $n_outputs outputs requires a Tuple rettyp with $n_outputs elements, got $rettyp")
+            end
+            elem_types = LLVMType[convert(LLVMType, T) for T in rettyp.parameters]
+            LLVM.FunctionType(LLVM.StructType(elem_types), llvm_argtyp)
+        else
+            llvm_ft
+        end
+        inline_asm = InlineAsm(asm_ft, String(asm), String(constraints), side_effects)
 
-        # generate IR
         @dispose builder=IRBuilder() begin
             entry = BasicBlock(llvm_f, "entry")
             position!(builder, entry)
 
-            val = call!(builder, llvm_ft, inline_asm, collect(parameters(llvm_f)))
-            if rettyp == Nothing
+            val = call!(builder, asm_ft, inline_asm, collect(parameters(llvm_f)))
+            if rettyp === Nothing
                 ret!(builder)
+            elseif n_outputs >= 2
+                ret_val = LLVM.UndefValue(llvm_rettyp)
+                for i in 0:n_outputs-1
+                    ret_val = insert_value!(builder, ret_val,
+                                            extract_value!(builder, val, i), i)
+                end
+                ret!(builder, ret_val)
             else
                 ret!(builder, val)
             end

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -137,6 +137,12 @@ if Sys.ARCH == :x86 || Sys.ARCH == :x86_64
 d1(a) = @asmcall("bswap \$0", "=r,r", Int32, Tuple{Int32}, a)
 @test d1(Int32(1)) == Int32(16777216)
 
+# single output as a 1-element Tuple (Julia lowers this to [1 x T], so the
+# scalar asm result needs to be reshaped into the array)
+
+d2(a) = @asmcall("bswap \$0", "=r,r", Tuple{Int32}, Tuple{Int32}, a)
+@test d2(Int32(1)) === (Int32(16777216),)
+
 # multiple output registers
 
 e1() = @asmcall("mov \$\$1, \$0; mov \$\$2, \$1;", "=r,=r", Tuple{Int16,Int32})

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -142,6 +142,25 @@ d1(a) = @asmcall("bswap \$0", "=r,r", Int32, Tuple{Int32}, a)
 e1() = @asmcall("mov \$\$1, \$0; mov \$\$2, \$1;", "=r,=r", Tuple{Int16,Int32})
 @test e1() == (Int16(1), Int32(2))
 
+# homogeneous-bitwidth tuples (Julia lowers these to [N x T] arrays — the asm
+# call still returns a struct, so the bridge must reshape it).
+
+e2() = @asmcall("mov \$\$1, \$0; mov \$\$2, \$1;", "=r,=r", Tuple{Int32,Int32})
+@test e2() == (Int32(1), Int32(2))
+
+e3() = @asmcall("mov \$\$1, \$0; mov \$\$2, \$1;", "=r,=r", Tuple{UInt32,UInt32})
+@test e3() == (UInt32(1), UInt32(2))
+
+e4() = @asmcall("mov \$\$1, \$0; mov \$\$2, \$1; mov \$\$3, \$2; mov \$\$4, \$3;",
+                "=r,=r,=r,=r", NTuple{4,Int32})
+@test e4() == (Int32(1), Int32(2), Int32(3), Int32(4))
+
+# multi-output with input operands (regression for issue #531).
+
+e5(x) = @asmcall("mov \$2, \$0; mov \$2, \$1;", "=r,=r,r", true,
+                 Tuple{Int32,Int32}, Tuple{Int32}, x)
+@test e5(Int32(7)) == (Int32(7), Int32(7))
+
 # TODO: alternative test snippets for other platforms
 
 end

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -155,11 +155,24 @@ e4() = @asmcall("mov \$\$1, \$0; mov \$\$2, \$1; mov \$\$3, \$2; mov \$\$4, \$3;
                 "=r,=r,=r,=r", NTuple{4,Int32})
 @test e4() == (Int32(1), Int32(2), Int32(3), Int32(4))
 
-# multi-output with input operands (regression for issue #531).
+# multi-output with input operands
 
 e5(x) = @asmcall("mov \$2, \$0; mov \$2, \$1;", "=r,=r,r", true,
                  Tuple{Int32,Int32}, Tuple{Int32}, x)
 @test e5(Int32(7)) == (Int32(7), Int32(7))
+
+# multi-output with input + per-output computation.
+
+e6(x) = @asmcall("mov \$2, \$0; lea 10(\$2), \$1;", "=r,=r,r", true,
+                 Tuple{Int32,Int32}, Tuple{Int32}, x)
+@test e6(Int32(12)) == (Int32(12), Int32(22))
+
+e7(x) = @asmcall("mov \$2, \$0; mov \$2, \$1;", "=r,=r,r", true,
+                 Tuple{Int32,Int32}, Tuple{Int32}, x)
+let ir = sprint(io -> code_llvm(io, e7, Tuple{Int32}))
+    @test occursin(r"call \{ i32, i32 \} asm", ir)
+    @test !occursin(r"call \[2 x i32\] asm", ir)
+end
 
 # TODO: alternative test snippets for other platforms
 


### PR DESCRIPTION
`@asmcall` produced malformed IR when the constraint string has 2+ direct outputs (e.g. `=r,=r`) and the rettyp is a homogeneous tuple like `Tuple{UInt32,UInt32}` or `NTuple{4,UInt32}`.

LLVM forces multi-output inline asm to return a struct `{T0,...,Tn}`, but Julia lowers homogeneous tuples to `[N x T]` arrays. The previous code used Julia's lowered type as the asm's declared return, so the `call`'s result type didn't match. Heterogeneous tuples like `Tuple{Int16,Int32}` lower to a struct directly, which happens to match what LLVM wants.

Build the asm's FunctionType with an explicit struct return and bridge to llvm_rettyp via extractvalue/insertvalue. After optimization the bridge folds away for the heterogeneous case and reduces to a small struct→array reshape for the homogeneous one.

Found this independently of #531. Wrote a workaround downstream first, so this PR is the upstream fix. Diagnosis and patch developed with Claude. Happy to iterate if there's a cleaner approach.

Fixes #531