### PR TITLE
"Don't crash the process when reporting errors

### DIFF
--- a/docs/src/man/essentials.md
+++ b/docs/src/man/essentials.md
@@ -154,6 +154,31 @@ julia> @dispose ctx=Context() mod=LLVM.Module("jit") begin
 
 It is recommended to use the [`@dispose`](@ref) macro whenever possible.
 
+### Disposal during exception handling
+
+When a context is disposed of while an exception is being thrown -- for example, when an
+error occurs inside a `Context() do` block, whose implicit `dispose` call then runs during
+stack unwinding -- the context is popped from the context stack but intentionally leaked
+instead of freed. This ensures that LLVM objects captured by the exception, or by test
+machinery recording it, remain valid when they are displayed later, e.g., as part of a test
+summary. Without this, reporting such errors would crash the process:
+
+```jldoctest
+julia> val = Ref{Any}();
+
+julia> try
+         @dispose ctx=Context() begin
+           val[] = LLVM.ConstantInt(Int32(42))
+           error("something went wrong")
+           # the implicit `dispose(ctx)` does not free the context here
+         end
+       catch
+       end
+
+julia> string(val[]) # safe, even though the context was disposed of
+"i32 42"
+```
+
 ### Debugging missing disposals
 
 To ensure that all resources are properly disposed of, LLVM.jl provides functionality to

--- a/src/core/context.jl
+++ b/src/core/context.jl
@@ -37,23 +37,30 @@ function Context(; opaque_pointers=nothing)
     ctx
 end
 
-# when set, `dispose(::Context)` only pops the context off the stack without actually
-# freeing it. intended for test setups that need to keep LLVM values alive for display
-# after the enclosing `Context() do`/`@dispose ctx=Context()` block has exited.
-const leak_contexts = Ref(false)
+# whether a context being disposed should be leaked instead of freed. this is the case
+# when an exception is in flight (i.e., when disposing from a `finally` block during
+# unwinding): the exception, or test machinery recording it, may have captured objects
+# from this context and will only display them after the context has been disposed,
+# which would crash the process.
+leak_context() = !isempty(current_exceptions())
 
 """
     dispose(ctx::Context)
 
 Dispose of the context, releasing all resources associated with it. The context should not
 be used after this operation.
+
+If an exception is in flight (e.g., when the context is disposed of by a `finally` block
+during stack unwinding), the context is popped from the context stack but intentionally
+leaked instead of freed. This keeps any values captured by the exception valid, so that
+error reporting does not crash the process.
 """
 function dispose(ctx::Context)
     deactivate(ctx)
     # in the leak path we still record the dispose in memcheck bookkeeping,
     # just without actually freeing, so report_leaks stays quiet and any real
     # missing dispose still stands out.
-    mark_dispose(leak_contexts[] ? Returns(nothing) : API.LLVMContextDispose, ctx)
+    mark_dispose(leak_context() ? Returns(nothing) : API.LLVMContextDispose, ctx)
 end
 
 function Context(f::Core.Function; kwargs...)

--- a/src/executionengine/ts_module.jl
+++ b/src/executionengine/ts_module.jl
@@ -20,9 +20,11 @@ This object needs to be disposed of using [`dispose(::ThreadSafeContext)`](@ref)
 """
 function ThreadSafeContext(; opaque_pointers=nothing)
     ts_ctx = mark_alloc(ThreadSafeContext(API.LLVMOrcCreateNewThreadSafeContext()))
+    ctx = context(ts_ctx)
     if opaque_pointers !== nothing
-        opaque_pointers!(context(ts_ctx), opaque_pointers)
+        opaque_pointers!(ctx, opaque_pointers)
     end
+    _install_handlers(ctx)
     activate(ts_ctx)
     ts_ctx
 end

--- a/src/executionengine/ts_module.jl
+++ b/src/executionengine/ts_module.jl
@@ -57,10 +57,13 @@ end
     dispose(ctx::ThreadSafeContext)
 
 Dispose of the thread-safe context, releasing all resources associated with it.
+
+If an exception is in flight, the context is leaked instead of freed, so that values
+captured by the exception remain valid; see [`dispose(::Context)`](@ref).
 """
 function dispose(ctx::ThreadSafeContext)
     deactivate(ctx)
-    mark_dispose(API.LLVMOrcDisposeThreadSafeContext, ctx)
+    mark_dispose(leak_context() ? Returns(nothing) : API.LLVMOrcDisposeThreadSafeContext, ctx)
 end
 
 """

--- a/test/core.jl
+++ b/test/core.jl
@@ -43,6 +43,18 @@ Context() do ctx end
     end
 end
 
+# disposing a context during exception unwinding should leak it instead of freeing it,
+# so that values captured by the exception (or by test machinery recording it) can still
+# be displayed afterwards
+let
+    val = Ref{Any}()
+    @test_throws ErrorException Context() do ctx
+        val[] = ConstantInt(Int32(42))
+        error("some error")
+    end
+    @test occursin("42", string(val[]))
+end
+
 @test context(; throw_error=false) === nothing
 
 end

--- a/test/orc.jl
+++ b/test/orc.jl
@@ -14,6 +14,23 @@ end
 ThreadSafeContext() do ctx
 end
 
+@testset "diagnostics" begin
+    # diagnostics emitted in the inner context should be thrown as LLVMExceptions, just
+    # like with a regular Context; without a handler installed, LLVM's default behavior
+    # is to print the error and exit the process.
+    ThreadSafeContext() do ts_ctx
+        ctx = context(ts_ctx)
+        activate(ctx)
+        try
+            invalid_bitcode = unsafe_wrap(Vector{UInt8}, "invalid")
+            @test_throws LLVMException parse(LLVM.Module, invalid_bitcode)
+            @test_throws LLVMException parse(LLVM.Module, invalid_bitcode; lazy=true)
+        finally
+            deactivate(ctx)
+        end
+    end
+end
+
 @testset "ThreadSafeModule" begin
     @dispose ts_ctx=ThreadSafeContext() ts_mod=ThreadSafeModule("jit") begin
         @test_throws LLVMException ts_mod() do mod

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,10 +1,6 @@
 using LLVM
 using Test
 
-# if a test throws within a Context() do block, displaying the LLVM value may crash
-# because the context has been disposed already. avoid that by leaking contexts.
-LLVM.leak_contexts[] = true
-
 macro check_ir(inst, str)
     quote
         inst = string($(esc(inst)))


### PR DESCRIPTION
Two fixes for error paths that killed the process instead of reporting the error:

- `ThreadSafeContext()` now installs the same diagnostic handler as `Context()`.
  Previously, diagnostic errors in its inner context (e.g. parsing corrupt bitcode)
  hit LLVM's default handler, which prints to stderr and calls `exit(1)`,
  uncatchable from Julia. They now throw `LLVMException`.

- `dispose(::Context)` and `dispose(::ThreadSafeContext)` now detect an in-flight
  exception (via `current_exceptions()`, i.e. when invoked from a `finally` block
  during unwinding) and leak the context instead of freeing it, so LLVM values
  captured by the exception -- or by test machinery recording it -- remain valid
  for later display. This replaces the `leak_contexts[]` override our test suite
  used, and extends the protection to downstream users (e.g. GPUCompiler's
  `InvalidIRError` holding IR values past `JuliaContext()` disposal) without
  requiring them to opt in.