### PR TITLE
Expose `convertUsersOfConstantsToInstructions` as `convert_users_to_instructions!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ BFloat16sExt = "BFloat16s"
 [compat]
 BFloat16s = "0.4, 0.5, 0.6"
 CEnum = "0.2, 0.3, 0.4, 0.5"
-LLVMExtra_jll = "=0.0.43"
+LLVMExtra_jll = "=0.0.44"
 Libdl = "1.8"
 PrecompileTools = "1"
 Preferences = "1.4"

--- a/deps/LLVMExtra/CMakeLists.txt
+++ b/deps/LLVMExtra/CMakeLists.txt
@@ -4,7 +4,7 @@ SET(CMAKE_CXX_FLAGS "-Wall -fPIC -fno-rtti")
 
 project(LLVMExtra
 VERSION
-    1.8
+    1.9
 LANGUAGES
    CXX
    C

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -84,6 +84,24 @@ void LLVMDestroyConstant(LLVMValueRef Const);
 LLVMTypeRef LLVMGetFunctionType(LLVMValueRef Fn);
 LLVMTypeRef LLVMGetGlobalValueType(LLVMValueRef Fn);
 
+// Replace constant-expression/aggregate users of the given constants with
+// equivalent instructions at each point of use; phi operands are materialized
+// in their incoming block. Mirrors llvm::convertUsersOfConstantsToInstructions
+// (llvm/IR/ReplaceConstant.h). Returns true if anything changed.
+//
+// The full four-parameter semantics are only available on LLVM 19+. On LLVM
+// 17/18 only the single-argument overload exists, so RestrictToFunc,
+// RemoveDeadConstants and IncludeSelf are fixed at nullptr/true/false
+// respectively (the Julia wrapper rejects other values there). LLVM < 17 does
+// not export the utility at all, so the function is unavailable.
+#if LLVM_VERSION_MAJOR >= 17
+LLVMBool LLVMConvertUsersOfConstantsToInstructions(LLVMValueRef *Consts,
+                                                   size_t Count,
+                                                   LLVMValueRef RestrictToFunc,
+                                                   LLVMBool RemoveDeadConstants,
+                                                   LLVMBool IncludeSelf);
+#endif
+
 // Attribute type detection (ConstantRange/ConstantRangeList kinds not exposed in C API)
 #if LLVM_VERSION_MAJOR >= 19
 LLVMBool LLVMIsConstantRangeAttribute(LLVMAttributeRef A);

--- a/deps/LLVMExtra/lib/Core.cpp
+++ b/deps/LLVMExtra/lib/Core.cpp
@@ -20,6 +20,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/ReplaceConstant.h>
 #include <llvm/Linker/Linker.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Transforms/IPO.h>
@@ -293,6 +294,32 @@ LLVMTypeRef LLVMGetGlobalValueType(LLVMValueRef GV) {
   auto Ftype = unwrap<GlobalValue>(GV)->getValueType();
   return wrap(Ftype);
 }
+
+#if LLVM_VERSION_MAJOR >= 17
+LLVMBool LLVMConvertUsersOfConstantsToInstructions(LLVMValueRef *Consts,
+                                                   size_t Count,
+                                                   LLVMValueRef RestrictToFunc,
+                                                   LLVMBool RemoveDeadConstants,
+                                                   LLVMBool IncludeSelf) {
+  SmallVector<Constant *> Cs;
+  for (auto *C : ArrayRef(Consts, Count))
+    Cs.push_back(cast<Constant>(unwrap(C)));
+#if LLVM_VERSION_MAJOR >= 19
+  return convertUsersOfConstantsToInstructions(
+      Cs, RestrictToFunc ? unwrap<Function>(RestrictToFunc) : nullptr,
+      RemoveDeadConstants, IncludeSelf);
+#else
+  // LLVM 17/18 only expose the single-argument overload, whose behavior is
+  // fixed at RestrictToFunc=nullptr, RemoveDeadConstants=true,
+  // IncludeSelf=false. The Julia wrapper rejects non-default values for these
+  // on LLVM < 19, so it is safe to ignore them here.
+  (void)RestrictToFunc;
+  (void)RemoveDeadConstants;
+  (void)IncludeSelf;
+  return convertUsersOfConstantsToInstructions(Cs);
+#endif
+}
+#endif
 
 
 //

--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -31,7 +31,7 @@ mkpath(build_dir)
 # download LLVM
 Pkg.activate(; temp=true)
 llvm_assertions = try
-    cglobal((:_ZN4llvm24DisableABIBreakingChecksE, Base.libllvm_path()), Cvoid)
+    dlsym(dlopen(Base.libllvm_path()), :_ZN4llvm24DisableABIBreakingChecksE)
     false
 catch
     true

--- a/docs/src/lib/values.md
+++ b/docs/src/lib/values.md
@@ -45,6 +45,7 @@ ConstantArray(::AbstractArray)
 collect(::ConstantArray)
 InlineAsm
 LLVM.ConstantExpr
+convert_users_to_instructions!
 ```
 
 ## Global values

