### PR TITLE
Add APIs for deterministic module layout

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,15 @@
 # LLVM.jl release notes
 
 
+## LLVM.jl v9.13
+
+New features:
+
+- Functions and global variables can be reordered with `move_before` and `move_after`, or
+  sorted by name with `sort!`, enabling deterministic module layouts.
+- Named metadata operands can be removed with `empty!`.
+
+
 ## LLVM.jl v9.12
 
 New features:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LLVM"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "9.12.0"
+version = "9.13.0"
 
 [workspace]
 projects = ["test", "docs", "examples", "deps", "res"]

--- a/deps/LLVMExtra/CMakeLists.txt
+++ b/deps/LLVMExtra/CMakeLists.txt
@@ -4,7 +4,7 @@ SET(CMAKE_CXX_FLAGS "-Wall -fPIC -fno-rtti")
 
 project(LLVMExtra
 VERSION
-    1.9
+    1.10
 LANGUAGES
    CXX
    C

--- a/deps/LLVMExtra/include/LLVMExtra.h
+++ b/deps/LLVMExtra/include/LLVMExtra.h
@@ -84,6 +84,17 @@ void LLVMDestroyConstant(LLVMValueRef Const);
 LLVMTypeRef LLVMGetFunctionType(LLVMValueRef Fn);
 LLVMTypeRef LLVMGetGlobalValueType(LLVMValueRef Fn);
 
+// Reordering of module contents
+//
+// Move a function/global variable to the position before/after another one in
+// its module's list, for example to give the module a deterministic layout.
+// Both values must belong to the same module. Moving a value relative to
+// itself is a no-op.
+void LLVMMoveFunctionBefore(LLVMValueRef Fn, LLVMValueRef MovePos);
+void LLVMMoveFunctionAfter(LLVMValueRef Fn, LLVMValueRef MovePos);
+void LLVMMoveGlobalBefore(LLVMValueRef GlobalVar, LLVMValueRef MovePos);
+void LLVMMoveGlobalAfter(LLVMValueRef GlobalVar, LLVMValueRef MovePos);
+
 // Replace constant-expression/aggregate users of the given constants with
 // equivalent instructions at each point of use; phi operands are materialized
 // in their incoming block. Mirrors llvm::convertUsersOfConstantsToInstructions
@@ -123,6 +134,7 @@ void LLVMGetMDNodeOperands2(LLVMMetadataRef MD, LLVMMetadataRef *Dest);
 unsigned LLVMGetNamedMetadataNumOperands2(LLVMNamedMDNodeRef NMD);
 void LLVMGetNamedMetadataOperands2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef *Dest);
 void LLVMAddNamedMetadataOperand2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef Val);
+void LLVMClearNamedMetadataOperands(LLVMNamedMDNodeRef NMD);
 void LLVMReplaceMDNodeOperandWith2(LLVMMetadataRef MD, unsigned I, LLVMMetadataRef New);
 
 // ORC API extensions

--- a/deps/LLVMExtra/lib/Core.cpp
+++ b/deps/LLVMExtra/lib/Core.cpp
@@ -1,5 +1,7 @@
 #include "LLVMExtra.h"
 
+#include <iterator>
+
 #if LLVM_VERSION_MAJOR >= 17
 #include <llvm/TargetParser/Triple.h>
 #else
@@ -295,6 +297,56 @@ LLVMTypeRef LLVMGetGlobalValueType(LLVMValueRef GV) {
   return wrap(Ftype);
 }
 
