### PR TITLE
Fix: incorrect integer extension for `Unsigned` in `pointerref` and `pointerset`.

### DIFF
--- a/src/interop/pointer.jl
+++ b/src/interop/pointer.jl
@@ -42,7 +42,7 @@ using Core: LLVMPtr
             ret!(builder, ld)
         end
 
-	call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, Int}, :ptr, :(i % Int - 1))
+        call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, Int}, :ptr, :(i % Int - 1))
     end
 end
 

--- a/src/interop/pointer.jl
+++ b/src/interop/pointer.jl
@@ -12,7 +12,9 @@ using Core: LLVMPtr
     @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T)
 
-        T_idx = convert(LLVMType, I)
+        # The index is converted to `Int64`, which must be at least as wide as the
+        # index width of every address space this is compiled for. 
+        T_idx = convert(LLVMType, Int)
         T_ptr = convert(LLVMType, ptr)
 
         T_typed_ptr = LLVM.PointerType(eltyp, A)
@@ -40,7 +42,7 @@ using Core: LLVMPtr
             ret!(builder, ld)
         end
 
-        call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, I}, :ptr, :(i-one(I)))
+	call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, Int}, :ptr, :(i % Int - 1))
     end
 end
 
@@ -50,7 +52,9 @@ end
     @dispose ctx=Context() begin
         eltyp = convert(LLVMType, T)
 
-        T_idx = convert(LLVMType, I)
+        # The index is converted to `Int64`, which must be at least as wide as the
+        # index width of every address space this is compiled for. 
+        T_idx = convert(LLVMType, Int)
         T_ptr = convert(LLVMType, ptr)
 
         T_typed_ptr = LLVM.PointerType(eltyp, A)
@@ -79,8 +83,8 @@ end
             ret!(builder)
         end
 
-        call_function(llvm_f, Cvoid, Tuple{LLVMPtr{T,A}, T, I},
-                      :ptr, :(convert(T,x)), :(i-one(I)))
+        call_function(llvm_f, Cvoid, Tuple{LLVMPtr{T,A}, T, Int},
+		      :ptr, :(convert(T,x)), :(i % Int  - 1))
     end
 end
 
@@ -89,7 +93,6 @@ end
 
 @inline Base.unsafe_store!(ptr::Core.LLVMPtr{T}, x, i::Integer=1, align::Val=Val(1)) where {T} =
     pointerset(ptr, convert(T, x), i, align)
-
 
 # pointer operations
 

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -359,6 +359,46 @@ end
     @test_throws "power of 2" unsafe_store!(ptr, Int64(0), 1, Val(6))
 end
 
+@testset "unsigned index extension" begin
+    # `getelementptr` treats its index as signed, so an unsigned index narrower than the
+    # pointer must be zero-extended. Sign-extending it sends indices above
+    # typemax(signed(I)) to an address 2^(bits(I)-1) elements below the buffer.
+    ptr = Core.LLVMPtr{Int8,0}
+
+    for I in (UInt8, UInt16, UInt32)
+        ir = sprint(io->code_llvm(io, unsafe_load, Tuple{ptr, I}))
+        @test contains(ir, r"\bzext i\d+ .+ to i64")
+        @test !contains(ir, r"\bsext i\d+ .+ to i64")
+    end
+
+    # signed indices are unaffected: sign extension is the correct widening
+    for I in (Int8, Int16, Int32)
+        ir = sprint(io->code_llvm(io, unsafe_load, Tuple{ptr, I}))
+        @test contains(ir, r"\bsext i\d+ .+ to i64")
+    end
+
+    # 64-bit indices need no extension at all
+    for I in (UInt64, Int64)
+        ir = sprint(io->code_llvm(io, unsafe_load, Tuple{ptr, I}))
+        @test !contains(ir, r"\b[sz]ext i\d+ .+ to i64")
+    end
+
+    # an index whose high bit is set after the -1 must still address forwards.
+    # the pointer sits at the midpoint so a sign-extended offset stays in bounds.
+    for I in (UInt8, UInt16)
+        half = 1 << (8*sizeof(I) - 1)
+        buf = zeros(Int8, 2half + 2)
+        buf[1], buf[2half + 1] = 9, 3
+        GC.@preserve buf begin
+            p = reinterpret(Core.LLVMPtr{Int8,0}, pointer(buf) + half)
+            @test unsafe_load(p, I(half + 1)) == 3
+            unsafe_store!(p, Int8(5), I(half + 1))
+            @test buf[2half + 1] == 5
+            @test buf[1] == 9
+        end
+    end
+end
+
 @testset "reinterpret with addrspacecast" begin
     ptr = reinterpret(Core.LLVMPtr{Int64, 4}, 0)
     for eltype_dest in (Int64, Int32), AS_dest in (4, 3)