--- a/docs/src/man/values.md
+++ b/docs/src/man/values.md
@@ -172,6 +172,36 @@ ptr inttoptr (i64 42 to ptr)
 
 For the exact list of supported constant expressions, refer to the LLVM documentation.
 
+Constant expressions (and constant aggregates) that wrap a given set of constants can be
+rewritten into equivalent instructions at each point of use, using
+`convert_users_to_instructions!`. This is useful when a constant needs to be replaced with a
+function-local value, which is not a valid operand of a constant expression. For example,
+given a global variable that is used through a `getelementptr` constant expression:
+
+```llvm
+define i32 @getelem() {
+entry:
+  %0 = load i32, ptr getelementptr inbounds ([4 x i32], ptr @myglobal, i32 0, i32 2), align 4
+  ret i32 %0
+}
+```
+
+calling `convert_users_to_instructions!([myglobal])` materializes the constant expression as
+a regular instruction:
+
+```llvm
+define i32 @getelem() {
+entry:
+  %0 = getelementptr inbounds [4 x i32], ptr @myglobal, i32 0, i32 2
+  %1 = load i32, ptr %0, align 4
+  ret i32 %1
+}
+```
+
+Operands of `phi` nodes are materialized in their respective incoming blocks. The function
+returns whether anything was changed, and by default removes the constants that became dead
+as a result of the rewrite.
+
 ### Inline assembly
 
 Inline assembly is a way to include raw assembly code in a program. It is often used to

--- a/lib/17/libLLVM_extra.jl
+++ b/lib/17/libLLVM_extra.jl
@@ -110,6 +110,10 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+    ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+end
+
 function LLVMIsConstantRangeAttribute(A)
     ccall((:LLVMIsConstantRangeAttribute, libLLVMExtra), LLVMBool, (LLVMAttributeRef,), A)
 end

--- a/lib/18/libLLVM_extra.jl
+++ b/lib/18/libLLVM_extra.jl
@@ -110,6 +110,10 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+    ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+end
+
 function LLVMIsConstantRangeAttribute(A)
     ccall((:LLVMIsConstantRangeAttribute, libLLVMExtra), LLVMBool, (LLVMAttributeRef,), A)
 end

--- a/lib/19/libLLVM_extra.jl
+++ b/lib/19/libLLVM_extra.jl
@@ -110,6 +110,10 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+    ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+end
+
 function LLVMIsConstantRangeAttribute(A)
     ccall((:LLVMIsConstantRangeAttribute, libLLVMExtra), LLVMBool, (LLVMAttributeRef,), A)
 end

--- a/lib/20/libLLVM_extra.jl
+++ b/lib/20/libLLVM_extra.jl
@@ -110,6 +110,10 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+    ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+end
+
 function LLVMIsConstantRangeAttribute(A)
     ccall((:LLVMIsConstantRangeAttribute, libLLVMExtra), LLVMBool, (LLVMAttributeRef,), A)
 end