+void LLVMMoveFunctionBefore(LLVMValueRef Fn, LLVMValueRef MovePos) {
+  Function *F = unwrap<Function>(Fn);
+  Function *Pos = unwrap<Function>(MovePos);
+  if (F == Pos)
+    return;
+  Module *M = Pos->getParent();
+  M->getFunctionList().splice(Pos->getIterator(), F->getParent()->getFunctionList(),
+                              F->getIterator());
+}
+
+void LLVMMoveFunctionAfter(LLVMValueRef Fn, LLVMValueRef MovePos) {
+  Function *F = unwrap<Function>(Fn);
+  Function *Pos = unwrap<Function>(MovePos);
+  if (F == Pos)
+    return;
+  Module *M = Pos->getParent();
+  M->getFunctionList().splice(std::next(Pos->getIterator()),
+                              F->getParent()->getFunctionList(), F->getIterator());
+}
+
+void LLVMMoveGlobalBefore(LLVMValueRef GlobalVar, LLVMValueRef MovePos) {
+  GlobalVariable *GV = unwrap<GlobalVariable>(GlobalVar);
+  GlobalVariable *Pos = unwrap<GlobalVariable>(MovePos);
+  if (GV == Pos)
+    return;
+  Module *M = Pos->getParent();
+#if LLVM_VERSION_MAJOR >= 17
+  GV->removeFromParent();
+  M->insertGlobalVariable(Pos->getIterator(), GV);
+#else
+  M->getGlobalList().splice(Pos->getIterator(), GV->getParent()->getGlobalList(),
+                            GV->getIterator());
+#endif
+}
+
+void LLVMMoveGlobalAfter(LLVMValueRef GlobalVar, LLVMValueRef MovePos) {
+  GlobalVariable *GV = unwrap<GlobalVariable>(GlobalVar);
+  GlobalVariable *Pos = unwrap<GlobalVariable>(MovePos);
+  if (GV == Pos)
+    return;
+  Module *M = Pos->getParent();
+#if LLVM_VERSION_MAJOR >= 17
+  GV->removeFromParent();
+  M->insertGlobalVariable(std::next(Pos->getIterator()), GV);
+#else
+  M->getGlobalList().splice(std::next(Pos->getIterator()),
+                            GV->getParent()->getGlobalList(), GV->getIterator());
+#endif
+}
+
 #if LLVM_VERSION_MAJOR >= 17
 LLVMBool LLVMConvertUsersOfConstantsToInstructions(LLVMValueRef *Consts,
                                                    size_t Count,
@@ -396,6 +448,10 @@ void LLVMGetNamedMetadataOperands2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef *Dest
 
 void LLVMAddNamedMetadataOperand2(LLVMNamedMDNodeRef NMD, LLVMMetadataRef Val) {
   unwrap<NamedMDNode>(NMD)->addOperand(unwrap<MDNode>(Val));
+}
+
+void LLVMClearNamedMetadataOperands(LLVMNamedMDNodeRef NMD) {
+  unwrap<NamedMDNode>(NMD)->clearOperands();
 }
 
 void LLVMReplaceMDNodeOperandWith2(LLVMMetadataRef MD, unsigned I, LLVMMetadataRef New) {

--- a/docs/src/lib/blocks.md
+++ b/docs/src/lib/blocks.md
@@ -15,8 +15,8 @@ erase!(::BasicBlock)
 LLVM.parent(::BasicBlock)
 terminator(::BasicBlock)
 name(::BasicBlock)
-move_before
-move_after
+move_before(::BasicBlock, ::BasicBlock)
+move_after(::BasicBlock, ::BasicBlock)
 ```
 
 ## Control flow

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -11,6 +11,8 @@ LLVM.Function(::LLVM.Module, ::String, ::LLVM.FunctionType)
 function_type
 empty!
 erase!(::LLVM.Function)
+move_before(::LLVM.Function, ::LLVM.Function)
+move_after(::LLVM.Function, ::LLVM.Function)
 personality
 personality!
 callconv

--- a/docs/src/lib/metadata.md
+++ b/docs/src/lib/metadata.md
@@ -29,6 +29,7 @@ metadata(::LLVM.Module)
 name(::NamedMDNode)
 operands(::NamedMDNode)
 push!(::NamedMDNode, ::MDNode)
+empty!(::NamedMDNode)
 ```
 
 ## Debug information

--- a/docs/src/lib/modules.md
+++ b/docs/src/lib/modules.md
@@ -46,9 +46,11 @@ write(io::IO, mod::LLVM.Module)
 
 ```@docs
 globals
+sort!(::LLVM.ModuleGlobalSet)
 prevglobal
 nextglobal
 functions(::LLVM.Module)
+sort!(::LLVM.ModuleFunctionSet)
 prevfun
 nextfun
 flags(::LLVM.Module)

--- a/docs/src/lib/values.md
+++ b/docs/src/lib/values.md
@@ -76,6 +76,8 @@ Global variables are a specific kind of global values, and have additional APIs:
 ```@docs
 GlobalVariable
 erase!(::GlobalVariable)
+move_before(::GlobalVariable, ::GlobalVariable)
+move_after(::GlobalVariable, ::GlobalVariable)
 initializer
 initializer!
 isthreadlocal

--- a/docs/src/man/metadata.md
+++ b/docs/src/man/metadata.md
@@ -113,8 +113,8 @@ julia> inst
 
 Metadata can also be attached to a module, in which case it needs to be grouped in a named
 metadata node (which can only contain other metadata nodes, and not e.g. strings directly).
-With LLVM's C API, module-level named metadata is append-only, which is done using the
-`push!` function:
+Operands can be appended to module-level named metadata with `push!` and removed with
+`empty!`:
 
 ```jldoctest
 julia> md = metadata(mod);

--- a/docs/src/man/modules.md
+++ b/docs/src/man/modules.md
@@ -118,6 +118,9 @@ julia> collect(globals(mod))
 
 In addition to the iteration interface, it is possible to move from one global to the
 previous or next one using respectively the `prevglobal` and `nextglobal` functions.
+Global variables can be reordered with `move_before` and `move_after`, or sorted in place
+with `sort!(globals(mod))`. The latter defaults to sorting by name, which is useful for
+producing deterministic module layouts.
 
 ### Functions
 
@@ -132,7 +135,9 @@ julia> collect(functions(mod))
 ```
 
 Again, it is possible to move from one function to the previous or next one using
-respectively the `prevfun` and `nextfun` functions.
+respectively the `prevfun` and `nextfun` functions. Functions can be reordered with
+`move_before` and `move_after`, or sorted by name with `sort!(functions(mod))` to produce a
+deterministic module layout.
 
 ### Flags
 

--- a/lib/15/libLLVM_extra.jl
+++ b/lib/15/libLLVM_extra.jl
@@ -142,6 +142,22 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMMoveFunctionBefore(Fn, MovePos)
+    ccall((:LLVMMoveFunctionBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveFunctionAfter(Fn, MovePos)
+    ccall((:LLVMMoveFunctionAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveGlobalBefore(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
+function LLVMMoveGlobalAfter(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
 function LLVMSetInitializer2(GlobalVar, ConstantVal)
     ccall((:LLVMSetInitializer2, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, ConstantVal)
 end
@@ -172,6 +188,10 @@ end
 
 function LLVMAddNamedMetadataOperand2(NMD, Val)
     ccall((:LLVMAddNamedMetadataOperand2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, LLVMMetadataRef), NMD, Val)
+end
+
+function LLVMClearNamedMetadataOperands(NMD)
+    ccall((:LLVMClearNamedMetadataOperands, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef,), NMD)
 end
 
 function LLVMReplaceMDNodeOperandWith2(MD, I, New)
@@ -503,4 +523,3 @@ end
 function LLVMLinkModules3(Dest, Src, Flags)
     ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
 end
-

--- a/lib/16/libLLVM_extra.jl
+++ b/lib/16/libLLVM_extra.jl
@@ -142,6 +142,22 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMMoveFunctionBefore(Fn, MovePos)
+    ccall((:LLVMMoveFunctionBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveFunctionAfter(Fn, MovePos)
+    ccall((:LLVMMoveFunctionAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveGlobalBefore(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
+function LLVMMoveGlobalAfter(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
 function LLVMSetInitializer2(GlobalVar, ConstantVal)
     ccall((:LLVMSetInitializer2, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, ConstantVal)
 end
@@ -172,6 +188,10 @@ end
 
 function LLVMAddNamedMetadataOperand2(NMD, Val)
     ccall((:LLVMAddNamedMetadataOperand2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, LLVMMetadataRef), NMD, Val)
+end
+
+function LLVMClearNamedMetadataOperands(NMD)
+    ccall((:LLVMClearNamedMetadataOperands, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef,), NMD)
 end
 
 function LLVMReplaceMDNodeOperandWith2(MD, I, New)
@@ -503,4 +523,3 @@ end
 function LLVMLinkModules3(Dest, Src, Flags)
     ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
 end
-

--- a/lib/17/libLLVM_extra.jl
+++ b/lib/17/libLLVM_extra.jl
@@ -110,6 +110,22 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMMoveFunctionBefore(Fn, MovePos)
+    ccall((:LLVMMoveFunctionBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveFunctionAfter(Fn, MovePos)
+    ccall((:LLVMMoveFunctionAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveGlobalBefore(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
+function LLVMMoveGlobalAfter(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
 function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
     ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
 end
@@ -148,6 +164,10 @@ end
 
 function LLVMAddNamedMetadataOperand2(NMD, Val)
     ccall((:LLVMAddNamedMetadataOperand2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, LLVMMetadataRef), NMD, Val)
+end
+
+function LLVMClearNamedMetadataOperands(NMD)
+    ccall((:LLVMClearNamedMetadataOperands, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef,), NMD)
 end
 
 function LLVMReplaceMDNodeOperandWith2(MD, I, New)
@@ -471,4 +491,3 @@ end
 function LLVMLinkModules3(Dest, Src, Flags)
     ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
 end
-

--- a/lib/18/libLLVM_extra.jl
+++ b/lib/18/libLLVM_extra.jl
@@ -110,6 +110,22 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMMoveFunctionBefore(Fn, MovePos)
+    ccall((:LLVMMoveFunctionBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveFunctionAfter(Fn, MovePos)
+    ccall((:LLVMMoveFunctionAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveGlobalBefore(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
+function LLVMMoveGlobalAfter(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
 function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
     ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
 end
@@ -148,6 +164,10 @@ end
 
 function LLVMAddNamedMetadataOperand2(NMD, Val)
     ccall((:LLVMAddNamedMetadataOperand2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, LLVMMetadataRef), NMD, Val)
+end
+
+function LLVMClearNamedMetadataOperands(NMD)
+    ccall((:LLVMClearNamedMetadataOperands, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef,), NMD)
 end
 
 function LLVMReplaceMDNodeOperandWith2(MD, I, New)
@@ -405,4 +425,3 @@ end
 function LLVMLinkModules3(Dest, Src, Flags)
     ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
 end
-

--- a/lib/19/libLLVM_extra.jl
+++ b/lib/19/libLLVM_extra.jl
@@ -110,6 +110,22 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMMoveFunctionBefore(Fn, MovePos)
+    ccall((:LLVMMoveFunctionBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveFunctionAfter(Fn, MovePos)
+    ccall((:LLVMMoveFunctionAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveGlobalBefore(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
+function LLVMMoveGlobalAfter(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
 function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
     ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
 end
@@ -148,6 +164,10 @@ end
 
 function LLVMAddNamedMetadataOperand2(NMD, Val)
     ccall((:LLVMAddNamedMetadataOperand2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, LLVMMetadataRef), NMD, Val)
+end
+
+function LLVMClearNamedMetadataOperands(NMD)
+    ccall((:LLVMClearNamedMetadataOperands, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef,), NMD)
 end
 
 function LLVMReplaceMDNodeOperandWith2(MD, I, New)
@@ -405,4 +425,3 @@ end
 function LLVMLinkModules3(Dest, Src, Flags)
     ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
 end
-

--- a/lib/20/libLLVM_extra.jl
+++ b/lib/20/libLLVM_extra.jl
@@ -110,6 +110,22 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMMoveFunctionBefore(Fn, MovePos)
+    ccall((:LLVMMoveFunctionBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveFunctionAfter(Fn, MovePos)
+    ccall((:LLVMMoveFunctionAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveGlobalBefore(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
+function LLVMMoveGlobalAfter(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
 function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
     ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
 end
@@ -144,6 +160,10 @@ end
 
 function LLVMAddNamedMetadataOperand2(NMD, Val)
     ccall((:LLVMAddNamedMetadataOperand2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, LLVMMetadataRef), NMD, Val)
+end
+
+function LLVMClearNamedMetadataOperands(NMD)
+    ccall((:LLVMClearNamedMetadataOperands, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef,), NMD)
 end
 
 function LLVMReplaceMDNodeOperandWith2(MD, I, New)
@@ -361,4 +381,3 @@ end
 function LLVMLinkModules3(Dest, Src, Flags)
     ccall((:LLVMLinkModules3, libLLVMExtra), LLVMBool, (LLVMModuleRef, LLVMModuleRef, Cuint), Dest, Src, Flags)
 end
-

--- a/lib/21/libLLVM_extra.jl
+++ b/lib/21/libLLVM_extra.jl
@@ -110,6 +110,22 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMMoveFunctionBefore(Fn, MovePos)
+    ccall((:LLVMMoveFunctionBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveFunctionAfter(Fn, MovePos)
+    ccall((:LLVMMoveFunctionAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveGlobalBefore(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
+function LLVMMoveGlobalAfter(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
 function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
     ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
 end
@@ -144,6 +160,10 @@ end
 
 function LLVMAddNamedMetadataOperand2(NMD, Val)
     ccall((:LLVMAddNamedMetadataOperand2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, LLVMMetadataRef), NMD, Val)
+end
+
+function LLVMClearNamedMetadataOperands(NMD)
+    ccall((:LLVMClearNamedMetadataOperands, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef,), NMD)
 end
 
 function LLVMReplaceMDNodeOperandWith2(MD, I, New)
@@ -361,4 +381,3 @@ end
 function LLVMOrcThreadSafeContextGetContext(TSCtx)
     ccall((:LLVMOrcThreadSafeContextGetContext, libLLVMExtra), LLVMContextRef, (LLVMOrcThreadSafeContextRef,), TSCtx)
 end
-

--- a/lib/22/libLLVM_extra.jl
+++ b/lib/22/libLLVM_extra.jl
@@ -110,6 +110,22 @@ function LLVMGetGlobalValueType(Fn)
     ccall((:LLVMGetGlobalValueType, libLLVMExtra), LLVMTypeRef, (LLVMValueRef,), Fn)
 end
 
+function LLVMMoveFunctionBefore(Fn, MovePos)
+    ccall((:LLVMMoveFunctionBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveFunctionAfter(Fn, MovePos)
+    ccall((:LLVMMoveFunctionAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), Fn, MovePos)
+end
+
+function LLVMMoveGlobalBefore(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalBefore, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
+function LLVMMoveGlobalAfter(GlobalVar, MovePos)
+    ccall((:LLVMMoveGlobalAfter, libLLVMExtra), Cvoid, (LLVMValueRef, LLVMValueRef), GlobalVar, MovePos)
+end
+
 function LLVMConvertUsersOfConstantsToInstructions(Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
     ccall((:LLVMConvertUsersOfConstantsToInstructions, libLLVMExtra), LLVMBool, (Ptr{LLVMValueRef}, Csize_t, LLVMValueRef, LLVMBool, LLVMBool), Consts, Count, RestrictToFunc, RemoveDeadConstants, IncludeSelf)
 end
@@ -144,6 +160,10 @@ end
 
 function LLVMAddNamedMetadataOperand2(NMD, Val)
     ccall((:LLVMAddNamedMetadataOperand2, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef, LLVMMetadataRef), NMD, Val)
+end
+
+function LLVMClearNamedMetadataOperands(NMD)
+    ccall((:LLVMClearNamedMetadataOperands, libLLVMExtra), Cvoid, (LLVMNamedMDNodeRef,), NMD)
 end
 
 function LLVMReplaceMDNodeOperandWith2(MD, I, New)

--- a/src/core/function.jl
+++ b/src/core/function.jl
@@ -49,6 +49,22 @@ Remove the given function from its parent module and free the object.
 erase!(f::Function) = API.LLVMDeleteFunction(f)
 
 """
+    move_before(f::Function, pos::Function)
+
+Move the function `f` before the function `pos` in the function list of the containing
+module. Both functions must reside in the same module.
+"""
+move_before(f::Function, pos::Function) = API.LLVMMoveFunctionBefore(f, pos)
+
+"""
+    move_after(f::Function, pos::Function)
+
+Move the function `f` after the function `pos` in the function list of the containing
+module. Both functions must reside in the same module.
+"""
+move_after(f::Function, pos::Function) = API.LLVMMoveFunctionAfter(f, pos)
+
+"""
     personality(f::Function)
 
 Get the personality function of the given function, or `nothing` if it has none.

--- a/src/core/metadata.jl
+++ b/src/core/metadata.jl
@@ -403,6 +403,16 @@ Add a metadata node to the given named metadata node.
 Base.push!(node::NamedMDNode, val::MDNode) =
     API.LLVMAddNamedMetadataOperand2(node, val)
 
+"""
+    empty!(node::NamedMDNode)
+
+Remove all operands from the given named metadata node.
+"""
+function Base.empty!(node::NamedMDNode)
+    API.LLVMClearNamedMetadataOperands(node)
+    node
+end
+
 
 ## module named metadata
 

--- a/src/core/module.jl
+++ b/src/core/module.jl
@@ -368,6 +368,21 @@ function Base.getindex(iter::ModuleGlobalSet, name::String)
     return GlobalVariable(objref)
 end
 
+"""
+    sort!(globals::ModuleGlobalSet; by=name, kwargs...)
+
+Reorder all global variables in a module according to `by`, which defaults to the symbol
+name. Additional keyword arguments are forwarded to [`sort!`](@ref).
+"""
+function Base.sort!(iter::ModuleGlobalSet; by=name, kwargs...)
+    elements = collect(iter)
+    sort!(elements; by, kwargs...)
+    for i in 2:length(elements)
+        move_after(elements[i], elements[i-1])
+    end
+    iter
+end
+
 
 ## function iteration
 
@@ -438,6 +453,21 @@ function Base.getindex(iter::ModuleFunctionSet, name::String)
     objref = API.LLVMGetNamedFunction(iter.mod, name)
     objref == C_NULL && throw(KeyError(name))
     return Function(objref)
+end
+
+"""
+    sort!(functions::ModuleFunctionSet; by=name, kwargs...)
+
+Reorder all functions in a module according to `by`, which defaults to the symbol name.
+Additional keyword arguments are forwarded to [`sort!`](@ref).
+"""
+function Base.sort!(iter::ModuleFunctionSet; by=name, kwargs...)
+    elements = collect(iter)
+    sort!(elements; by, kwargs...)
+    for i in 2:length(elements)
+        move_after(elements[i], elements[i-1])
+    end
+    iter
 end
 
 

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -969,6 +969,22 @@ Remove the global variable from its parent module and delete it.
 erase!(gv::GlobalVariable) = API.LLVMDeleteGlobal(gv)
 
 """
+    move_before(gv::GlobalVariable, pos::GlobalVariable)
+
+Move the global variable `gv` before the global variable `pos` in the global list of the
+containing module. Both global variables must reside in the same module.
+"""
+move_before(gv::GlobalVariable, pos::GlobalVariable) = API.LLVMMoveGlobalBefore(gv, pos)
+
+"""
+    move_after(gv::GlobalVariable, pos::GlobalVariable)
+
+Move the global variable `gv` after the global variable `pos` in the global list of the
+containing module. Both global variables must reside in the same module.
+"""
+move_after(gv::GlobalVariable, pos::GlobalVariable) = API.LLVMMoveGlobalAfter(gv, pos)
+
+"""
     initializer(gv::GlobalVariable)
 
 Get the initializer of the global variable.

--- a/test/core.jl
+++ b/test/core.jl
@@ -1257,6 +1257,14 @@ end
 
         push!(mds["SomeMDNode"], node)
         @test node in operands(mds["SomeMDNode"])
+
+        push!(mds["SomeMDNode"], MDNode([MDString("SomeOtherMDString")]))
+        @test length(operands(mds["SomeMDNode"])) == 2
+        @test empty!(mds["SomeMDNode"]) === mds["SomeMDNode"]
+        @test isempty(operands(mds["SomeMDNode"]))
+
+        push!(mds["SomeMDNode"], node)
+        @test operands(mds["SomeMDNode"]) == [node]
     end
 end
 
@@ -1282,6 +1290,30 @@ end
         @test !haskey(gvs, "SomeOtherGlobal")
         @test_throws KeyError gvs["SomeOtherGlobal"]
     end
+end
+
+# global variable ordering
+@dispose ctx=Context() mod=LLVM.Module("SomeModule") begin
+    c = GlobalVariable(mod, LLVM.Int32Type(), "c")
+    a = GlobalVariable(mod, LLVM.Int32Type(), "a")
+    b = GlobalVariable(mod, LLVM.Int32Type(), "b")
+    gvs = globals(mod)
+
+    @test name.(collect(gvs)) == ["c", "a", "b"]
+    move_before(b, c)
+    @test name.(collect(gvs)) == ["b", "c", "a"]
+    move_after(b, a)
+    @test name.(collect(gvs)) == ["c", "a", "b"]
+    move_before(a, a)
+    @test name.(collect(gvs)) == ["c", "a", "b"]
+    @test length(collect(gvs)) == 3
+
+    @test sort!(gvs) === gvs
+    @test name.(collect(gvs)) == ["a", "b", "c"]
+    @test sort!(gvs; rev=true) === gvs
+    @test name.(collect(gvs)) == ["c", "b", "a"]
+    @test all(haskey(gvs, name) for name in ("a", "b", "c"))
+    @test occursin(r"(?s)@c.*@b.*@a", string(mod))
 end
 
 # function iteration
@@ -1321,6 +1353,31 @@ end
     @test nextfun(dummyfn) == anotherfn
     @test prevfun(anotherfn) == dummyfn
     @test nextfun(anotherfn) === nothing
+end
+
+# function ordering
+@dispose ctx=Context() mod=LLVM.Module("SomeModule") begin
+    ft = LLVM.FunctionType(LLVM.VoidType())
+    c = LLVM.Function(mod, "c", ft)
+    a = LLVM.Function(mod, "a", ft)
+    b = LLVM.Function(mod, "b", ft)
+    fns = functions(mod)
+
+    @test name.(collect(fns)) == ["c", "a", "b"]
+    move_before(b, c)
+    @test name.(collect(fns)) == ["b", "c", "a"]
+    move_after(b, a)
+    @test name.(collect(fns)) == ["c", "a", "b"]
+    move_after(a, a)
+    @test name.(collect(fns)) == ["c", "a", "b"]
+    @test length(collect(fns)) == 3
+
+    @test sort!(fns) === fns
+    @test name.(collect(fns)) == ["a", "b", "c"]
+    @test sort!(fns; rev=true) === fns
+    @test name.(collect(fns)) == ["c", "b", "a"]
+    @test all(haskey(fns, name) for name in ("a", "b", "c"))
+    @test occursin(r"(?s)@c.*@b.*@a", string(mod))
 end
 
 # textual IR


### PR DESCRIPTION
Add APIs for reordering module contents and resetting named metadata:

  - support `move_before` and `move_after` for functions and global variables
  - support `sort!` on module function and global iterators, sorting by name by default
  - support `empty!` on named metadata nodes
  - add the corresponding LLVMExtra C APIs and bindings for LLVM 15–22

This enables deterministic function and global ordering without rebuilding the module.