### PR TITLE
Wrap ExpandAtomicModifyPass (Julia 1.13)

### DIFF
--- a/src/interop/passes.jl
+++ b/src/interop/passes.jl
@@ -25,6 +25,9 @@ end
 @static if VERSION >= v"1.11.0-DEV.208"
     @function_pass "FinalLowerGC" FinalLowerGCPass
 end
+@static if VERSION >= v"1.13.0-DEV.321"
+    @function_pass "ExpandAtomicModify" ExpandAtomicModifyPass
+end
 @function_pass "GCInvariantVerifier" GCInvariantVerifierPass
 
 @loop_pass "JuliaLICM" JuliaLICMPass

--- a/test/newpm.jl
+++ b/test/newpm.jl
@@ -539,6 +539,9 @@ end
                     if VERSION >= v"1.11.0-DEV.208"
                         add!(fpm, FinalLowerGCPass())
                     end
+                    if VERSION >= v"1.13.0-DEV.321"
+                        add!(fpm, ExpandAtomicModifyPass())
+                    end
                 end
                 if VERSION < v"1.11.0-DEV.208"
                     add!(mpm, FinalLowerGCPass())


### PR DESCRIPTION
Julia 1.13 (JuliaLang/julia#57010, `1.13.0-DEV.321`) added the `ExpandAtomicModify` function pass, which lowers the `julia.atomicmodify.*` pseudo-intrinsics. Wrap it so downstream packages (e.g. GPUCompiler.jl) don't need to define it themselves.

The pass is registered in Julia as `FUNCTION_PASS("ExpandAtomicModify", ExpandAtomicModifyPass())`; the version gate matches the introducing commit exactly (`contrib/commit-name.sh aab74908dc6` → `1.13.0-DEV.321`).

Also adds it to the Julia-pipeline replication test in `test/newpm.jl`, right after `FinalLowerGCPass`, matching its placement in Julia's `src/pipeline.cpp`.

Tested on 1.13.0-rc1: `newpm` and `interop` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)