--- a/lib/21/libLLVM_extra.jl
+++ b/lib/21/libLLVM_extra.jl
@@ -110,6 +110,10 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+    ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
+end
+
 function LLVMIsConstantRangeAttribute(A)
     ccall((:LLVMIsConstantRangeAttribute, libLLVMExtra), LLVMBool, (LLVMAttributeRef,), A)
 end

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -15,6 +15,41 @@ unsafe_destroy!(constant::Constant) = API.LLVMDestroyConstant(constant)
 end
 abstract type Instruction <: User end
 
+export convert_users_to_instructions!
+
+"""
+    convert_users_to_instructions!(consts::Vector{<:Constant};
+                                   func::Union{Nothing,LLVM.Function}=nothing,
+                                   remove_dead_constants::Bool=true,
+                                   include_self::Bool=false) -> Bool
+
+Rewrite every constant expression or constant aggregate that (transitively) uses one of
+`consts` into equivalent instructions at each point of use; phi operands are materialized in
+their incoming block. Returns whether anything changed.
+
+Optionally restrict the rewrite to `func`, keep dead constants around
+(`remove_dead_constants=false`), or also convert the passed constants themselves
+(`include_self=true`). These three options require LLVM 19 or later; the function itself
+requires LLVM 17 or later.
+"""
+function convert_users_to_instructions!(consts::Vector{<:Constant};
+                                        func=nothing,
+                                        remove_dead_constants::Bool=true,
+                                        include_self::Bool=false)
+    if version() < v"17"
+        throw(ArgumentError("convert_users_to_instructions! requires LLVM 17 or later"))
+    end
+    if version() < v"19" && (func !== nothing || !remove_dead_constants || include_self)
+        throw(ArgumentError("the `func`, `remove_dead_constants` and `include_self` " *
+                            "options require LLVM 19 or later"))
+    end
+    func === nothing || func isa Function ||
+        throw(ArgumentError("`func` must be an LLVM.Function or `nothing`"))
+    API.LLVMConvertUsersOfConstantsToInstructions(
+        consts, length(consts), something(func, C_NULL),
+        remove_dead_constants, include_self) |> Bool
+end
+
 
 ## convenience constructors
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -746,6 +746,156 @@ end
     end
 end
 
