### PR TITLE
Publish no-op __register_frame stubs on Windows.

### DIFF
--- a/src/LLVM.jl
+++ b/src/LLVM.jl
@@ -119,6 +119,7 @@ function __init__()
                   Please re-compile Julia and LLVM.jl (but note that USE_SYSTEM_LLVM is not a supported configuration)."""
     end
 
+    register_eh_frame_stubs()
     _install_handlers()
     atexit(report_leaks)
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,4 +1,7 @@
 @setup_workload begin
+    # __init__ has not yet run during precompilation, so ensure the EH frame
+    # registration stubs are published before exercising the LLJIT (see support.jl).
+    register_eh_frame_stubs()
     @compile_workload begin
         @dispose ctx=Context() begin
             # Type conversions for common Julia primitive types

--- a/src/support.jl
+++ b/src/support.jl
@@ -23,3 +23,17 @@ load_library_permanently(path) = API.LLVMLoadLibraryPermanently(path)
 
 # Search the global symbols for `name` and return the pointer to it.
 find_symbol(name) = API.LLVMSearchForAddressOfSymbol(name)
+
+# No-op stubs for DWARF EH frame registration. Windows x86_64 uses SEH for unwinding,
+# so registering DWARF frames is unnecessary. Since LLVM 21, JITLink's EHFrameRegistration
+# plugin treats a missing `__register_frame` as a hard error (previously, the void-typed
+# SPS wrapper silently swallowed it), so we publish no-op symbols to satisfy the lookup.
+noop_register_frame(::Ptr{Cvoid})::Cvoid = nothing
+
+function register_eh_frame_stubs()
+    Sys.iswindows() || return
+    fp = @cfunction(noop_register_frame, Cvoid, (Ptr{Cvoid},))
+    add_symbol("__register_frame", fp)
+    add_symbol("__deregister_frame", fp)
+    return
+end


### PR DESCRIPTION
LLVM 21's EHFrameRegistrationPlugin treats a missing __register_frame as a hard error, breaking LLJIT lookup on Windows (which uses SEH).