### PR DESCRIPTION
LLVM seems to assume signed integers by default in its `getelementptr` instruction which (I assume) means Julia employs `sext` when generating the LLVM IR. However, if the index is an `Unsigned` that is smaller than the index width of the target, this gets interpreted as `Signed` and incorrectly extended using `sext` instead of `zext`. This can lead to incorrect memory accesses or segmentation faults. See:

```Julia
using LLVM, InteractiveUtils
using Core: LLVMPtr

load_u32(p::LLVMPtr{Int8,0}, i::UInt32) = unsafe_load(p, i)
load_i64(p::LLVMPtr{Int8,0}, i::Int64)  = unsafe_load(p, i)

# ---- 1. the generated IR ----------------------------------------------------
println("--- unsafe_load(p, i::UInt32) ---")
@code_llvm debuginfo=:none load_u32(LLVMPtr{Int8,0}(0), UInt32(1))
println("--- unsafe_load(p, i::Int64) ----")
@code_llvm debuginfo=:none load_i64(LLVMPtr{Int8,0}(0), Int64(1))

# ---- 2. an actual wrong load ------------------------------------------------
# 4 GiB buffer; put the pointer in the middle so that BOTH the correct (+2^31)
# and the sign-extended (-2^31) offsets land inside valid memory.
buf = fill(Int8(0), 2^32 + 8)
buf[1]        = Int8(11)      # what a sign-extended index will hit
buf[2^32 + 1] = Int8(22)      # what the correct index should hit

GC.@preserve buf begin
    mid = reinterpret(LLVMPtr{Int8,0}, pointer(buf) + 2^31)
    i = 2^31 + 1              # i-1 == 2^31, high bit of the i32 is set
    println("\ni          = ", i)
    println("Int64  index -> ", load_i64(mid, Int64(i)),  "  (expected 22)")
    println("UInt32 index -> ", load_u32(mid, UInt32(i)), "  (expected 22)")
end
```
which outputs:
```llvm
--- unsafe_load(p, i::UInt32) ---
; Function Signature: load_u32(Core.LLVMPtr{Int8, 0}, UInt32)
define i8 @julia_load_u32_1117(ptr %"p::LLVMPtr", i32 zeroext %"i::UInt32") #0 {
top:
  %0 = add i32 %"i::UInt32", -1
  %1 = sext i32 %0 to i64
  %2 = getelementptr inbounds i8, ptr %"p::LLVMPtr", i64 %1
  %3 = load i8, ptr %2, align 1
  ret i8 %3
}
--- unsafe_load(p, i::Int64) ----
; Function Signature: load_i64(Core.LLVMPtr{Int8, 0}, Int64)
define i8 @julia_load_i64_1128(ptr %"p::LLVMPtr", i64 signext %"i::Int64") #0 {
top:
  %0 = getelementptr i8, ptr %"p::LLVMPtr", i64 %"i::Int64"
  %1 = getelementptr i8, ptr %0, i64 -1
  %2 = load i8, ptr %1, align 1
  ret i8 %2
}

i          = 2147483649
Int64  index -> 22  (expected 22)
UInt32 index -> 11  (expected 22)
```
The `UInt32` gets interpreted as a `i32` and then extended to `i64` via `sext`. This gives a wrong address whenever the index is between `typemax(Int32)` and `typemax(UInt32)`. 

This PR promotes any index to Int64 which alters the LLVM IR for `Unsigned` to first use `zext` before computing the address: 
```LLVM
--- unsafe_load(p, i::UInt32) ---
; Function Signature: load_u32(Core.LLVMPtr{Int8, 0}, UInt32)
define i8 @julia_load_u32_1202(ptr %"p::LLVMPtr", i32 zeroext %"i::UInt32") #0 {
top:
  %0 = zext i32 %"i::UInt32" to i64
  %1 = getelementptr i8, ptr %"p::LLVMPtr", i64 %0
  %2 = getelementptr i8, ptr %1, i64 -1
  %3 = load i8, ptr %2, align 1
  ret i8 %3
}
--- unsafe_load(p, i::Int64) ----
; Function Signature: load_i64(Core.LLVMPtr{Int8, 0}, Int64)
define i8 @julia_load_i64_1211(ptr %"p::LLVMPtr", i64 signext %"i::Int64") #0 {
top:
  %0 = getelementptr i8, ptr %"p::LLVMPtr", i64 %"i::Int64"
  %1 = getelementptr i8, ptr %0, i64 -1
  %2 = load i8, ptr %1, align 1
  ret i8 %2
}

i          = 2147483649
Int64  index -> 22  (expected 22)
UInt32 index -> 22  (expected 22)
``` 
The LLVM IR generated for `Signed` is identical and for index widths of 32bits I believe LLVM should optimize the extension followed by truncation to a no-op. 

Tests to follow so leaving this as a draft, but this should fix https://github.com/JuliaGPU/CUDA.jl/issues/3220.