+# convert_users_to_instructions!
+if LLVM.version() >= v"17"
+@testset "convert users to instructions" begin
+
+# a global used through a constant-expression GEP inside a function
+@dispose ctx=Context() builder=IRBuilder() mod=LLVM.Module("SomeModule") begin
+    T_i32 = LLVM.Int32Type()
+    T_arr = LLVM.ArrayType(T_i32, 4)
+    gv = GlobalVariable(mod, T_arr, "gv")
+
+    fn = LLVM.Function(mod, "f", LLVM.FunctionType(T_i32, LLVM.LLVMType[]))
+    position!(builder, BasicBlock(fn, "entry"))
+    ce = const_gep(T_arr, gv, LLVM.Constant[ConstantInt(Int32(0)), ConstantInt(Int32(2))])
+    loadinst = load!(builder, T_i32, ce)
+    ret!(builder, loadinst)
+
+    # before: the load's pointer operand is a constant expression
+    @test operands(loadinst)[1] isa LLVM.ConstantExpr
+
+    @test convert_users_to_instructions!(LLVM.Constant[gv])
+
+    # after: the operand is an instruction, and the dead constexpr is gone
+    @test operands(loadinst)[1] isa LLVM.Instruction
+    @check_ir operands(loadinst)[1] "getelementptr"
+    @test all(u -> user(u) isa LLVM.Instruction, uses(gv))
+
+    # calling again is a no-op
+    @test !convert_users_to_instructions!(LLVM.Constant[gv])
+end
+
+# a global used directly (no constant expression): a no-op
+@dispose ctx=Context() builder=IRBuilder() mod=LLVM.Module("SomeModule") begin
+    T_i32 = LLVM.Int32Type()
+    gv = GlobalVariable(mod, T_i32, "gv")
+
+    fn = LLVM.Function(mod, "f", LLVM.FunctionType(T_i32, LLVM.LLVMType[]))
+    position!(builder, BasicBlock(fn, "entry"))
+    ret!(builder, load!(builder, T_i32, gv))
+
+    @test !convert_users_to_instructions!(LLVM.Constant[gv])
+end
+
+# a phi whose incoming value is a constant expression: the materialized
+# instruction lands in the incoming block, not in the phi's block
+@dispose ctx=Context() builder=IRBuilder() mod=LLVM.Module("SomeModule") begin
+    T_i32 = LLVM.Int32Type()
+    T_ptr = LLVM.PointerType(T_i32)
+    T_arr = LLVM.ArrayType(T_i32, 4)
+    gv = GlobalVariable(mod, T_arr, "gv")
+
+    fn = LLVM.Function(mod, "f", LLVM.FunctionType(T_i32, [LLVM.Int1Type()]))
+    entry = BasicBlock(fn, "entry")
+    left = BasicBlock(fn, "left")
+    merge = BasicBlock(fn, "merge")
+
+    position!(builder, entry)
+    br!(builder, parameters(fn)[1], left, merge)
+    position!(builder, left)
+    br!(builder, merge)
+    position!(builder, merge)
+    ce = const_gep(T_arr, gv, LLVM.Constant[ConstantInt(Int32(0)), ConstantInt(Int32(2))])
+    phi = phi!(builder, T_ptr)
+    append!(incoming(phi), [(ce, left), (null(T_ptr), entry)])
+    ret!(builder, load!(builder, T_i32, phi))
+
+    @test convert_users_to_instructions!(LLVM.Constant[gv])
+
+    hasgep(bb) = any(inst -> occursin("getelementptr", string(inst)), instructions(bb))
+    @test hasgep(left)    # materialized in the incoming block
+    @test !hasgep(merge)  # not in the phi's own block
+end
+
+# options that require LLVM 19+
+if LLVM.version() >= v"19"
+
+# `func` restricts the rewrite to a single function
+@dispose ctx=Context() builder=IRBuilder() mod=LLVM.Module("SomeModule") begin
+    T_i32 = LLVM.Int32Type()
+    T_arr = LLVM.ArrayType(T_i32, 4)
+    gv = GlobalVariable(mod, T_arr, "gv")
+    ft = LLVM.FunctionType(T_i32, LLVM.LLVMType[])
+    idxs = LLVM.Constant[ConstantInt(Int32(0)), ConstantInt(Int32(2))]
+
+    f1 = LLVM.Function(mod, "f1", ft)
+    position!(builder, BasicBlock(f1, "entry"))
+    l1 = load!(builder, T_i32, const_gep(T_arr, gv, idxs))
+    ret!(builder, l1)
+
+    f2 = LLVM.Function(mod, "f2", ft)
+    position!(builder, BasicBlock(f2, "entry"))
+    l2 = load!(builder, T_i32, const_gep(T_arr, gv, idxs))
+    ret!(builder, l2)
+
+    # (both loads share the same uniqued constant expression)
+    @test convert_users_to_instructions!(LLVM.Constant[gv]; func=f1)
+    @test operands(l1)[1] isa LLVM.Instruction   # rewritten in f1
+    @test operands(l2)[1] isa LLVM.ConstantExpr   # untouched in f2
+end
+
+# `include_self` also converts the passed constants themselves
+@dispose ctx=Context() builder=IRBuilder() mod=LLVM.Module("SomeModule") begin
+    T_i32 = LLVM.Int32Type()
+    T_arr = LLVM.ArrayType(T_i32, 4)
+    gv = GlobalVariable(mod, T_arr, "gv")
+
+    fn = LLVM.Function(mod, "f", LLVM.FunctionType(T_i32, LLVM.LLVMType[]))
+    position!(builder, BasicBlock(fn, "entry"))
+    ce = const_gep(T_arr, gv, LLVM.Constant[ConstantInt(Int32(0)), ConstantInt(Int32(1))])
+    loadinst = load!(builder, T_i32, ce)
+    ret!(builder, loadinst)
+
+    # without include_self, only (constant) users of `ce` are considered: none
+    @test !convert_users_to_instructions!(LLVM.Constant[ce]; include_self=false)
+    @test operands(loadinst)[1] isa LLVM.ConstantExpr
+
+    # with include_self, the constant expression itself is materialized
+    @test convert_users_to_instructions!(LLVM.Constant[ce]; include_self=true)
+    @test operands(loadinst)[1] isa LLVM.Instruction
+end
+
+# `remove_dead_constants=false` keeps the now-dead constant expression around
+@dispose ctx=Context() builder=IRBuilder() mod=LLVM.Module("SomeModule") begin
+    T_i32 = LLVM.Int32Type()
+    T_arr = LLVM.ArrayType(T_i32, 4)
+    gv = GlobalVariable(mod, T_arr, "gv")
+
+    fn = LLVM.Function(mod, "f", LLVM.FunctionType(T_i32, LLVM.LLVMType[]))
+    position!(builder, BasicBlock(fn, "entry"))
+    ce = const_gep(T_arr, gv, LLVM.Constant[ConstantInt(Int32(0)), ConstantInt(Int32(2))])
+    ret!(builder, load!(builder, T_i32, ce))
+
+    @test convert_users_to_instructions!(LLVM.Constant[gv]; remove_dead_constants=false)
+    # the dead constant expression is retained as a user of `gv`
+    @test any(u -> user(u) isa LLVM.ConstantExpr, uses(gv))
+end
+
+else
+
+# the extra options are rejected before LLVM 19
+@dispose ctx=Context() mod=LLVM.Module("SomeModule") begin
+    gv = GlobalVariable(mod, LLVM.Int32Type(), "gv")
+    @test_throws ArgumentError convert_users_to_instructions!(LLVM.Constant[gv]; include_self=true)
+    @test_throws ArgumentError convert_users_to_instructions!(LLVM.Constant[gv]; func=nothing, remove_dead_constants=false)
+end
+
+end
+
+end
+end
+
 # global values
 @dispose ctx=Context() mod=LLVM.Module("SomeModule") begin
     st = LLVM.StructType("SomeType")


