### PR TITLE
test: Use upcoming TypeEgal for addrspacecast code_llvm

### DIFF
--- a/test/interop.jl
+++ b/test/interop.jl
@@ -363,7 +363,8 @@ end
     ptr = reinterpret(Core.LLVMPtr{Int64, 4}, 0)
     for eltype_dest in (Int64, Int32), AS_dest in (4, 3)
         T_dest = Core.LLVMPtr{eltype_dest, AS_dest}
-        ir = sprint(io->code_llvm(io, LLVM.Interop.addrspacecast, Tuple{Type{T_dest}, typeof(ptr)}))
+        T_arg = isdefined(Core, :TypeEgal) ? Core.TypeEgal{T_dest} : Type{T_dest}
+        ir = sprint(io->code_llvm(io, LLVM.Interop.addrspacecast, Tuple{T_arg, typeof(ptr)}))
         if supports_typed_ptrs
             if AS_dest == 3
                 @test contains(ir, r"addrspacecast i8 addrspace\(4\)\* %.+? to i8 addrspace\(3\)\*")


### PR DESCRIPTION
The Base PR JuliaLang/julia#62001 is expected to spell exact closed type-object dispatch keys as Core.TypeEgal. Select that upcoming type-object argument spelling for the addrspacecast code_llvm test when Julia exposes Core.TypeEgal, while preserving the existing Type{T} path on older Julia versions.

AI disclosure: This commit was prepared with assistance from generative AI. The resulting PR should be checked carefully by a maintainer before merging.