### PR DESCRIPTION
Adds an API for LLVM's `convertUsersOfConstantsToInstructions`
(`llvm/IR/ReplaceConstant.h`), which rewrites every constant expression or constant
aggregate that (transitively) uses a given set of constants into equivalent instructions at
each point of use; phi operands are materialized in their incoming block. This utility is
not part of the LLVM C API on any release, so it is exposed through libLLVMExtra and wrapped
with an idiomatic Julia function.

## What's in it

- **libLLVMExtra** gains `LLVMConvertUsersOfConstantsToInstructions`, guarded by
  `LLVM_VERSION_MAJOR >= 17`. Since libLLVMExtra is C++ linked against libLLVM, it forwards
  directly to `llvm::convertUsersOfConstantsToInstructions` — the full four-argument
  overload on LLVM 19+, and the single-argument overload on LLVM 17/18. Nothing is vendored.
  The project version is bumped to 1.9.
- **`convert_users_to_instructions!(consts; func, remove_dead_constants, include_self)`** is
  the high-level wrapper, added near `unsafe_destroy!` in `src/core/value/constant.jl`. The
  keyword options mirror the trunk C++ defaults.
- Low-level generated-style ccall wrappers in `lib/{17,18,19,20,21}/libLLVM_extra.jl`.
- A manual section with a before/after IR example, an API reference entry, and a testset
  covering constexpr expansion, phi-operand materialization in the incoming block, and the
  no-op case; the `func`, `include_self` and `remove_dead_constants` options are exercised
  on LLVM 19+.

## Scope

Intentionally supports **LLVM 17+ / Julia 1.12+ only** and vendors nothing. LLVM 15/16 never
exported the symbol. The LLVM 17/18 one-arg overload hardcodes the API defaults
(`RestrictToFunc=nullptr`, `RemoveDeadConstants=true`, `IncludeSelf=false`), so non-default
values for those three options are rejected with a clear error below LLVM 19, and the
function as a whole requires LLVM 17+.